### PR TITLE
chore: stage env 설정

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,12 +1,12 @@
 SENTRY_ENVIRONMENT=local
 
 # web page
-# NEXT_PUBLIC_WEB_URL=http://localhost:3000
-NEXT_PUBLIC_WEB_URL=https://www.stage.solid-connection.com
+NEXT_PUBLIC_WEB_URL=http://localhost:3000
+# NEXT_PUBLIC_WEB_URL=https://www.stage.solid-connection.com
 
 # api server
-# NEXT_PUBLIC_API_SERVER_URL=https://api.solid-connection.com
-NEXT_PUBLIC_API_SERVER_URL=https://api.stage.solid-connection.com
+NEXT_PUBLIC_API_SERVER_URL=https://api.solid-connection.com
+# NEXT_PUBLIC_API_SERVER_URL=https://api.stage.solid-connection.com
 
 # kakao
 # NEXT_PUBLIC_KAKAO_JS_KEY=


### PR DESCRIPTION
development에 지정된건 vercel에 자동반영되지 않음.
development 설정은 로컬 개발을 위한 설정으로 남겨두는 것이 맞아 보인다.