### PR TITLE
fix: 중복 토스트 메시지 제거

### DIFF
--- a/apps/web/src/app/university/application/ScorePageContent.tsx
+++ b/apps/web/src/app/university/application/ScorePageContent.tsx
@@ -115,7 +115,6 @@ const ScorePageContent = () => {
   useEffect(() => {
     if (isLoading) return;
     if (isError) {
-      toast.error("지원 현황을 불러오는 중에 오류가 발생했습니다. 지원 절차를 진행해주세요.");
       router.replace("/university/application/apply");
     }
   }, [isError, isLoading, router]);


### PR DESCRIPTION
## 관련 이슈

- resolves: #369 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

| 로그인 O | 로그인 X |
|:--:|:--:|
| <img src="https://github.com/user-attachments/assets/ba808950-9584-4579-8a49-b608494939d4" width="300" /> | <img src="https://github.com/user-attachments/assets/46282574-a8a7-477a-89ea-a28abf3e5175" width="300" /> |


<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

**지원자 현황 확인** 진입 시, 수정 전에는 에러 토스트가 2가지가 나오던 것을 수정 후 로그인 확인에 실패한 경우에 대해서 올바를 에러 토스트 1가지만 나오도록 수정하였습니다. 따라서 로그인 후 동일 페이지 진입 시에는 로그인 관련 에러 토스트가 더 이상 나오지 않는 것으로 확인했습니다!

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->
**로그인에는 성공했지만 점수 공유 현황의 목록이 나오지 않는 경우**를 테스트 해보기 위해 개발자 도구에서 `applications` api의 요청 URL을 임의로 차단하는 방식을 이용했습니다. 테스트 해 본 결과, 에러 토스트 메세지로 'Network Error'를 띄우고 `/university/application/apply` 로 이동하여 사용자에게 지원서를 입력하도록 작동하고 있는 것을 확인했습니다! 해당 과정에서 추가로 수정할 부분이 있다면 알려주세요!
