### PR TITLE
feat(home): 홈 푸터에 사업자 정보 추가

### DIFF
--- a/apps/web/src/app/(home)/_ui/SiteFooter/index.tsx
+++ b/apps/web/src/app/(home)/_ui/SiteFooter/index.tsx
@@ -1,0 +1,25 @@
+const BUSINESS_INFO = [
+  { label: "상호", value: "바삭크리스피" },
+  { label: "대표", value: "박위백" },
+  { label: "사업자등록번호", value: "671-38-01352" },
+  { label: "주소", value: "인천광역시 미추홀구 인하로 100, 인하드림센터동 2층 213A호" },
+] as const;
+
+const SiteFooter = () => {
+  return (
+    <footer className="mt-6 border-t-[5px] border-k-50 bg-background-2 px-5 py-6">
+      <p className="mb-2 font-serif text-k-600 typo-sb-11">사업자 정보</p>
+      <ul className="space-y-1">
+        {BUSINESS_INFO.map(({ label, value }) => (
+          <li key={label} className="flex gap-2 text-k-500 typo-regular-5">
+            <span className="w-20 shrink-0 text-k-400">{label}</span>
+            <span className="flex-1 text-k-600">{value}</span>
+          </li>
+        ))}
+      </ul>
+      <p className="mt-4 text-k-400 typo-regular-6">© {new Date().getFullYear()} 솔리드커넥션. All rights reserved.</p>
+    </footer>
+  );
+};
+
+export default SiteFooter;

--- a/apps/web/src/app/(home)/_ui/SiteFooter/index.tsx
+++ b/apps/web/src/app/(home)/_ui/SiteFooter/index.tsx
@@ -1,21 +1,24 @@
-const BUSINESS_INFO = [
-  { label: "상호", value: "바삭크리스피" },
-  { label: "대표", value: "박위백" },
-  { label: "사업자등록번호", value: "671-38-01352" },
-  { label: "주소", value: "인천광역시 미추홀구 인하로 100, 인하드림센터동 2층 213A호" },
-] as const;
-
 const SiteFooter = () => {
   return (
     <footer className="mt-6 border-t-[5px] border-k-50 bg-background-2 px-5 py-6">
       <p className="mb-2 font-serif text-k-600 typo-sb-11">사업자 정보</p>
       <ul className="space-y-1">
-        {BUSINESS_INFO.map(({ label, value }) => (
-          <li key={label} className="flex gap-2 text-k-500 typo-regular-5">
-            <span className="w-20 shrink-0 text-k-400">{label}</span>
-            <span className="flex-1 text-k-600">{value}</span>
-          </li>
-        ))}
+        <li className="flex gap-2 typo-regular-5">
+          <span className="w-20 shrink-0 text-k-400">상호</span>
+          <span className="flex-1 text-k-600">바삭크리스피</span>
+        </li>
+        <li className="flex gap-2 typo-regular-5">
+          <span className="w-20 shrink-0 text-k-400">대표</span>
+          <span className="flex-1 text-k-600">박위백</span>
+        </li>
+        <li className="flex gap-2 typo-regular-5">
+          <span className="w-20 shrink-0 text-k-400">사업자등록번호</span>
+          <span className="flex-1 text-k-600">671-38-01352</span>
+        </li>
+        <li className="flex gap-2 typo-regular-5">
+          <span className="w-20 shrink-0 text-k-400">주소</span>
+          <span className="flex-1 text-k-600">인천광역시 미추홀구 인하로 100, 인하드림센터동 2층 213A호</span>
+        </li>
       </ul>
       <p className="mt-4 text-k-400 typo-regular-6">© {new Date().getFullYear()} 솔리드커넥션. All rights reserved.</p>
     </footer>

--- a/apps/web/src/app/(home)/page.tsx
+++ b/apps/web/src/app/(home)/page.tsx
@@ -8,6 +8,7 @@ import { RegionEnumExtend } from "@/types/university";
 import FindLastYearScoreBar from "./_ui/FindLastYearScoreBar";
 import NewsSectionSkeleton from "./_ui/NewsSection/skeleton";
 import PopularUniversitySection from "./_ui/PopularUniversitySection";
+import SiteFooter from "./_ui/SiteFooter";
 import UniversityList from "./_ui/UniversityList";
 
 const NewsSectionDynamic = dynamic(() => import("./_ui/NewsSection"), {
@@ -149,6 +150,8 @@ const HomePage = async () => {
         </div>
 
         <NewsSectionDynamic newsList={newsList} />
+
+        <SiteFooter />
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- 홈 화면 하단에 사업자 정보를 노출하는 `SiteFooter` 컴포넌트를 추가했습니다.
- 사용자에게 상호, 대표자, 사업자등록번호, 주소, 저작권 정보를 한곳에서 확인할 수 있도록 구성했습니다.

## 변경 사항
- `apps/web/src/app/(home)/_ui/SiteFooter/index.tsx` 추가
- 홈 페이지 하단에 `SiteFooter`를 렌더링하도록 연결
- 현재 연도를 기준으로 저작권 문구가 표시되도록 구현

## Testing
- Not run (not requested)

## 노트
- 푸터는 홈 화면에만 적용됩니다.