### PR TITLE
fix : serverFetch를 쓰지않는 fetch를 수정하다

### DIFF
--- a/src/api/university/server/getUniversityDetail.ts
+++ b/src/api/university/server/getUniversityDetail.ts
@@ -1,17 +1,9 @@
-import { AxiosResponse } from "axios";
-
-import { publicAxiosInstance } from "@/utils/axiosInstance";
+import serverFetch from "@/utils/serverFetchUtil";
 
 import { University } from "@/types/university";
 
-/**
- * @description 대학 상세 조회 서버 사이드 API 함수
- * @param universityInfoForApplyId - 대학 ID
- * @returns Promise<University>
- */
-export const getUniversityDetail = async (universityInfoForApplyId: number): Promise<University> => {
-  const response: AxiosResponse<University> = await publicAxiosInstance.get(
-    `/univ-apply-infos/${universityInfoForApplyId}`,
-  );
-  return response.data;
+export const getUniversityDetail = async (universityInfoForApplyId: number): Promise<University | undefined> => {
+  const result = await serverFetch<University>(`/univ-apply-infos/${universityInfoForApplyId}`);
+
+  return result.data;
 };


### PR DESCRIPTION
## 관련 이슈

- resolves: #이슈 번호

## 작업 내용

- 센트리 오류로 발견 
- ssr을 위한 fetch가 serverFetch를 사용하지 않아서 애러 바운더리가 안되는 버그가 존재 해당 이슈를 해결 

<img width="822" height="395" alt="스크린샷 2025-10-04 오전 12 57 31" src="https://github.com/user-attachments/assets/decc39bf-6c25-42e4-98e7-4b1af9e66de5" />

