### PR TITLE
feat(web): 멘토 수정 플로팅 버튼 및 합격 레시피 노출

### DIFF
--- a/apps/web/src/app/mentor/modify/_ui/ModifyContent/index.tsx
+++ b/apps/web/src/app/mentor/modify/_ui/ModifyContent/index.tsx
@@ -54,7 +54,7 @@ const ModifyContent = () => {
               </div>
             </div>
           </div>
-          <div className="mt-10">
+          <div className="mt-10 pb-36">
             <h2 className="mb-2.5 text-primary-1 typo-sb-5">내 채널 관리</h2>
             <ChannelBox channels={channels} />
             {/* 4개의 고정된 채널 입력 필드 */}
@@ -96,8 +96,11 @@ const ModifyContent = () => {
             <div className="mb-6">
               <AddArticleCard />
             </div>
-            <div className="mt-20 flex justify-center">
-              <button type="submit" className="mb-10 h-10 w-37.5 rounded-3xl bg-primary-1 px-5 py-2.5 text-k-0">
+          </div>
+
+          <div className="pointer-events-none fixed bottom-20 left-1/2 z-20 flex w-full -translate-x-1/2 justify-center">
+            <div className="pointer-events-auto px-5">
+              <button type="submit" className="h-10 w-37.5 rounded-3xl bg-primary-1 px-5 py-2.5 text-k-0">
                 수정하기
               </button>
             </div>

--- a/apps/web/src/components/mentor/MentorCard/index.tsx
+++ b/apps/web/src/components/mentor/MentorCard/index.tsx
@@ -28,6 +28,7 @@ const MentorCard = ({ mentor, observeRef, isMine = false }: MentorCardProps) => 
     nickname,
     universityName,
     introduction,
+    passTip,
     channels,
     term,
     id,
@@ -67,6 +68,14 @@ const MentorCard = ({ mentor, observeRef, isMine = false }: MentorCardProps) => 
             <h4 className="mb-2 text-blue-600 typo-medium-5">멘토 한마디</h4>
             <p className="text-k-500 typo-regular-2">{introduction}</p>
           </div>
+
+          {/* 합격 레시피 */}
+          {isDetail && (
+            <div className="mb-4">
+              <h4 className="mb-2 text-blue-600 typo-medium-5">합격 레시피</h4>
+              <p className="text-k-500 typo-regular-2">{passTip || "정보가 없습니다."}</p>
+            </div>
+          )}
 
           {/* 멘토 채널 */}
           <div className="mb-4">


### PR DESCRIPTION
## 관련 이슈

- resolves: 없음

## 작업 내용

- 멘토 프로필 수정 페이지(`/mentor/modify`)의 `수정하기` 버튼을 하단 플로팅 버튼으로 변경했습니다.
- 플로팅 버튼에 콘텐츠가 가려지지 않도록 수정 폼 본문 하단 여백(`pb-36`)을 추가했습니다.
- 나의 멘토 페이지 카드 확장 UI에서 누락되던 `합격 레시피` 데이터를 기존 섹션 디자인과 동일한 스타일로 추가 노출했습니다.
- `합격 레시피` 값이 비어있는 경우 `정보가 없습니다.` 문구를 표시하도록 처리했습니다.

## 특이 사항

- 기존 버튼의 시각 스타일(색상/라운드/텍스트)은 유지한 채 위치만 플로팅 형태로 이동했습니다.

## 리뷰 요구사항 (선택)

- 멘토 프로필 수정 화면에서 스크롤 시에도 `수정하기` 버튼이 하단에 고정 노출되는지 확인 부탁드립니다.
- 나의 멘토 페이지에서 카드 펼침 시 `멘토 한마디` 아래 `합격 레시피`가 정상 노출되는지 확인 부탁드립니다.
