### PR TITLE
feat(web): admin 뷰 전환을 플로팅 메뉴로 이관

### DIFF
--- a/apps/web/src/app/mentor/_ui/MentorClient/index.tsx
+++ b/apps/web/src/app/mentor/_ui/MentorClient/index.tsx
@@ -6,7 +6,7 @@ import { postReissueToken } from "@/apis/Auth";
 import CloudSpinnerPage from "@/components/ui/CloudSpinnerPage";
 import useAuthStore from "@/lib/zustand/useAuthStore";
 import { UserRole } from "@/types/mentor";
-import { isTokenExpired, tokenParse } from "@/utils/jwtUtils";
+import { isTokenExpired } from "@/utils/jwtUtils";
 
 // 레이지 로드 컴포넌트
 const MenteePage = lazy(() => import("./_ui/MenteePage"));
@@ -14,12 +14,9 @@ const MentorPage = lazy(() => import("./_ui/MentorPage"));
 
 const MentorClient = () => {
   const router = useRouter();
-  const { isLoading, accessToken, isInitialized, refreshStatus, setRefreshStatus } = useAuthStore();
+  const { isLoading, accessToken, clientRole, isInitialized, refreshStatus, setRefreshStatus } = useAuthStore();
   const [isRefreshing, setIsRefreshing] = useState(false);
   const hasValidAccessToken = Boolean(accessToken && !isTokenExpired(accessToken));
-
-  // 어드민 전용: 뷰 전환 상태 (true: 멘토 뷰, false: 멘티 뷰)
-  const [showMentorView, setShowMentorView] = useState<boolean>(true);
 
   // 토큰 재발급 로직
   useEffect(() => {
@@ -62,40 +59,14 @@ const MentorClient = () => {
     return <CloudSpinnerPage />;
   }
 
-  const parsedToken = tokenParse(accessToken);
-  const userRole = parsedToken?.role;
-  const isMentor = userRole === UserRole.MENTOR || userRole === UserRole.ADMIN;
-  const isAdmin = userRole === UserRole.ADMIN;
-
-  // 어드민이 아닌 경우 기존 로직대로
-  const shouldShowMentorView = isAdmin ? showMentorView : isMentor;
+  if (!clientRole) {
+    return <CloudSpinnerPage />;
+  }
 
   return (
-    <>
-      {/* 어드민 전용 뷰 전환 버튼 */}
-      {isAdmin && (
-        <div className="mb-4 flex gap-2">
-          <button
-            onClick={() => setShowMentorView(true)}
-            className={`flex-1 rounded-lg px-4 py-2.5 transition-colors typo-sb-9 ${
-              showMentorView ? "bg-primary text-white" : "border border-k-200 bg-white text-k-600 hover:bg-k-50"
-            }`}
-          >
-            멘토 페이지 보기
-          </button>
-          <button
-            onClick={() => setShowMentorView(false)}
-            className={`flex-1 rounded-lg px-4 py-2.5 transition-colors typo-sb-9 ${
-              !showMentorView ? "bg-primary text-white" : "border border-k-200 bg-white text-k-600 hover:bg-k-50"
-            }`}
-          >
-            멘티 페이지 보기
-          </button>
-        </div>
-      )}
-
-      <Suspense fallback={<CloudSpinnerPage />}>{shouldShowMentorView ? <MentorPage /> : <MenteePage />}</Suspense>
-    </>
+    <Suspense fallback={<CloudSpinnerPage />}>
+      {clientRole === UserRole.MENTOR ? <MentorPage /> : <MenteePage />}
+    </Suspense>
   );
 };
 

--- a/apps/web/src/app/my/_ui/MyProfileContent/index.tsx
+++ b/apps/web/src/app/my/_ui/MyProfileContent/index.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
 import { useDeleteUserAccount, usePostLogout } from "@/apis/Auth";
 import { type MyInfoResponse, useGetMyInfo } from "@/apis/MyPage";
 import LinkedTextWithIcon from "@/components/ui/LinkedTextWithIcon";
 import ProfileWithBadge from "@/components/ui/ProfileWithBadge";
+import useAuthStore from "@/lib/zustand/useAuthStore";
 import { toast } from "@/lib/zustand/useToastStore";
 import { IconLikeFill } from "@/public/svgs/mentor";
 import {
@@ -25,47 +25,20 @@ const MyProfileContent = () => {
   const { data: profileData = {} as MyInfoResponse } = useGetMyInfo();
   const { mutate: deleteUserAccount } = useDeleteUserAccount();
   const { mutate: postLogout } = usePostLogout();
+  const clientRole = useAuthStore((state) => state.clientRole);
 
   const { nickname, email, profileImageUrl } = profileData;
 
-  const isAdmin = profileData.role === UserRole.ADMIN;
   const isMentor = profileData.role === UserRole.MENTOR || profileData.role === UserRole.ADMIN;
-
-  // 어드민 전용: 뷰 전환 상태 (true: 멘토 뷰, false: 멘티 뷰)
-  const [showMentorView, setShowMentorView] = useState<boolean>(true);
-
-  // 어드민이 아닌 경우 기존 로직대로, 어드민인 경우 토글 상태에 따라
-  const viewAsMentor = isAdmin ? showMentorView : isMentor;
+  const viewAsMentor = clientRole ? clientRole === UserRole.MENTOR : isMentor;
 
   const university =
     profileData.role === UserRole.MENTOR || profileData.role === UserRole.ADMIN ? profileData.attendedUniversity : null;
   const favoriteLocation =
-    profileData.role === UserRole.MENTEE ? profileData.interestedCountries?.slice(0, 3).join(", ") || "없음" : null;
+    profileData.role === UserRole.MENTEE ? profileData.interestedCountries.slice(0, 3).join(", ") || "없음" : "없음";
 
   return (
     <div className="px-5 py-2">
-      {/* 어드민 전용 뷰 전환 버튼 */}
-      {isAdmin && (
-        <div className="mb-4 flex gap-2">
-          <button
-            onClick={() => setShowMentorView(true)}
-            className={`flex-1 rounded-lg px-4 py-2.5 transition-colors typo-sb-9 ${
-              showMentorView ? "bg-primary text-white" : "border border-k-200 bg-white text-k-600 hover:bg-k-50"
-            }`}
-          >
-            멘토 뷰
-          </button>
-          <button
-            onClick={() => setShowMentorView(false)}
-            className={`flex-1 rounded-lg px-4 py-2.5 transition-colors typo-sb-9 ${
-              !showMentorView ? "bg-primary text-white" : "border border-k-200 bg-white text-k-600 hover:bg-k-50"
-            }`}
-          >
-            멘티 뷰
-          </button>
-        </div>
-      )}
-
       <div className="mb-4 text-start text-k-700 typo-sb-5">
         <p>{nickname}님은</p>
         <p>

--- a/apps/web/src/app/my/match/_ui/MatchContent/index.tsx
+++ b/apps/web/src/app/my/match/_ui/MatchContent/index.tsx
@@ -1,51 +1,24 @@
 "use client";
 
-import { useState } from "react";
 import { useGetChatRooms } from "@/apis/chat";
 import { type MyInfoResponse, useGetMyInfo } from "@/apis/MyPage";
 import MentorCard from "@/components/mentor/MentorCard";
 import MentorChatCard from "@/components/mentor/MentorChatCard";
+import useAuthStore from "@/lib/zustand/useAuthStore";
 import { UserRole } from "@/types/mentor";
 
 const MatchContent = () => {
   const { data: myInfo = {} as MyInfoResponse } = useGetMyInfo();
   const { data: chatRoom = [] } = useGetChatRooms();
+  const clientRole = useAuthStore((state) => state.clientRole);
 
-  const isAdmin = myInfo.role === UserRole.ADMIN;
   const isMentor = myInfo.role === UserRole.MENTOR || myInfo.role === UserRole.ADMIN;
-
-  // 어드민 전용: 뷰 전환 상태 (true: 멘토 뷰, false: 멘티 뷰)
-  const [showMentorView, setShowMentorView] = useState<boolean>(true);
-
-  // 어드민이 아닌 경우 기존 로직대로, 어드민인 경우 토글 상태에 따라
-  const viewAsMentor = isAdmin ? showMentorView : isMentor;
+  const viewAsMentor = clientRole ? clientRole === UserRole.MENTOR : isMentor;
 
   const { nickname } = myInfo;
 
   return (
     <div className="flex h-full flex-col px-5">
-      {/* 어드민 전용 뷰 전환 버튼 */}
-      {isAdmin && (
-        <div className="mb-4 flex gap-2">
-          <button
-            onClick={() => setShowMentorView(true)}
-            className={`flex-1 rounded-lg px-4 py-2.5 transition-colors typo-sb-9 ${
-              showMentorView ? "bg-primary text-white" : "border border-k-200 bg-white text-k-600 hover:bg-k-50"
-            }`}
-          >
-            멘토 뷰
-          </button>
-          <button
-            onClick={() => setShowMentorView(false)}
-            className={`flex-1 rounded-lg px-4 py-2.5 transition-colors typo-sb-9 ${
-              !showMentorView ? "bg-primary text-white" : "border border-k-200 bg-white text-k-600 hover:bg-k-50"
-            }`}
-          >
-            멘티 뷰
-          </button>
-        </div>
-      )}
-
       <p className="font-pretendard text-k-700 typo-sb-4">
         {nickname ? `${nickname}님의` : "회원님이"}
         <br />

--- a/apps/web/src/components/layout/GlobalLayout/ui/AIInspectorFab/index.tsx
+++ b/apps/web/src/components/layout/GlobalLayout/ui/AIInspectorFab/index.tsx
@@ -12,13 +12,14 @@ import { toast } from "@/lib/zustand/useToastStore";
 import { UserRole } from "@/types/mentor";
 
 const AIInspectorFab = () => {
-  const { userRole, isInitialized, accessToken } = useAuthStore();
-  const isAdmin = isInitialized && userRole === UserRole.ADMIN;
+  const { serverRole, clientRole, setClientRole, isInitialized, accessToken } = useAuthStore();
+  const isAdmin = isInitialized && serverRole === UserRole.ADMIN;
 
   const { isInspecting, setIsInspecting, hoverRect, selection, clearSelection, resetInspector } =
     useAiInspectorSelection({ isEnabled: isAdmin });
   const [instruction, setInstruction] = useState("");
   const [isSaving, setIsSaving] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   if (!isAdmin) {
     return null;
@@ -27,6 +28,22 @@ const AIInspectorFab = () => {
   const resetForm = () => {
     setInstruction("");
     resetInspector();
+  };
+
+  const handleToggleInspector = () => {
+    setIsInspecting((prev) => !prev);
+    clearSelection();
+    setInstruction("");
+  };
+
+  const handleSwitchToMentorView = () => {
+    setClientRole(UserRole.MENTOR);
+    toast.success("멘토 UI 보기로 전환되었습니다.");
+  };
+
+  const handleSwitchToMenteeView = () => {
+    setClientRole(UserRole.MENTEE);
+    toast.success("멘티 UI 보기로 전환되었습니다.");
   };
 
   const handleSave = async () => {
@@ -84,21 +101,6 @@ const AIInspectorFab = () => {
       )}
 
       <div data-ai-inspector-ui="true" className="fixed bottom-20 left-4 z-[100] flex flex-col gap-2">
-        <button
-          type="button"
-          onClick={() => {
-            setIsInspecting((prev) => !prev);
-            clearSelection();
-            setInstruction("");
-          }}
-          className={`flex h-12 w-12 items-center justify-center rounded-full text-white shadow-lg transition ${
-            isInspecting ? "bg-secondary hover:bg-secondary-800" : "bg-primary hover:bg-primary-1"
-          }`}
-          aria-label="AI 인스펙터"
-        >
-          {isInspecting ? <Target size={20} /> : <Bot size={20} />}
-        </button>
-
         {selection && (
           <div className="w-80 rounded-xl border border-k-100 bg-white p-3 shadow-2xl">
             <div className="mb-2 flex items-center justify-between">
@@ -141,6 +143,59 @@ const AIInspectorFab = () => {
             </div>
           </div>
         )}
+
+        {isMenuOpen && (
+          <div className="w-56 rounded-xl border border-k-100 bg-white p-3 shadow-2xl">
+            <button
+              type="button"
+              onClick={handleToggleInspector}
+              className={`w-full rounded-md px-3 py-2 text-left typo-medium-4 transition ${
+                isInspecting ? "bg-secondary-50 text-secondary-800" : "bg-k-50 text-k-700 hover:bg-k-100"
+              }`}
+            >
+              {isInspecting ? "인스펙터 끄기" : "인스펙터 켜기"}
+            </button>
+
+            <div className="mt-3 text-k-500 typo-medium-4">뷰 전환</div>
+            <div className="mt-2 grid grid-cols-2 gap-2">
+              <button
+                type="button"
+                onClick={handleSwitchToMentorView}
+                className={`rounded-md px-2 py-2 typo-medium-4 transition ${
+                  clientRole === UserRole.MENTOR
+                    ? "bg-primary text-white"
+                    : "border border-k-200 bg-white text-k-700 hover:bg-k-50"
+                }`}
+              >
+                멘토 UI
+              </button>
+              <button
+                type="button"
+                onClick={handleSwitchToMenteeView}
+                className={`rounded-md px-2 py-2 typo-medium-4 transition ${
+                  clientRole === UserRole.MENTEE
+                    ? "bg-primary text-white"
+                    : "border border-k-200 bg-white text-k-700 hover:bg-k-50"
+                }`}
+              >
+                멘티 UI
+              </button>
+            </div>
+          </div>
+        )}
+
+        <button
+          type="button"
+          onClick={() => {
+            setIsMenuOpen((prev) => !prev);
+          }}
+          className={`flex h-12 w-12 items-center justify-center rounded-full text-white shadow-lg transition ${
+            isMenuOpen ? "bg-secondary hover:bg-secondary-800" : "bg-primary hover:bg-primary-1"
+          }`}
+          aria-label="관리자 메뉴"
+        >
+          {isMenuOpen ? <X size={20} /> : isInspecting ? <Target size={20} /> : <Bot size={20} />}
+        </button>
       </div>
     </>
   );

--- a/apps/web/src/components/mentor/MentorApplyCountContent/index.tsx
+++ b/apps/web/src/components/mentor/MentorApplyCountContent/index.tsx
@@ -8,8 +8,8 @@ import { UserRole } from "@/types/mentor";
 
 const MentorApplyCountContent = () => {
   const router = useRouter();
-  const { isInitialized, isAuthenticated, userRole } = useAuthStore();
-  const isMentor = userRole === UserRole.MENTOR;
+  const { isInitialized, isAuthenticated, serverRole } = useAuthStore();
+  const isMentor = serverRole === UserRole.MENTOR;
 
   const { data: count, isSuccess } = useGetUnconfirmedMentoringCount(isInitialized && isAuthenticated && isMentor);
 

--- a/apps/web/src/components/mentor/MentorExpandChatCard/hooks/useExpandCardClickHandler.ts
+++ b/apps/web/src/components/mentor/MentorExpandChatCard/hooks/useExpandCardClickHandler.ts
@@ -17,8 +17,8 @@ const useExpandCardClickHandler = ({
   mentoringId,
   initChecked = false,
 }: UseExpandCardClickHandlerProps): UseExpandCardClickHandlerReturn => {
-  const userRole = useAuthStore((state) => state.userRole);
-  const isMentor = userRole === UserRole.MENTOR;
+  const clientRole = useAuthStore((state) => state.clientRole);
+  const isMentor = clientRole === UserRole.MENTOR;
 
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
   const [isCheckedState, setIsCheckedState] = useState<boolean>(initChecked || false);

--- a/apps/web/src/lib/zustand/useAuthStore.ts
+++ b/apps/web/src/lib/zustand/useAuthStore.ts
@@ -20,16 +20,31 @@ const parseUserRoleFromToken = (token: string | null): UserRole | null => {
 };
 
 type RefreshStatus = "idle" | "refreshing" | "success" | "failed";
+type ClientRole = UserRole.MENTOR | UserRole.MENTEE;
+
+const resolveClientRole = (serverRole: UserRole | null, currentClientRole: ClientRole | null): ClientRole | null => {
+  if (serverRole === UserRole.ADMIN) {
+    return currentClientRole ?? UserRole.MENTOR;
+  }
+
+  if (serverRole === UserRole.MENTOR || serverRole === UserRole.MENTEE) {
+    return serverRole;
+  }
+
+  return null;
+};
 
 interface AuthState {
   accessToken: string | null;
-  userRole: UserRole | null;
+  serverRole: UserRole | null;
+  clientRole: ClientRole | null;
   isAuthenticated: boolean;
   isLoading: boolean;
   isInitialized: boolean;
   refreshStatus: RefreshStatus;
   setAccessToken: (token: string) => void;
   clearAccessToken: () => void;
+  setClientRole: (role: ClientRole) => void;
   setLoading: (loading: boolean) => void;
   setInitialized: (initialized: boolean) => void;
   setRefreshStatus: (status: RefreshStatus) => void;
@@ -39,31 +54,48 @@ const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
       accessToken: null,
-      userRole: null,
+      serverRole: null,
+      clientRole: null,
       isAuthenticated: false,
       isLoading: false,
       isInitialized: false,
       refreshStatus: "idle",
 
       setAccessToken: (token) => {
-        set({
-          accessToken: token,
-          userRole: parseUserRoleFromToken(token),
-          isAuthenticated: true,
-          isLoading: false,
-          isInitialized: true,
-          refreshStatus: "success",
+        set((state) => {
+          const serverRole = parseUserRoleFromToken(token);
+
+          return {
+            accessToken: token,
+            serverRole,
+            clientRole: resolveClientRole(serverRole, state.clientRole),
+            isAuthenticated: true,
+            isLoading: false,
+            isInitialized: true,
+            refreshStatus: "success",
+          };
         });
       },
 
       clearAccessToken: () => {
         set({
           accessToken: null,
-          userRole: null,
+          serverRole: null,
+          clientRole: null,
           isAuthenticated: false,
           isLoading: false,
           isInitialized: true,
           refreshStatus: "idle",
+        });
+      },
+
+      setClientRole: (role) => {
+        set((state) => {
+          if (state.serverRole !== UserRole.ADMIN) {
+            return {};
+          }
+
+          return { clientRole: role };
         });
       },
 
@@ -83,6 +115,7 @@ const useAuthStore = create<AuthState>()(
       name: "auth-storage",
       partialize: (state) => ({
         accessToken: state.accessToken,
+        clientRole: state.clientRole,
         isAuthenticated: state.isAuthenticated,
       }),
       onRehydrateStorage: () => (state) => {
@@ -92,11 +125,14 @@ const useAuthStore = create<AuthState>()(
 
           if (!hasValidToken) {
             state.accessToken = null;
-            state.userRole = null;
+            state.serverRole = null;
+            state.clientRole = null;
             state.isAuthenticated = false;
             state.refreshStatus = "idle";
           } else {
-            state.userRole = parseUserRoleFromToken(state.accessToken);
+            const serverRole = parseUserRoleFromToken(state.accessToken);
+            state.serverRole = serverRole;
+            state.clientRole = resolveClientRole(serverRole, state.clientRole);
             state.isAuthenticated = true;
             state.refreshStatus = "success";
           }


### PR DESCRIPTION
## 관련 이슈

- resolves: 없음

## 작업 내용

- 인증 스토어 역할을 `serverRole`(권한 판정용)과 `clientRole`(UI 뷰 판정용)로 분리했습니다.
- admin 사용자는 하단 좌측 플로팅 버튼에서만 다음 기능을 사용하도록 변경했습니다.
  - 인스펙터 켜기/끄기
  - 멘토 UI 보기 / 멘티 UI 보기 전환
- 마이페이지, 매칭 페이지, 멘토 페이지 상단에 노출되던 기존 멘토/멘티 전환 버튼 UI를 제거했습니다.
- 화면 렌더링은 `clientRole` 기준으로, admin 여부/플로팅 버튼 노출은 `serverRole` 기준으로 동작하도록 분리했습니다.
- 멘토 알림 카운트 컴포넌트는 실제 권한(`serverRole`) 기준으로 유지하고, 카드 확장 읽음 처리 분기는 UI 역할(`clientRole`) 기준으로 맞췄습니다.

## 특이 사항

- `setAccessToken`/rehydrate 시 admin의 `clientRole`은 기존 선택값을 유지하고, 최초에는 멘토 뷰를 기본값으로 설정했습니다.
- 로그아웃/토큰 만료 시에는 `serverRole`/`clientRole`을 함께 초기화합니다.

## 리뷰 요구사항 (선택)

- admin 계정에서 `멘티 UI 보기`로 전환해도 좌하단 플로팅 버튼(관리 메뉴)이 계속 노출되는지 확인 부탁드립니다.
- 마이페이지(`/my`), 매칭(`/my/match`), 멘토(`/mentor`)에서 기존 상단 토글이 완전히 제거되었는지 확인 부탁드립니다.
