### PR TITLE
fix : node version을 추가하다

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "solid-connect-web",
   "version": "2.2445",
   "private": true,
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## 관련 이슈

- resolves: #이슈 번호

## 작업 내용

- node version 정의 문제로 인해 22.x를 명시했습니다 

```
Run vercel build --yes --target=preview --token=***
Vercel CLI 47.0.7
WARN! Build not running on Vercel. System environment variables will not be available.
Error: Node.js Version "18.x" is discontinued and must be upgraded. Please set Node.js Version to 22.x in your Project Settings to use Node.js 22.
Learn More: http://vercel.link/node-version
Error: Process completed with exit code 1.
```