### PR TITLE
fix: prettier 설정 통일 및 포맷팅 수정

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "prettier.printWidth": 100,
+  "prettier.requireConfig": true,
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.tabSize": 2

--- a/src/components/button/BlockBtn.tsx
+++ b/src/components/button/BlockBtn.tsx
@@ -21,7 +21,8 @@ const blockBtnVariants = cva("h-13 w-full min-w-80 max-w-screen-sm rounded-lg fl
 });
 
 export interface BlockBtnProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof blockBtnVariants> {
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof blockBtnVariants> {
   onClick: () => void;
   children: React.ReactNode;
 }

--- a/src/components/button/RoundBtn.tsx
+++ b/src/components/button/RoundBtn.tsx
@@ -23,7 +23,8 @@ const roundBtnVariants = cva("h-[2.375rem] w-[6.375rem] rounded-3xl px-4 py-2.5 
 });
 
 export interface RoundBtnProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof roundBtnVariants> {
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof roundBtnVariants> {
   onClick?: () => void;
   children: React.ReactNode;
 }


### PR DESCRIPTION
## 작업 내용
- `.vscode/settings.json`에서 `prettier.printWidth: 100` 제거
- `prettier.requireConfig: true` 추가하여 `.prettierrc.json` 설정만 따르도록 설정
- Prettier 포맷팅 오류가 있던 버튼 컴포넌트 수정 (BlockBtn, RoundBtn)

## 리뷰 요구사항 (선택)
Prettier 설정 통일 방식에 대해 더 좋은 방법이 있다면 이야기 나눠봐도 좋을 것 같아요!
