### PR TITLE
fix(web,admin): 이미지 URL을 upload CDN으로 통일

### DIFF
--- a/apps/admin/src/components/features/scores/GpaScoreTable.tsx
+++ b/apps/admin/src/components/features/scores/GpaScoreTable.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { scoreApi } from "@/lib/api/scores";
+import { normalizeImageUrlToUploadCdn } from "@/lib/utils/cdnUrl";
 import type { GpaScoreWithUser, VerifyStatus } from "@/types/scores";
 import { ScoreVerifyButton } from "./ScoreVerifyButton";
 import { StatusBadge } from "./StatusBadge";
@@ -12,8 +13,6 @@ import { StatusBadge } from "./StatusBadge";
 interface Props {
 	verifyFilter: VerifyStatus;
 }
-
-const S3_BASE_URL = (import.meta.env.VITE_S3_BASE_URL as string | undefined) || "";
 
 export function GpaScoreTable({ verifyFilter }: Props) {
 	const queryClient = useQueryClient();
@@ -142,7 +141,7 @@ export function GpaScoreTable({ verifyFilter }: Props) {
 									<TableCell>
 										<div className="flex items-center">
 											<img
-												src={score.siteUserResponse.profileImageUrl}
+												src={normalizeImageUrlToUploadCdn(score.siteUserResponse.profileImageUrl)}
 												alt="프로필"
 												className="mr-2 h-8 w-8 rounded-full border border-k-100"
 											/>
@@ -197,7 +196,7 @@ export function GpaScoreTable({ verifyFilter }: Props) {
 									<TableCell>{score.gpaScoreStatusResponse.rejectedReason || "-"}</TableCell>
 									<TableCell>
 										<a
-											href={`${S3_BASE_URL}${score.gpaScoreStatusResponse.gpaResponse.gpaReportUrl}`}
+											href={normalizeImageUrlToUploadCdn(score.gpaScoreStatusResponse.gpaResponse.gpaReportUrl)}
 											target="_blank"
 											rel="noopener noreferrer"
 											className="typo-medium-4 text-primary hover:text-primary-700 hover:underline"

--- a/apps/admin/src/components/features/scores/LanguageScoreTable.tsx
+++ b/apps/admin/src/components/features/scores/LanguageScoreTable.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { scoreApi } from "@/lib/api/scores";
+import { normalizeImageUrlToUploadCdn } from "@/lib/utils/cdnUrl";
 import type { LanguageScoreWithUser, LanguageTestType, VerifyStatus } from "@/types/scores";
 import { ScoreVerifyButton } from "./ScoreVerifyButton";
 import { StatusBadge } from "./StatusBadge";
@@ -12,8 +13,6 @@ import { StatusBadge } from "./StatusBadge";
 interface Props {
 	verifyFilter: VerifyStatus;
 }
-
-const S3_BASE_URL = (import.meta.env.VITE_S3_BASE_URL as string | undefined) || "";
 
 const LANGUAGE_TEST_OPTIONS: { value: LanguageTestType; label: string }[] = [
 	{ value: "TOEIC", label: "TOEIC" },
@@ -157,7 +156,7 @@ export function LanguageScoreTable({ verifyFilter }: Props) {
 									<TableCell>
 										<div className="flex items-center">
 											<img
-												src={score.siteUserResponse.profileImageUrl}
+												src={normalizeImageUrlToUploadCdn(score.siteUserResponse.profileImageUrl)}
 												alt="프로필"
 												className="mr-2 h-8 w-8 rounded-full border border-k-100"
 											/>
@@ -220,7 +219,9 @@ export function LanguageScoreTable({ verifyFilter }: Props) {
 									<TableCell>{score.languageTestScoreStatusResponse.rejectedReason || "-"}</TableCell>
 									<TableCell>
 										<a
-											href={`${S3_BASE_URL}${score.languageTestScoreStatusResponse.languageTestResponse.languageTestReportUrl}`}
+											href={normalizeImageUrlToUploadCdn(
+												score.languageTestScoreStatusResponse.languageTestResponse.languageTestReportUrl,
+											)}
 											target="_blank"
 											rel="noopener noreferrer"
 											className="typo-medium-4 text-primary hover:text-primary-700 hover:underline"

--- a/apps/admin/src/lib/utils/cdnUrl.ts
+++ b/apps/admin/src/lib/utils/cdnUrl.ts
@@ -1,0 +1,109 @@
+const UPLOAD_CDN_ORIGIN = "https://cdn.upload.solid-connection.com";
+const UPLOAD_CDN_HOSTNAME = "cdn.upload.solid-connection.com";
+const DEFAULT_CDN_HOSTNAME = "cdn.default.solid-connection.com";
+const LEGACY_BUCKET_NAME = "solid-connection";
+
+const s3PathStyleHostRegex = /^s3([.-][a-z0-9-]+)?\.amazonaws\.com$/i;
+const legacyS3VirtualHostRegex = new RegExp(
+	`^${LEGACY_BUCKET_NAME.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&")}\\.s3([.-][a-z0-9-]+)?\\.amazonaws\\.com$`,
+	"i",
+);
+
+const normalizeOrigin = (value: string | undefined) => {
+	if (!value) return undefined;
+	const trimmed = value.trim();
+	if (!trimmed) return undefined;
+
+	try {
+		const parsed = new URL(trimmed);
+		return `${parsed.protocol}//${parsed.host}`.replace(/\/+$/, "");
+	} catch {
+		return undefined;
+	}
+};
+
+const getHostname = (value: string | undefined) => {
+	if (!value) return undefined;
+
+	try {
+		return new URL(value).hostname.toLowerCase();
+	} catch {
+		return undefined;
+	}
+};
+
+const runtimeEnv = (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env;
+const envUploadOrigin = normalizeOrigin(runtimeEnv?.VITE_UPLOADED_IMAGE_URL);
+const envS3BaseOrigin = normalizeOrigin(runtimeEnv?.VITE_S3_BASE_URL);
+const uploadOrigin = envUploadOrigin ?? UPLOAD_CDN_ORIGIN;
+
+const cdnHostnames = new Set(
+	[UPLOAD_CDN_HOSTNAME, DEFAULT_CDN_HOSTNAME, getHostname(envUploadOrigin), getHostname(envS3BaseOrigin)].filter(
+		(hostname): hostname is string => Boolean(hostname),
+	),
+);
+
+const joinUploadOrigin = (path: string, search = "", hash = "") => {
+	const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+	return `${uploadOrigin}${normalizedPath}${search}${hash}`;
+};
+
+const getLegacyS3ObjectPath = (pathname: string) => {
+	const prefix = `/${LEGACY_BUCKET_NAME}/`;
+	if (pathname.startsWith(prefix)) {
+		return pathname.slice(prefix.length - 1);
+	}
+
+	if (pathname === `/${LEGACY_BUCKET_NAME}`) {
+		return "/";
+	}
+
+	return null;
+};
+
+const isHttpUrl = (value: string) => value.startsWith("http://") || value.startsWith("https://");
+
+export const normalizeImageUrlToUploadCdn = (url: string | null | undefined): string => {
+	if (!url) return "";
+
+	const trimmed = url.trim();
+	if (!trimmed) return "";
+
+	if (trimmed.startsWith("blob:") || trimmed.startsWith("data:") || trimmed.startsWith("/")) {
+		return trimmed;
+	}
+
+	if (trimmed.startsWith("//")) {
+		return normalizeImageUrlToUploadCdn(`https:${trimmed}`);
+	}
+
+	if (!isHttpUrl(trimmed)) {
+		return joinUploadOrigin(trimmed.replace(/^\/+/, ""));
+	}
+
+	let parsed: URL;
+	try {
+		parsed = new URL(trimmed);
+	} catch {
+		return trimmed;
+	}
+
+	const hostname = parsed.hostname.toLowerCase();
+
+	if (cdnHostnames.has(hostname)) {
+		return joinUploadOrigin(parsed.pathname, parsed.search, parsed.hash);
+	}
+
+	if (legacyS3VirtualHostRegex.test(hostname)) {
+		return joinUploadOrigin(parsed.pathname, parsed.search, parsed.hash);
+	}
+
+	if (s3PathStyleHostRegex.test(hostname)) {
+		const objectPath = getLegacyS3ObjectPath(parsed.pathname);
+		if (objectPath) {
+			return joinUploadOrigin(objectPath, parsed.search, parsed.hash);
+		}
+	}
+
+	return trimmed;
+};

--- a/apps/web/src/components/ui/FallbackImage.tsx
+++ b/apps/web/src/components/ui/FallbackImage.tsx
@@ -2,31 +2,33 @@
 
 import NextImage from "next/image";
 import { useState } from "react";
+import { getUploadCdnOrigin, normalizeImageUrlToUploadCdn } from "@/utils/cdnUrl";
 
 const DEFAULT_FALLBACK_SRC = "/svgs/placeholders/image-placeholder.svg";
-const DEFAULT_CDN_HOST = "https://cdn.default.solid-connection.com";
-const UPLOAD_CDN_HOST = "https://cdn.upload.solid-connection.com";
 
 type CdnHostType = "default" | "upload";
 
 const CDN_HOSTS: Record<CdnHostType, string> = {
-  default: process.env.NEXT_PUBLIC_IMAGE_URL || DEFAULT_CDN_HOST,
-  upload: process.env.NEXT_PUBLIC_UPLOADED_IMAGE_URL || UPLOAD_CDN_HOST,
+  default: getUploadCdnOrigin(),
+  upload: getUploadCdnOrigin(),
 };
 
 const resolveCdnUrl = (src: string, cdnHostType?: CdnHostType) => {
   const trimmedSrc = src.trim();
 
   if (trimmedSrc.length === 0) return "";
-  if (trimmedSrc.startsWith("http://") || trimmedSrc.startsWith("https://")) return trimmedSrc;
+  if (trimmedSrc.startsWith("http://") || trimmedSrc.startsWith("https://")) {
+    return normalizeImageUrlToUploadCdn(trimmedSrc);
+  }
   if (trimmedSrc.startsWith("blob:") || trimmedSrc.startsWith("data:")) return trimmedSrc;
-  if (trimmedSrc.startsWith("//")) return `https:${trimmedSrc}`;
-  if (!cdnHostType) return trimmedSrc;
+  if (trimmedSrc.startsWith("//")) return normalizeImageUrlToUploadCdn(`https:${trimmedSrc}`);
+  if (trimmedSrc.startsWith("/")) return trimmedSrc;
+  if (!cdnHostType) return normalizeImageUrlToUploadCdn(trimmedSrc);
 
   const normalizedHost = CDN_HOSTS[cdnHostType].replace(/\/+$/, "");
   const normalizedPath = trimmedSrc.replace(/^\/+/, "");
 
-  return `${normalizedHost}/${normalizedPath}`;
+  return normalizeImageUrlToUploadCdn(`${normalizedHost}/${normalizedPath}`);
 };
 
 type FallbackImageProps = React.ComponentProps<typeof NextImage> & {

--- a/apps/web/src/utils/cdnUrl.ts
+++ b/apps/web/src/utils/cdnUrl.ts
@@ -1,0 +1,132 @@
+const UPLOAD_CDN_ORIGIN = "https://cdn.upload.solid-connection.com";
+const UPLOAD_CDN_HOSTNAME = "cdn.upload.solid-connection.com";
+const DEFAULT_CDN_HOSTNAME = "cdn.default.solid-connection.com";
+const LEGACY_BUCKET_NAME = "solid-connection";
+
+const LOCAL_STATIC_PREFIXES = ["/images/", "/svgs/"];
+
+const isHttpUrl = (value: string) => value.startsWith("http://") || value.startsWith("https://");
+
+const normalizeOrigin = (value: string | undefined) => {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  try {
+    const parsed = new URL(trimmed);
+    return `${parsed.protocol}//${parsed.host}`.replace(/\/+$/, "");
+  } catch {
+    return undefined;
+  }
+};
+
+const getHostname = (value: string | undefined) => {
+  if (!value) return undefined;
+
+  try {
+    return new URL(value).hostname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+};
+
+const envUploadOrigin = normalizeOrigin(process.env.NEXT_PUBLIC_UPLOADED_IMAGE_URL);
+const envDefaultOrigin = normalizeOrigin(process.env.NEXT_PUBLIC_IMAGE_URL);
+
+const uploadOrigin = envUploadOrigin ?? UPLOAD_CDN_ORIGIN;
+
+const cdnHostnames = new Set(
+  [UPLOAD_CDN_HOSTNAME, DEFAULT_CDN_HOSTNAME, getHostname(envUploadOrigin), getHostname(envDefaultOrigin)].filter(
+    (hostname): hostname is string => Boolean(hostname),
+  ),
+);
+
+const legacyS3VirtualHostRegex = new RegExp(
+  `^${LEGACY_BUCKET_NAME.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&")}\\.s3([.-][a-z0-9-]+)?\\.amazonaws\\.com$`,
+  "i",
+);
+
+const s3PathStyleHostRegex = /^s3([.-][a-z0-9-]+)?\.amazonaws\.com$/i;
+
+const joinUploadOrigin = (path: string, search = "", hash = "") => {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${uploadOrigin}${normalizedPath}${search}${hash}`;
+};
+
+const getLegacyS3ObjectPath = (pathname: string) => {
+  const prefix = `/${LEGACY_BUCKET_NAME}/`;
+  if (pathname.startsWith(prefix)) {
+    return pathname.slice(prefix.length - 1);
+  }
+
+  if (pathname === `/${LEGACY_BUCKET_NAME}`) {
+    return "/";
+  }
+
+  return null;
+};
+
+const shouldKeepAsLocalStaticPath = (value: string) => {
+  return LOCAL_STATIC_PREFIXES.some((prefix) => value.startsWith(prefix));
+};
+
+/**
+ * 이미지 URL을 upload CDN 기준으로 정규화한다.
+ * - 상대 경로(key)는 upload CDN으로 변환
+ * - legacy default CDN/S3 URL은 upload CDN으로 변환
+ * - 로컬 정적 경로(/images, /svgs), blob/data, 외부 도메인은 유지
+ */
+export const normalizeImageUrlToUploadCdn = (url: string | null | undefined): string => {
+  if (!url) return "";
+
+  const trimmed = url.trim();
+  if (!trimmed) return "";
+
+  if (trimmed.startsWith("blob:") || trimmed.startsWith("data:")) {
+    return trimmed;
+  }
+
+  if (trimmed.startsWith("//")) {
+    return normalizeImageUrlToUploadCdn(`https:${trimmed}`);
+  }
+
+  if (trimmed.startsWith("/")) {
+    if (shouldKeepAsLocalStaticPath(trimmed)) {
+      return trimmed;
+    }
+
+    return trimmed;
+  }
+
+  if (!isHttpUrl(trimmed)) {
+    return joinUploadOrigin(trimmed.replace(/^\/+/, ""));
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return trimmed;
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+
+  if (cdnHostnames.has(hostname)) {
+    return joinUploadOrigin(parsed.pathname, parsed.search, parsed.hash);
+  }
+
+  if (legacyS3VirtualHostRegex.test(hostname)) {
+    return joinUploadOrigin(parsed.pathname, parsed.search, parsed.hash);
+  }
+
+  if (s3PathStyleHostRegex.test(hostname)) {
+    const objectPath = getLegacyS3ObjectPath(parsed.pathname);
+    if (objectPath) {
+      return joinUploadOrigin(objectPath, parsed.search, parsed.hash);
+    }
+  }
+
+  return trimmed;
+};
+
+export const getUploadCdnOrigin = () => uploadOrigin;

--- a/apps/web/src/utils/fileUtils.ts
+++ b/apps/web/src/utils/fileUtils.ts
@@ -1,3 +1,5 @@
+import { normalizeImageUrlToUploadCdn } from "@/utils/cdnUrl";
+
 // 파일명에서 확장자 추출
 export const getFileExtension = (url: string) => {
   return url.split(".").pop()?.toUpperCase() || "FILE";
@@ -57,24 +59,10 @@ export const downloadLocalFile = (file: File, fileName?: string) => {
   URL.revokeObjectURL(blobUrl);
 };
 
-const NEXT_PUBLIC_UPLOADED_IMAGE_URL = process.env.NEXT_PUBLIC_UPLOADED_IMAGE_URL;
-const NEXT_PUBLIC_IMAGE_URL = process.env.NEXT_PUBLIC_IMAGE_URL;
-
 export const convertUploadedImageUrl = (url: string | null | undefined): string => {
-  if (!url) return "";
-  if (url.startsWith("http") || url.startsWith("blob")) return url;
-  if (!NEXT_PUBLIC_UPLOADED_IMAGE_URL) {
-    return url;
-  }
-  return `${NEXT_PUBLIC_UPLOADED_IMAGE_URL}/${url}`;
+  return normalizeImageUrlToUploadCdn(url);
 };
 
 export const convertImageUrl = (url: string | null | undefined): string => {
-  if (!url) return "";
-  if (url.startsWith("https://img.example")) return `${NEXT_PUBLIC_IMAGE_URL}/${url}`;
-  if (url.startsWith("http") || url.startsWith("blob")) return url;
-  if (!NEXT_PUBLIC_IMAGE_URL) {
-    return url;
-  }
-  return `${NEXT_PUBLIC_IMAGE_URL}/${url}`;
+  return normalizeImageUrlToUploadCdn(url);
 };


### PR DESCRIPTION
## 요약
- web/admin 이미지 URL 정규화 기준을 `cdn.upload.solid-connection.com`으로 통일했습니다.
- 로컬 정적 경로(`/images`, `/svgs`), `blob:`, `data:`, 외부 도메인 URL은 그대로 유지합니다.
- `FallbackImage`의 `cdnHostType` 인터페이스는 호환성을 유지하고, `default`는 내부적으로 upload alias로 동작합니다.

## 변경 사항
- web 공통 유틸 추가: `apps/web/src/utils/cdnUrl.ts`
- `convertUploadedImageUrl` / `convertImageUrl`를 공통 정규화 로직으로 통합
- `FallbackImage`가 원격 URL 및 상대 key를 upload CDN 기준으로 해석하도록 변경
- admin 공통 유틸 추가: `apps/admin/src/lib/utils/cdnUrl.ts`
- GPA/어학 점수 테이블에서 프로필 이미지 src와 인증파일 링크를 정규화 로직으로 통일

## URL 정규화 규칙
- upload CDN으로 변환:
  - `https://cdn.default.solid-connection.com/...`
  - `https://solid-connection.s3.ap-northeast-2.amazonaws.com/...`
  - `https://s3.ap-northeast-2.amazonaws.com/solid-connection/...`
  - `foo/bar.png` 같은 상대 key
- 그대로 유지:
  - `/images/...`, `/svgs/...`
  - `blob:*`, `data:*`
  - 외부 호스트 URL(카카오/지도 등)

## 검증
- `pnpm --filter web run lint:check`
- `pnpm --filter web run typecheck:ci`
- `pnpm --filter admin run lint:check`
- `pnpm --filter admin run typecheck:ci`
- `tsx` 기반 URL 변환 케이스 확인
