### PR TITLE
fix(web): add robots/sitemap metadata and bypass middleware

### DIFF
--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,0 +1,34 @@
+import type { MetadataRoute } from "next";
+
+const DEFAULT_SITE_URL = "https://www.solid-connection.com";
+
+const getSiteUrl = () => (process.env.NEXT_PUBLIC_WEB_URL ?? DEFAULT_SITE_URL).replace(/\/$/, "");
+
+export default function robots(): MetadataRoute.Robots {
+  const siteUrl = getSiteUrl();
+  const vercelEnv = process.env.VERCEL_ENV;
+  const isNonIndexEnvironment =
+    vercelEnv === "preview" ||
+    vercelEnv === "development" ||
+    siteUrl.includes("stage") ||
+    siteUrl.includes("localhost") ||
+    siteUrl.includes("127.0.0.1");
+
+  if (isNonIndexEnvironment) {
+    return {
+      rules: {
+        userAgent: "*",
+        disallow: "/",
+      },
+    };
+  }
+
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+    host: new URL(siteUrl).host,
+  };
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,0 +1,42 @@
+import type { MetadataRoute } from "next";
+
+const DEFAULT_SITE_URL = "https://www.solid-connection.com";
+
+const getSiteUrl = () => (process.env.NEXT_PUBLIC_WEB_URL ?? DEFAULT_SITE_URL).replace(/\/$/, "");
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const siteUrl = getSiteUrl();
+
+  if (siteUrl.includes("stage") || siteUrl.includes("localhost") || siteUrl.includes("127.0.0.1")) {
+    return [];
+  }
+
+  const lastModified = new Date();
+
+  return [
+    {
+      url: `${siteUrl}/`,
+      lastModified,
+      changeFrequency: "daily",
+      priority: 1,
+    },
+    {
+      url: `${siteUrl}/mentor`,
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 0.8,
+    },
+    {
+      url: `${siteUrl}/university`,
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 0.8,
+    },
+    {
+      url: `${siteUrl}/terms`,
+      lastModified,
+      changeFrequency: "yearly",
+      priority: 0.5,
+    },
+  ];
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -105,6 +105,6 @@ export function middleware(request: NextRequest) {
 }
 export const config = {
   matcher: [
-    "/((?!api|_next/static|_next/image|static/chunks|images|assets|favicon.ico|sw.js|viewer|fonts|.*\\.splat).*)",
+    "/((?!api|_next/static|_next/image|static/chunks|images|assets|favicon.ico|robots.txt|sitemap.xml|sw.js|viewer|fonts|.*\\.splat).*)",
   ],
 };


### PR DESCRIPTION
## 배경 / 원인
- Search Console에서 `robots.txt에 의해 차단됨` 경고가 발생
- 점검 시점 기준, production(`www.solid-connection.com`)에서 아래가 404 응답이었음
  - `/robots.txt`
  - `/sitemap.xml`
- 또한 middleware matcher가 해당 경로를 명시적으로 제외하지 않아, 향후 인증/리다이렉트 로직 영향 가능성이 있었음

## 변경 사항
- `apps/web/src/app/robots.ts` 추가
  - 환경별 crawler 정책 명시
  - production: `Allow: /` + `Sitemap` 노출
  - stage/preview/local: `Disallow: /`
- `apps/web/src/app/sitemap.ts` 추가
  - production URL 목록 제공
  - stage/local은 빈 sitemap 반환
- `apps/web/src/middleware.ts`
  - matcher 예외에 `robots.txt`, `sitemap.xml` 추가

## 기대 효과
- robots/sitemap 엔드포인트가 명시적으로 제공되어 크롤러 동작이 예측 가능해짐
- middleware/auth 로직과 크롤러 메타 파일 경로 분리
- GSC 경고 재검증(Validate Fix) 가능한 상태로 정리

## 검증
- `pnpm --filter web exec tsc -p tsconfig.json --noEmit`
- pre-push CI parity hook 통과
  - `lint`
  - `typecheck`
  - `next build`

## 배포 후 확인 포인트
- `https://www.solid-connection.com/robots.txt` -> `200` + `Allow: /`
- `https://www.solid-connection.com/sitemap.xml` -> `200`
- Search Console에서 `Validate Fix` 실행
