### PR TITLE
feat : serverFetch 구현했습니다

### DIFF
--- a/src/components/mentor/MentorCard/index.tsx
+++ b/src/components/mentor/MentorCard/index.tsx
@@ -4,22 +4,22 @@ import React, { useState } from "react";
 
 import { Link } from "lucide-react";
 
-import IconConfirmCancelModal from "../modal/IconConfirmCancelModal";
-import ChannelBadge from "../ui/ChannelBadge";
-import ProfileWithBadge from "../ui/ProfileWithBadge";
-import StudyStatusBox from "./StudyStatusBox";
+import ChannelBadge from "@/components/ui/ChannelBadge";
+import ProfileWithBadge from "@/components/ui/ProfileWithBadge";
+
+import StudyStatusBox from "../StudyStatusBox";
+import MentorApplyPanel from "./ui/MentorApplyPanel";
 
 import { ChannelType, Mentor } from "@/types/mentor";
 
-import { IconCheck, IconDirectionDown, IconDirectionUp, IconTime } from "@/public/svgs/mentor";
+import { IconDirectionDown, IconDirectionUp } from "@/public/svgs/mentor";
 
 interface MentorCardProps {
   mentor: Mentor;
   isMine?: boolean; // isMine prop 추가
-  isDistribute?: boolean; // isDistribute prop 추가
 }
 
-const MentorCard = ({ mentor, isMine = false, isDistribute = false }: MentorCardProps) => {
+const MentorCard = ({ mentor, isMine = false }: MentorCardProps) => {
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
 
   // 구조분해 할당
@@ -34,10 +34,6 @@ const MentorCard = ({ mentor, isMine = false, isDistribute = false }: MentorCard
     channels,
     studyStatus,
   } = mentor;
-
-  const handleToggle = () => {
-    setIsExpanded(!isExpanded);
-  };
 
   return (
     <div className="rounded-lg bg-white p-4 shadow-sdwB">
@@ -109,7 +105,7 @@ const MentorCard = ({ mentor, isMine = false, isDistribute = false }: MentorCard
                 <button className="flex h-[41px] w-1/2 flex-shrink-0 items-center justify-center gap-3 rounded-[20px] bg-primary px-5 py-[10px] font-medium text-white">
                   멘토 페이지
                 </button>
-                <MentoAppliePanel isDistribute={isDistribute} />
+                <MentorApplyPanel />
               </>
             )}
           </div>
@@ -119,7 +115,7 @@ const MentorCard = ({ mentor, isMine = false, isDistribute = false }: MentorCard
       {/* 접기/펼치기 버튼 */}
       <div className="flex justify-center">
         <button
-          onClick={handleToggle}
+          onClick={() => setIsExpanded(!isExpanded)}
           className="flex h-6 w-6 items-center justify-center rounded-full border border-gray-300"
         >
           <div className="flex h-full w-full items-center justify-center">
@@ -132,41 +128,3 @@ const MentorCard = ({ mentor, isMine = false, isDistribute = false }: MentorCard
 };
 
 export default MentorCard;
-
-const MentoAppliePanel = ({ isDistribute }: { isDistribute: boolean }) => {
-  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
-
-  // isDistribute에 따른 모달 내용 설정
-  const modalConfig = isDistribute
-    ? {
-        icon: <IconTime />,
-        title: "지금은 방해금지 시간이에요.",
-        content: "방해 금지 시간이 지난 후 멘티 신청을 할 수 있어요.\n내일 아침 다시 신청해주세요.",
-      }
-    : {
-        icon: <IconCheck />,
-        title: "멘토 신청이 완료되었어요!",
-        content: "멘토가 신청을 수락하면 대화를 시작할 수 있어요.\n대화 수락까지 조금만 기다려주세요.",
-      };
-
-  return (
-    <>
-      <button
-        onClick={() => setIsModalOpen(true)}
-        className="flex h-[41px] w-1/2 flex-shrink-0 items-center justify-center gap-3 rounded-[20px] bg-primary px-5 py-[10px] font-medium text-white"
-      >
-        멘토 신청하기
-      </button>
-      <IconConfirmCancelModal
-        icon={modalConfig.icon}
-        isOpen={isModalOpen}
-        title={modalConfig.title}
-        content={modalConfig.content}
-        handleCancel={() => setIsModalOpen(false)}
-        handleConfirm={() => setIsModalOpen(false)}
-        cancelText="홈으로"
-        approveText="다른 멘토 찾기"
-      />
-    </>
-  );
-};

--- a/src/components/mentor/MentorCard/ui/MentorApplyPanel/index.tsx
+++ b/src/components/mentor/MentorCard/ui/MentorApplyPanel/index.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+
+import IconConfirmCancelModal from "@/components/modal/IconConfirmCancelModal";
+
+import { IconCheck } from "@/public/svgs/mentor";
+
+const MentorApplyPanel = () => {
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
+  const modalConfig = {
+    icon: <IconCheck />,
+    title: "멘토 신청이 완료되었어요!",
+    content: "멘토가 신청을 수락하면 대화를 시작할 수 있어요.\n대화 수락까지 조금만 기다려주세요.",
+  };
+
+  return (
+    <>
+      <button
+        onClick={() => setIsModalOpen(true)}
+        className="flex h-[41px] w-1/2 flex-shrink-0 items-center justify-center gap-3 rounded-[20px] bg-primary px-5 py-[10px] font-medium text-white"
+      >
+        멘토 신청하기
+      </button>
+      <IconConfirmCancelModal
+        icon={modalConfig.icon}
+        isOpen={isModalOpen}
+        title={modalConfig.title}
+        content={modalConfig.content}
+        handleCancel={() => setIsModalOpen(false)}
+        handleConfirm={() => setIsModalOpen(false)}
+        cancelText="홈으로"
+        approveText="다른 멘토 찾기"
+      />
+    </>
+  );
+};
+
+export default MentorApplyPanel;

--- a/src/utils/jwtUtils.ts
+++ b/src/utils/jwtUtils.ts
@@ -20,3 +20,12 @@ export const isTokenExpired = (token: string): boolean => {
     return true;
   }
 };
+
+export const decodeExp = (jwt: string) => {
+  try {
+    const { exp = 0 } = JSON.parse(Buffer.from(jwt.split(".")[1], "base64").toString("utf8"));
+    return exp * 1000; // → ms
+  } catch {
+    return 0;
+  }
+};

--- a/src/utils/jwtUtils.ts
+++ b/src/utils/jwtUtils.ts
@@ -21,9 +21,10 @@ export const isTokenExpired = (token: string): boolean => {
   }
 };
 
-export const decodeExp = (jwt: string) => {
+export const decodeExp = (token: string) => {
   try {
-    const { exp = 0 } = JSON.parse(Buffer.from(jwt.split(".")[1], "base64").toString("utf8"));
+    const payload = JSON.parse(atob(token.split(".")[1]));
+    const { exp } = payload;
     return exp * 1000; // → ms
   } catch {
     return 0;

--- a/src/utils/serverFetchUtil.ts
+++ b/src/utils/serverFetchUtil.ts
@@ -1,4 +1,3 @@
-// src/utils/serverFetch.ts
 import { cookies } from "next/headers";
 // protectedFetch.ts
 import { redirect } from "next/navigation";
@@ -8,6 +7,7 @@ import { decodeExp, isTokenExpired } from "./jwtUtils";
 import { reissueAccessTokenPublicApi } from "@/api/auth";
 
 const AUTH_EXPIRED = "AUTH_EXPIRED";
+const TIME_LIMIT = 30 * 1000; // 30초
 
 /** 커스텀 HTTP 에러: any 캐스팅 없이 status · body 보존 */
 class HttpError extends Error {
@@ -37,7 +37,7 @@ const accessCache: AccessCache = globalSemaphore.__accessCache;
 
 const getAccessToken = async (refresh: string) => {
   // 만료 30초 전까지는 재발급하지 않고 캐싱
-  if (accessCache.token && Date.now() < accessCache.exp - 30000) return accessCache.token;
+  if (accessCache.token && Date.now() < accessCache.exp - TIME_LIMIT) return accessCache.token;
   if (accessCache.refreshing) return accessCache.refreshing;
 
   accessCache.refreshing = reissueAccessTokenPublicApi(refresh)

--- a/src/utils/serverFetchUtil.ts
+++ b/src/utils/serverFetchUtil.ts
@@ -3,7 +3,7 @@ import { cookies } from "next/headers";
 // protectedFetch.ts
 import { redirect } from "next/navigation";
 
-import { isTokenExpired } from "./jwtUtils";
+import { decodeExp, isTokenExpired } from "./jwtUtils";
 
 import { reissueAccessTokenPublicApi } from "@/api/auth";
 
@@ -35,14 +35,6 @@ if (!globalSemaphore.__accessCache) {
 // 전역 캐시 객체
 const accessCache: AccessCache = globalSemaphore.__accessCache;
 
-const decodeExp = (jwt: string) => {
-  try {
-    const { exp = 0 } = JSON.parse(Buffer.from(jwt.split(".")[1], "base64").toString("utf8"));
-    return exp * 1000; // → ms
-  } catch {
-    return 0;
-  }
-};
 const getAccessToken = async (refresh: string) => {
   // 만료 30초 전까지는 재발급하지 않고 캐싱
   if (accessCache.token && Date.now() < accessCache.exp - 30000) return accessCache.token;

--- a/src/utils/serverFetchUtil.ts
+++ b/src/utils/serverFetchUtil.ts
@@ -1,0 +1,131 @@
+// src/utils/serverFetch.ts
+import { cookies } from "next/headers";
+// protectedFetch.ts
+import { redirect } from "next/navigation";
+
+import { isTokenExpired } from "./jwtUtils";
+
+import { reissueAccessTokenPublicApi } from "@/api/auth";
+
+const AUTH_EXPIRED = "AUTH_EXPIRED";
+
+/* ---------- 전역 캐시 ---------- */
+interface AccessCache {
+  token: string | null;
+  exp: number; // ms
+  refreshing: Promise<string> | null;
+}
+// 전역 객체에 캐시 추가
+const globalSemaphore = globalThis as typeof globalThis & { __accessCache?: AccessCache };
+// 값 초기화
+if (!globalSemaphore.__accessCache) {
+  globalSemaphore.__accessCache = { token: null, exp: 0, refreshing: null };
+}
+// 전역 캐시 객체
+const accessCache: AccessCache = globalSemaphore.__accessCache;
+
+const decodeExp = (jwt: string) => {
+  try {
+    const { exp = 0 } = JSON.parse(Buffer.from(jwt.split(".")[1], "base64").toString("utf8"));
+    return exp * 1000; // → ms
+  } catch {
+    return 0;
+  }
+};
+const getAccessToken = async (refresh: string) => {
+  // 만료 이전 5초까지만 캐싱
+  if (accessCache.token && Date.now() < accessCache.exp - 5000) return accessCache.token;
+  if (accessCache.refreshing) return accessCache.refreshing;
+
+  accessCache.refreshing = reissueAccessTokenPublicApi(refresh)
+    .then(({ data }) => {
+      accessCache.token = data.accessToken;
+      accessCache.exp = decodeExp(data.accessToken);
+      accessCache.refreshing = null;
+      return data.accessToken;
+    })
+    .catch((e) => {
+      accessCache.refreshing = null;
+      throw e;
+    });
+
+  return accessCache.refreshing;
+};
+
+/* ---------- fetch 래퍼 ---------- */
+type NextCacheOpt =
+  | { revalidate?: number; tags?: string[] } // App Router 캐시 옵션
+  | undefined;
+
+interface ServerFetchOptions extends Omit<RequestInit, "body"> {
+  /** JSON 바디를 넘기고 싶을 때 */
+  json?: unknown;
+  /** 로그인 필요 여부 (기본 true) */
+  isAuth?: boolean;
+  /** Next.js 캐시 옵션 */
+  next?: NextCacheOpt;
+}
+
+const BASE = process.env.NEXT_PUBLIC_API_SERVER_URL!;
+
+/** SSR-only fetch (App Router) */
+async function internalFetch<T = unknown>(
+  input: string,
+  { json, isAuth = false, next, headers, ...init }: ServerFetchOptions = {},
+): Promise<T> {
+  /* 쿠키 & 토큰 */
+  const cookieStore = cookies();
+  const refreshToken = cookieStore.get("refreshToken")?.value ?? null;
+  let accessToken: string | null = null;
+
+  if (isAuth) {
+    if (!refreshToken || isTokenExpired(refreshToken)) throw new Error(AUTH_EXPIRED);
+    accessToken = await getAccessToken(refreshToken);
+  }
+
+  /* 요청 헤더 구성 */
+  const reqHeaders = new Headers(headers);
+  if (accessToken) reqHeaders.set("Authorization", `Bearer ${accessToken}`);
+
+  let body: RequestInit["body"] = undefined;
+  if (json !== undefined) {
+    reqHeaders.set("Content-Type", "application/json");
+    body = JSON.stringify(json);
+  }
+
+  const response = await fetch(`${BASE}${input}`, {
+    ...init,
+    body,
+    headers: reqHeaders,
+    credentials: "omit", // refresh 쿠키는 전달X 서버에서만 사용
+    next, // revalidate / tags 옵션 그대로 전달
+  });
+
+  if (!response.ok) throw new Error(`FETCH_ERROR_${response.status}`);
+  // JSON 외 형식이 필요하면 호출부에서 Response 자체를 반환받도록 제네릭을 수정
+  return response.json() as Promise<T>;
+}
+
+/** Unified fetch: (url, body, isAuth, otherOptions) */
+async function serverFetch<T = unknown>(
+  url: string,
+  body?: unknown,
+  isAuth: boolean = false,
+  otherOptions: Omit<ServerFetchOptions, "json" | "auth"> = {},
+): Promise<T> {
+  try {
+    return await internalFetch<T>(url, {
+      ...otherOptions,
+      json: body,
+      isAuth: isAuth,
+    });
+  } catch (e: unknown) {
+    const err = e as Error;
+    if (isAuth && err.message === AUTH_EXPIRED) {
+      redirect(`/login?next=${url}`);
+    }
+    throw err;
+  }
+}
+
+export default serverFetch;


### PR DESCRIPTION
## 관련 이슈

## 작업 내용

- SSR 전용 fetch 유틸 함수 `serverFetchUtil.ts` 구현
- App Router에서 `cookies()`와 `Authorization`을 활용한 서버 전용 fetch 래퍼 제공
- `refreshToken` 기반 자동 `accessToken` 재발급 및 전역 캐싱 처리 (`globalThis.__accessCache`)
- 인증 만료 시 자동 리다이렉트 (`/login?next=…`)
- `revalidate`, `tags` 등 Next.js 캐시 옵션 전달 가능
- JWT 만료 시점을 파싱하는 `decodeExp()` 유틸 추가

## 특이 사항

- 클라이언트 컴포넌트에서는 사용 불가 (App Router 서버 컴포넌트 전용)
- 인증된 요청(`isAuth: true`)은 자동으로 토큰 헤더 포함
- 백엔드가 이후 전역 쿠키로 넘겨주도록 수정작업중에 있습니다. httpOnly가 아닙니다 

## 리뷰 요구사항 (선택)

- 전역 캐시 동작 및 재발급 로직 검토
- 인증 없는 요청 흐름 검증 (`isAuth: false`)
- Next.js 캐시 옵션 적용 방식 검토
- redirect 발생 시 페이지 흐름 자연스러운지 확인

## 논의가 필요한 부분
- 클라이언트 요청 시 대응 방식 (향후 클라 전용 fetch와 통합 여부)
- 현재 로그인 필요시 redirect url을 login/next:/url 같은 방식으로 전달중인데 이는 현재 로그인페이지에 구현된 기능이 아니기에 추후 해당기능을 구현해보고자합니다 