### PR TITLE
fix(web): 채팅 이미지 업로드 경로를 /file/chat/post로 수정

### DIFF
--- a/apps/web/src/apis/image-upload/api.ts
+++ b/apps/web/src/apis/image-upload/api.ts
@@ -44,12 +44,12 @@ export const imageUploadApi = {
   },
 
   /**
-   * 프로필 이미지 업로드 (로그인 후)
+   * 채팅 이미지 업로드 (로그인 후)
    */
   postUploadProfileImage: async (file: File): Promise<UploadProfileImageResponse> => {
     const formData = new FormData();
     formData.append("file", file);
-    const res = await axiosInstance.post<UploadProfileImageResponse>(`/file/profile/post`, formData, {
+    const res = await axiosInstance.post<UploadProfileImageResponse>(`/file/chat/post`, formData, {
       headers: { "Content-Type": "multipart/form-data" },
     });
     return res.data;


### PR DESCRIPTION
## 변경 배경
채팅 이미지 업로드가 `/file/profile/post`로 전송되고 있어 서버 최신 브루노 스펙과 불일치했습니다.

## 변경 내용
- `apps/web/src/apis/image-upload/api.ts`
- 로그인 후 채팅 이미지 업로드 엔드포인트 변경
  - 이전: `/file/profile/post`
  - 변경: `/file/chat/post`
- 응답 타입(`fileUrl`) 및 multipart/form-data 처리 로직은 유지

## 영향 범위
- 멘토 채팅 이미지 업로드 경로 교정
- 회원가입 전 프로필 업로드(`/file/profile/pre`) 및 기타 업로드 API는 변경 없음

## 검증
- `pnpm --filter @solid-connect/web run lint:check`
- `pnpm --filter @solid-connect/web run typecheck:ci`
- `pnpm --filter @solid-connect/web run build`

## 체크 포인트
- 채팅방 이미지 업로드 요청 URL이 `/file/chat/post`로 호출되는지 네트워크 탭에서 확인 부탁드립니다.