### PR TITLE
refactor : university -> univ-apply-infos 로 엔드포인트 수정했습니다

### DIFF
--- a/src/api/university/client/useGetRecommendedUniversity.ts
+++ b/src/api/university/client/useGetRecommendedUniversity.ts
@@ -9,7 +9,7 @@ const getRecommendedUniversity = async ({
 }: {
   queryKey: [string, boolean];
 }): Promise<RecommendedUniversityResponse> => {
-  const endpoint = "/universities/recommend";
+  const endpoint = "/univ-apply-infos/recommend";
 
   const [, isLogin] = queryKey;
   const instance = isLogin ? axiosInstance : publicAxiosInstance;

--- a/src/api/university/server/getRecommendedUniversity.ts
+++ b/src/api/university/server/getRecommendedUniversity.ts
@@ -3,7 +3,7 @@ import serverFetch from "@/utils/serverFetchUtil";
 import { RecommendedUniversityResponse } from "../type/response";
 
 const getRecommendedUniversity = async () => {
-  const endpoint = "/universities/recommend";
+  const endpoint = "/univ-apply-infos/recommend";
 
   const res = await serverFetch<RecommendedUniversityResponse>(endpoint);
   return res;

--- a/src/api/university/server/getSearchUniversityList.ts
+++ b/src/api/university/server/getSearchUniversityList.ts
@@ -20,7 +20,7 @@ interface SearchParams {
  * - 필요 시 query string 을 동적으로 붙인다.
  */
 const getSearchUniversityList = async ({ region, keyword, testType, testScore }: SearchParams = {}) => {
-  const endpoint = "/universities/search";
+  const endpoint = "/univ-apply-infos/search";
 
   const params = new URLSearchParams();
 

--- a/src/utils/serverFetchUtil.ts
+++ b/src/utils/serverFetchUtil.ts
@@ -28,8 +28,7 @@ interface ServerFetchOptions extends Omit<RequestInit, "body"> {
   next?: NextCacheOpt;
 }
 
-// const BASE = process.env.NEXT_PUBLIC_API_SERVER_URL;
-const BASE = "https://api.solid-connection.com"; // 예시 URL, 실제 환경에 맞게 변경
+const BASE = process.env.NEXT_PUBLIC_API_SERVER_URL;
 if (!BASE) {
   throw new Error("NEXT_PUBLIC_API_SERVER_URL is not defined");
 }


### PR DESCRIPTION
# 📌 PR 제목

## 관련 이슈
	•	resolves: #이슈번호 (이슈가 있다면 번호 입력)

## 작업 내용
	•	기존 엔드포인트 /universities/* → /univ-apply-infos/* 로 변경
	•	다음 3개의 API 함수에서 endpoint 경로 수정:
	•	getRecommendedUniversity (client)
	•	getRecommendedUniversity (server)
	•	getSearchUniversityList
	•	API 서버 URL 하드코딩된 주석 제거 및 BASE URL 고정 사용

## 특이 사항
	•	엔드포인트 명 변경 외 비즈니스 로직은 변경 없음
	•	해당 변경으로 인해 프론트 전반의 대학 추천 및 검색 기능 테스트 필요

## 리뷰 요구사항
	•	API endpoint 변경이 다른 로직에 영향 주지 않는지 확인
	•	혹시 /universities로 하드코딩된 부분이 남아있다면 추가 리뷰 필요