### PR TITLE
fix: 커뮤니티 게시물 조회 시 전역 스피너 비활성화

### DIFF
--- a/src/apis/community/getPostDetail.ts
+++ b/src/apis/community/getPostDetail.ts
@@ -12,6 +12,7 @@ const useGetPostDetail = (postId: number) => {
     queryKey: [CommunityQueryKeys.posts, postId],
     queryFn: () => communityApi.getPostDetail(postId),
     enabled: !!postId,
+    meta: { showGlobalSpinner: false },
   });
 };
 

--- a/src/components/layout/GlobalLayout/ui/ClientModal/index.tsx
+++ b/src/components/layout/GlobalLayout/ui/ClientModal/index.tsx
@@ -23,7 +23,9 @@ const ClientModal = () => {
     checkAndOpen,
   } = useSurveyModalStore();
 
-  const isFetching = useIsFetching();
+  const isFetching = useIsFetching({
+    predicate: (query) => query.meta?.showGlobalSpinner !== false,
+  });
 
   // 페이지 로드 시 만족도 조사 모달 표시 여부 확인
   useEffect(() => {


### PR DESCRIPTION
## 관련 이슈

- resolves: #374 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->
| 수정 전 | 수정 후 |
|:--:|:--:|
| <img width="100%" alt="수정 전 - 로딩 스피너 중복 노출" src="https://github.com/user-attachments/assets/d9c8f1f1-5ce1-4734-949d-20bc99d43c17" /> | <img width="100%" alt="수정 후 - 단일 로딩 스피너 노출" src="https://github.com/user-attachments/assets/ebf72450-af1b-447f-85ba-deb1ffb42c09" /> |



<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

로딩 스피너를 불러오는 곳이 2가지(게시물 조회 시 isLoading, 전역 스피너의 isFetching)라 다음과 이와 같은 문제가 발생한 것으로 확인했습니다. 따라서 로딩 시, 1개의 로딩 스피너만 불러올 수 있도록 수정하였습니다. 

기존 쿼리에 meta data 를 추가하여 수정하였으며, 추후에 다른 쿼리 및 페이지에서도 동일한 문제가 발생했을 경우, 같은 방식으로 해당 쿼리에 같은 meta data 만 추가한다면 문제를 해결할 수 있을 것이라 생각합니다!

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->
추후 다른 페이지에서도 동일한 문제가 발견되거나 새로운 페이지를 추가했을 경우 같은 문제가 생길 수도 있는 것을 감안하여 전역 스피너 관련 코드(index.tsx) 의 수정을 최소화하는 방안을 택하였습니다. 필요할 때마다 전역 스피너에 queryKey를 import하여 코드를 추가하게 된다면 코드가 지저분해질 것 같아서 이와 같은 방법을 택하였는데, 혹시 더 나은 방법이 있다면 알려주시면 감사하겠습니다! 피드백 부탁드리겠습니다☺️!

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
