### PR TITLE
feat : 쿠키와 zustand만을 이용한 로그인 로직 구현했습니다 

### DIFF
--- a/src/api/mentor/server/getMentoringNewCount.ts
+++ b/src/api/mentor/server/getMentoringNewCount.ts
@@ -4,6 +4,7 @@ import { MentoringNewCountResponse } from "../type/response";
 
 const getMentoringNewCount = () => {
   return serverFetch<MentoringNewCountResponse>("/mentorings/check", {
+    isAuth: true, // 로그인 필요
     next: { revalidate: 600 }, // ISR: 10분마다 백그라운드 갱신
   });
 };

--- a/src/api/mentor/server/getMentoringNewCount.ts
+++ b/src/api/mentor/server/getMentoringNewCount.ts
@@ -4,7 +4,6 @@ import { MentoringNewCountResponse } from "../type/response";
 
 const getMentoringNewCount = () => {
   return serverFetch<MentoringNewCountResponse>("/mentorings/check", {
-    isAuth: true, // 로그인 필요
     next: { revalidate: 600 }, // ISR: 10분마다 백그라운드 갱신
   });
 };

--- a/src/api/university/server/getRecommendedUniversity.ts
+++ b/src/api/university/server/getRecommendedUniversity.ts
@@ -5,9 +5,7 @@ import { RecommendedUniversityResponse } from "../type/response";
 const getRecommendedUniversity = async () => {
   const endpoint = "/universities/recommend";
 
-  const res = await serverFetch<RecommendedUniversityResponse>(endpoint, {
-    isAuth: false, // 인증이 필요 없는 API로 설정
-  });
+  const res = await serverFetch<RecommendedUniversityResponse>(endpoint);
   return res;
 };
 

--- a/src/api/university/server/getRecommendedUniversity.ts
+++ b/src/api/university/server/getRecommendedUniversity.ts
@@ -5,7 +5,9 @@ import { RecommendedUniversityResponse } from "../type/response";
 const getRecommendedUniversity = async () => {
   const endpoint = "/universities/recommend";
 
-  const res = await serverFetch<RecommendedUniversityResponse>(endpoint);
+  const res = await serverFetch<RecommendedUniversityResponse>(endpoint, {
+    isAuth: false, // 인증이 필요 없는 API로 설정
+  });
   return res;
 };
 

--- a/src/api/university/server/getSearchUniversityList.ts
+++ b/src/api/university/server/getSearchUniversityList.ts
@@ -31,7 +31,7 @@ const getSearchUniversityList = async ({ region, keyword, testType, testScore }:
 
   const url = params.size ? `${endpoint}?${params.toString()}` : endpoint;
 
-  return serverFetch<SearchUniversityListResponse>(url, { isAuth: false });
+  return serverFetch<SearchUniversityListResponse>(url);
 };
 
 /**

--- a/src/api/university/server/getSearchUniversityList.ts
+++ b/src/api/university/server/getSearchUniversityList.ts
@@ -31,7 +31,7 @@ const getSearchUniversityList = async ({ region, keyword, testType, testScore }:
 
   const url = params.size ? `${endpoint}?${params.toString()}` : endpoint;
 
-  return serverFetch<SearchUniversityListResponse>(url);
+  return serverFetch<SearchUniversityListResponse>(url, { isAuth: false });
 };
 
 /**

--- a/src/app/(home)/_ui/PopularUniversitySection/index.tsx
+++ b/src/app/(home)/_ui/PopularUniversitySection/index.tsx
@@ -1,61 +1,24 @@
-import dynamic from "next/dynamic";
-import { Suspense } from "react";
-
 import PopularUniversityCard from "./_ui/PopularUniversityCard";
 
 import { ListUniversity } from "@/types/university";
-
-// PopularUniversityCard를 동적 임포트
-const PopularUniversityCardDynamic = dynamic(() => import("./_ui/PopularUniversityCard"), {
-  ssr: false,
-  loading: () => (
-    <div className="relative w-[153px]">
-      <div className="h-[120px] w-[153px] animate-pulse rounded-lg bg-gray-200" />
-    </div>
-  ),
-});
 
 type PopularUniversitySectionProps = {
   universities: ListUniversity[];
 };
 
 const PopularUniversitySection = ({ universities }: PopularUniversitySectionProps) => {
-  const aboveFold = universities.slice(0, 3);
-  const belowFold = universities.slice(3);
-
   return (
     <div className="overflow-x-auto">
       <div className="flex gap-2">
-        {/* 첫 3장은 즉시 전송 – LCP 후보 */}
-        {aboveFold.map((university, index) => (
+        {universities.map((university, index) => (
           <PopularUniversityCard
-            priority={index === 0} // 첫 번째만 priority
-            loading="eager" // 즉시 로딩
-            fetchPriority="high" // 높은 우선순위
-            quality={index === 0 ? 60 : 55} // LCP는 60, 나머지는 55로 최적화
             key={university.id}
             university={university}
+            priority={index === 0} // 첫 번째만 priority로 LCP 최적화
+            loading={index < 3 ? "eager" : "lazy"} // 첫 3개는 즉시, 나머지는 지연 로딩
+            fetchPriority={index === 0 ? "high" : "low"} // 첫 번째만 높은 우선순위
+            quality={index === 0 ? 60 : 50} // 첫 번째는 고품질, 나머지는 압축
           />
-        ))}
-
-        {/* 나머지는 동적 렌더링으로 위임 */}
-        {belowFold.map((university) => (
-          <Suspense
-            key={university.id}
-            fallback={
-              <div className="relative w-[153px]">
-                <div className="h-[120px] w-[153px] animate-pulse rounded-lg bg-gray-200" />
-              </div>
-            }
-          >
-            <PopularUniversityCardDynamic
-              university={university}
-              priority={false}
-              loading="lazy"
-              fetchPriority="low"
-              quality={50} // 동적 로딩 이미지는 50으로 최대 압축
-            />
-          </Suspense>
         ))}
       </div>
     </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,10 +15,10 @@ export const metadata: Metadata = {
   description: "솔리드 커넥션. 교환학생의 첫 걸음",
 };
 
-// 🎯 폰트 최적화: 하나의 폰트만 사용
+// 🎯 폰트 최적화: 하나의 폰트만 사용 + 즉시 로딩
 const pretendard = localFont({
   src: "../../public/fonts/PretendardVariable.woff2",
-  display: "swap", // optional → swap으로 변경 (preload와 호환)
+  display: "optional", // swap → optional로 변경 (3초 후 fallback)
   weight: "45 920",
   variable: "--font-pretendard",
   preload: true,
@@ -70,7 +70,7 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => (
         <style
           dangerouslySetInnerHTML={{
             __html: `
-              /* 폰트 즉시 렌더링 - swap과 호환 */
+              /* 폰트 즉시 렌더링 */
               html {
                 font-family: var(--font-pretendard), system-ui, -apple-system, sans-serif;
                 font-synthesis: none;
@@ -83,12 +83,6 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => (
                 margin: 0;
                 background: white;
                 font-family: system-ui, -apple-system, sans-serif; /* 폰트 로딩 전 즉시 렌더링 */
-              }
-              
-              /* 폰트 로딩 시 깜빡임 최소화 */
-              @font-face {
-                font-family: 'Pretendard Variable';
-                font-display: swap;
               }
               
               /* LCP 이미지만 최적화 */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,10 +15,10 @@ export const metadata: Metadata = {
   description: "솔리드 커넥션. 교환학생의 첫 걸음",
 };
 
-// 🎯 폰트 최적화: 하나의 폰트만 사용 + 즉시 로딩
+// 🎯 폰트 최적화: 하나의 폰트만 사용
 const pretendard = localFont({
   src: "../../public/fonts/PretendardVariable.woff2",
-  display: "optional", // swap → optional로 변경 (3초 후 fallback)
+  display: "swap", // optional → swap으로 변경 (preload와 호환)
   weight: "45 920",
   variable: "--font-pretendard",
   preload: true,
@@ -70,7 +70,7 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => (
         <style
           dangerouslySetInnerHTML={{
             __html: `
-              /* 폰트 즉시 렌더링 */
+              /* 폰트 즉시 렌더링 - swap과 호환 */
               html {
                 font-family: var(--font-pretendard), system-ui, -apple-system, sans-serif;
                 font-synthesis: none;
@@ -83,6 +83,12 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => (
                 margin: 0;
                 background: white;
                 font-family: system-ui, -apple-system, sans-serif; /* 폰트 로딩 전 즉시 렌더링 */
+              }
+              
+              /* 폰트 로딩 시 깜빡임 최소화 */
+              @font-face {
+                font-family: 'Pretendard Variable';
+                font-display: swap;
               }
               
               /* LCP 이미지만 최적화 */

--- a/src/utils/serverFetchUtil.ts
+++ b/src/utils/serverFetchUtil.ts
@@ -1,3 +1,14 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+// protectedFetch.ts
+import { decodeExp, isTokenExpired } from "./jwtUtils";
+
+import { reissueAccessTokenPublicApi } from "@/api/auth";
+
+const AUTH_EXPIRED = "AUTH_EXPIRED";
+const TIME_LIMIT = 30 * 1000; // 30초
+
 /** 커스텀 HTTP 에러: any 캐스팅 없이 status · body 보존 */
 class HttpError extends Error {
   status: number;
@@ -13,6 +24,79 @@ type ServerFetchSuccess<T> = { ok: true; status: number; data: T };
 type ServerFetchFailure = { ok: false; status: number; error: string; data: undefined };
 export type ServerFetchResult<T> = ServerFetchSuccess<T> | ServerFetchFailure;
 
+/* ---------- 전역 캐시 ---------- */
+interface AccessCacheItem {
+  token: string | null;
+  exp: number; // ms
+  refreshing: Promise<string> | null;
+  lastAccess: number; // 마지막 접근 시각
+}
+
+type AccessCacheMap = Record<string, AccessCacheItem>;
+
+const MAX_CACHE_ENTRIES = 1000;
+const CLEANUP_EVERY = 100; // getCache 호출 N회마다 정리
+let _cleanupCounter = 0;
+
+// 전역 객체에 캐시 맵 추가 (리프레시 토큰을 key 로 사용)
+const globalSemaphore = globalThis as typeof globalThis & {
+  __accessCacheMap?: AccessCacheMap;
+};
+
+if (!globalSemaphore.__accessCacheMap) {
+  globalSemaphore.__accessCacheMap = {};
+}
+
+/** 필요 시 새로 할당하여 캐시 항목 반환 + 주기적 정리 */
+const getCache = (refreshToken: string): AccessCacheItem => {
+  const map = globalSemaphore.__accessCacheMap!;
+  let item = map[refreshToken];
+  if (!item) {
+    item = { token: null, exp: 0, refreshing: null, lastAccess: Date.now() };
+    map[refreshToken] = item;
+  } else {
+    item.lastAccess = Date.now();
+  }
+
+  // 주기적 캐시 정리
+  if (++_cleanupCounter >= CLEANUP_EVERY && Object.keys(map).length > MAX_CACHE_ENTRIES) {
+    _cleanupCounter = 0;
+    const now = Date.now();
+    for (const [key, value] of Object.entries(map)) {
+      // 만료된 토큰이거나 1시간 이상 접근이 없으면 제거
+      if (now - value.lastAccess > 60 * 60 * 1000 || now > value.exp + TIME_LIMIT) {
+        delete map[key];
+      }
+    }
+  }
+  return item;
+};
+
+const getAccessToken = async (refresh: string) => {
+  const cache = getCache(refresh);
+
+  // 만료 30초 전까지는 재발급하지 않고 캐싱
+  if (cache.token && Date.now() < cache.exp - TIME_LIMIT) return cache.token;
+  if (cache.refreshing) return cache.refreshing;
+
+  cache.refreshing = reissueAccessTokenPublicApi(refresh)
+    .then(({ data }) => {
+      cache.token = data.accessToken;
+      cache.exp = decodeExp(data.accessToken);
+      cache.refreshing = null;
+      return data.accessToken;
+    })
+    .catch((e) => {
+      // 토큰 재발급 실패 시 캐시 초기화
+      cache.refreshing = null;
+      // 실패한 토큰은 캐시에서 제거하여 메모리 누수 방지
+      delete globalSemaphore.__accessCacheMap![refresh];
+      throw e;
+    });
+
+  return cache.refreshing;
+};
+
 /* ---------- fetch 래퍼 ---------- */
 type NextCacheOpt =
   | { revalidate?: number; tags?: string[] } // App Router 캐시 옵션
@@ -24,6 +108,8 @@ interface ServerFetchOptions extends Omit<RequestInit, "body"> {
    *  - string, Blob, FormData 등 → 그대로 전송
    */
   body?: unknown;
+  /** 로그인 필요 여부 (기본 true) */
+  isAuth?: boolean;
   /** Next.js 캐시 옵션 */
   next?: NextCacheOpt;
 }
@@ -34,13 +120,24 @@ if (!BASE) {
   throw new Error("NEXT_PUBLIC_API_SERVER_URL is not defined");
 }
 
-/** ISR 친화적 fetch - 인증 없는 공개 API만 지원 */
+/** SSR-only fetch (App Router) */
 async function internalFetch<T = unknown>(
   input: string,
-  { body, next, headers, ...init }: ServerFetchOptions = {},
+  { body, isAuth = false, next, headers, ...init }: ServerFetchOptions = {},
 ): Promise<T> {
-  /* 요청 헤더 구성 - 인증 제거 */
+  /* 쿠키 & 토큰 */
+  const cookieStore = cookies();
+  const refreshToken = cookieStore.get("refreshToken")?.value ?? null;
+  let accessToken: string | null = null;
+
+  if (isAuth) {
+    if (!refreshToken || isTokenExpired(refreshToken)) throw new Error(AUTH_EXPIRED);
+    accessToken = await getAccessToken(refreshToken);
+  }
+
+  /* 요청 헤더 구성 */
   const reqHeaders = new Headers(headers);
+  if (accessToken) reqHeaders.set("Authorization", `Bearer ${accessToken}`);
 
   let requestBody: RequestInit["body"] = undefined;
   if (body !== undefined) {
@@ -57,6 +154,7 @@ async function internalFetch<T = unknown>(
     ...init,
     body: requestBody,
     headers: reqHeaders,
+    credentials: "omit", // refresh 쿠키는 전달X 서버에서만 사용
     next, // revalidate / tags 옵션 그대로 전달
   });
 
@@ -75,16 +173,26 @@ async function internalFetch<T = unknown>(
   return textBody as unknown as T;
 }
 
-/** ISR 친화적 공개 API 전용 fetch */
+/** 옵션 객체 기반 Unified fetch */
 async function serverFetch<T = unknown>(url: string, options: ServerFetchOptions = {}): Promise<ServerFetchResult<T>> {
+  const { isAuth = false } = options;
+
   try {
     const data = await internalFetch<T>(url, options);
     return { ok: true, status: 200, data };
   } catch (e: unknown) {
+    // 중앙집중 인증 실패 처리 → 로그인 페이지로 리다이렉트
+    if (isAuth && e instanceof HttpError && (e.status === 401 || e.status === 403)) {
+      redirect(`/login?next=${encodeURIComponent(url)}`);
+    }
     if (e instanceof HttpError) {
       return { ok: false, status: e.status, error: e.body, data: undefined };
     }
     const err = e as Error;
+    // 예외 메시지 기반 토큰 만료 처리
+    if (isAuth && err.message === AUTH_EXPIRED) {
+      redirect(`/login?next=${encodeURIComponent(url)}`);
+    }
     return { ok: false, status: 500, error: err.message ?? "Unknown error", data: undefined };
   }
 }

--- a/src/utils/serverFetchUtil.ts
+++ b/src/utils/serverFetchUtil.ts
@@ -1,14 +1,3 @@
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
-
-// protectedFetch.ts
-import { decodeExp, isTokenExpired } from "./jwtUtils";
-
-import { reissueAccessTokenPublicApi } from "@/api/auth";
-
-const AUTH_EXPIRED = "AUTH_EXPIRED";
-const TIME_LIMIT = 30 * 1000; // 30초
-
 /** 커스텀 HTTP 에러: any 캐스팅 없이 status · body 보존 */
 class HttpError extends Error {
   status: number;
@@ -24,79 +13,6 @@ type ServerFetchSuccess<T> = { ok: true; status: number; data: T };
 type ServerFetchFailure = { ok: false; status: number; error: string; data: undefined };
 export type ServerFetchResult<T> = ServerFetchSuccess<T> | ServerFetchFailure;
 
-/* ---------- 전역 캐시 ---------- */
-interface AccessCacheItem {
-  token: string | null;
-  exp: number; // ms
-  refreshing: Promise<string> | null;
-  lastAccess: number; // 마지막 접근 시각
-}
-
-type AccessCacheMap = Record<string, AccessCacheItem>;
-
-const MAX_CACHE_ENTRIES = 1000;
-const CLEANUP_EVERY = 100; // getCache 호출 N회마다 정리
-let _cleanupCounter = 0;
-
-// 전역 객체에 캐시 맵 추가 (리프레시 토큰을 key 로 사용)
-const globalSemaphore = globalThis as typeof globalThis & {
-  __accessCacheMap?: AccessCacheMap;
-};
-
-if (!globalSemaphore.__accessCacheMap) {
-  globalSemaphore.__accessCacheMap = {};
-}
-
-/** 필요 시 새로 할당하여 캐시 항목 반환 + 주기적 정리 */
-const getCache = (refreshToken: string): AccessCacheItem => {
-  const map = globalSemaphore.__accessCacheMap!;
-  let item = map[refreshToken];
-  if (!item) {
-    item = { token: null, exp: 0, refreshing: null, lastAccess: Date.now() };
-    map[refreshToken] = item;
-  } else {
-    item.lastAccess = Date.now();
-  }
-
-  // 주기적 캐시 정리
-  if (++_cleanupCounter >= CLEANUP_EVERY && Object.keys(map).length > MAX_CACHE_ENTRIES) {
-    _cleanupCounter = 0;
-    const now = Date.now();
-    for (const [key, value] of Object.entries(map)) {
-      // 만료된 토큰이거나 1시간 이상 접근이 없으면 제거
-      if (now - value.lastAccess > 60 * 60 * 1000 || now > value.exp + TIME_LIMIT) {
-        delete map[key];
-      }
-    }
-  }
-  return item;
-};
-
-const getAccessToken = async (refresh: string) => {
-  const cache = getCache(refresh);
-
-  // 만료 30초 전까지는 재발급하지 않고 캐싱
-  if (cache.token && Date.now() < cache.exp - TIME_LIMIT) return cache.token;
-  if (cache.refreshing) return cache.refreshing;
-
-  cache.refreshing = reissueAccessTokenPublicApi(refresh)
-    .then(({ data }) => {
-      cache.token = data.accessToken;
-      cache.exp = decodeExp(data.accessToken);
-      cache.refreshing = null;
-      return data.accessToken;
-    })
-    .catch((e) => {
-      // 토큰 재발급 실패 시 캐시 초기화
-      cache.refreshing = null;
-      // 실패한 토큰은 캐시에서 제거하여 메모리 누수 방지
-      delete globalSemaphore.__accessCacheMap![refresh];
-      throw e;
-    });
-
-  return cache.refreshing;
-};
-
 /* ---------- fetch 래퍼 ---------- */
 type NextCacheOpt =
   | { revalidate?: number; tags?: string[] } // App Router 캐시 옵션
@@ -108,8 +24,6 @@ interface ServerFetchOptions extends Omit<RequestInit, "body"> {
    *  - string, Blob, FormData 등 → 그대로 전송
    */
   body?: unknown;
-  /** 로그인 필요 여부 (기본 true) */
-  isAuth?: boolean;
   /** Next.js 캐시 옵션 */
   next?: NextCacheOpt;
 }
@@ -120,24 +34,13 @@ if (!BASE) {
   throw new Error("NEXT_PUBLIC_API_SERVER_URL is not defined");
 }
 
-/** SSR-only fetch (App Router) */
+/** ISR 친화적 fetch - 인증 없는 공개 API만 지원 */
 async function internalFetch<T = unknown>(
   input: string,
-  { body, isAuth = false, next, headers, ...init }: ServerFetchOptions = {},
+  { body, next, headers, ...init }: ServerFetchOptions = {},
 ): Promise<T> {
-  /* 쿠키 & 토큰 */
-  const cookieStore = cookies();
-  const refreshToken = cookieStore.get("refreshToken")?.value ?? null;
-  let accessToken: string | null = null;
-
-  if (isAuth) {
-    if (!refreshToken || isTokenExpired(refreshToken)) throw new Error(AUTH_EXPIRED);
-    accessToken = await getAccessToken(refreshToken);
-  }
-
-  /* 요청 헤더 구성 */
+  /* 요청 헤더 구성 - 인증 제거 */
   const reqHeaders = new Headers(headers);
-  if (accessToken) reqHeaders.set("Authorization", `Bearer ${accessToken}`);
 
   let requestBody: RequestInit["body"] = undefined;
   if (body !== undefined) {
@@ -154,7 +57,6 @@ async function internalFetch<T = unknown>(
     ...init,
     body: requestBody,
     headers: reqHeaders,
-    credentials: "omit", // refresh 쿠키는 전달X 서버에서만 사용
     next, // revalidate / tags 옵션 그대로 전달
   });
 
@@ -173,26 +75,16 @@ async function internalFetch<T = unknown>(
   return textBody as unknown as T;
 }
 
-/** 옵션 객체 기반 Unified fetch */
+/** ISR 친화적 공개 API 전용 fetch */
 async function serverFetch<T = unknown>(url: string, options: ServerFetchOptions = {}): Promise<ServerFetchResult<T>> {
-  const { isAuth = false } = options;
-
   try {
     const data = await internalFetch<T>(url, options);
     return { ok: true, status: 200, data };
   } catch (e: unknown) {
-    // 중앙집중 인증 실패 처리 → 로그인 페이지로 리다이렉트
-    if (isAuth && e instanceof HttpError && (e.status === 401 || e.status === 403)) {
-      redirect(`/login?next=${encodeURIComponent(url)}`);
-    }
     if (e instanceof HttpError) {
       return { ok: false, status: e.status, error: e.body, data: undefined };
     }
     const err = e as Error;
-    // 예외 메시지 기반 토큰 만료 처리
-    if (isAuth && err.message === AUTH_EXPIRED) {
-      redirect(`/login?next=${encodeURIComponent(url)}`);
-    }
     return { ok: false, status: 500, error: err.message ?? "Unknown error", data: undefined };
   }
 }


### PR DESCRIPTION
# 관련 이슈
	•	resolves: #이슈번호

# 작업 내용
	•	zustand 기반 메모리 전용 토큰 스토어(useTokenStore) 구현
	•	accessToken 상태 관리 (setAccessToken, clearAccessToken, hasToken)
	•	컴포넌트 외부에서도 사용 가능한 헬퍼 함수(getAccessToken, setAccessToken, clearAccessToken, hasToken) 제공
	•	토큰 관리 로직을 중앙화하여 전역적으로 일관된 접근 가능
	•	추후 API 호출 시 전역 토큰 참조 가능하도록 구조 설계

# 특이 사항
	•	토큰은 메모리 전용으로 저장되며, 새로고침 시 초기화됨
	•	LocalStorage, SessionStorage 등 영구 저장소와의 연동은 현재 미구현 상태
	•	로그인/로그아웃 로직 연계 시 헬퍼 함수를 사용해야 함

# 리뷰 요구사항
	•	로컬스토리지를 사용하는 로직이 남아있는지 여부 검토
	•	프로젝트 내 다른 상태관리 로직과의 중복 여부 검토
	•	추후 영구 저장 전략 도입 시 구조 변경이 용이한지 점검
