### PR TITLE
fix(web): 채팅 이미지 업로드 경로를 Bruno 명세(/file/chat)와 동기화

### DIFF
--- a/apps/web/src/apis/image-upload/api.ts
+++ b/apps/web/src/apis/image-upload/api.ts
@@ -14,6 +14,10 @@ export interface UploadProfileImageResponse {
   fileUrl: string;
 }
 
+export interface UploadChatImageResponse {
+  fileUrl: string;
+}
+
 export interface UploadGpaReportResponse {
   fileUrl: string;
 }
@@ -44,15 +48,30 @@ export const imageUploadApi = {
   },
 
   /**
-   * 채팅 이미지 업로드 (로그인 후)
+   * 프로필 이미지 업로드 (로그인 후)
    */
   postUploadProfileImage: async (file: File): Promise<UploadProfileImageResponse> => {
     const formData = new FormData();
     formData.append("file", file);
-    const res = await axiosInstance.post<UploadProfileImageResponse>(`/file/chat/post`, formData, {
+    const res = await axiosInstance.post<UploadProfileImageResponse>(`/file/profile/post`, formData, {
       headers: { "Content-Type": "multipart/form-data" },
     });
     return res.data;
+  },
+
+  /**
+   * 채팅 이미지 업로드 (로그인 후)
+   */
+  postUploadChatImages: async (files: File[]): Promise<string[]> => {
+    const formData = new FormData();
+    files.forEach((file) => {
+      formData.append("files", file);
+    });
+
+    const res = await axiosInstance.post<UploadChatImageResponse[]>(`/file/chat`, formData, {
+      headers: { "Content-Type": "multipart/form-data" },
+    });
+    return res.data.map((image) => image.fileUrl);
   },
 
   /**

--- a/apps/web/src/apis/image-upload/index.ts
+++ b/apps/web/src/apis/image-upload/index.ts
@@ -1,7 +1,13 @@
-export type { UploadGpaReportResponse, UploadLanguageTestReportResponse, UploadProfileImageResponse } from "./api";
+export type {
+  UploadChatImageResponse,
+  UploadGpaReportResponse,
+  UploadLanguageTestReportResponse,
+  UploadProfileImageResponse,
+} from "./api";
 export { imageUploadApi } from "./api";
 
 export { default as useSlackNotification } from "./postSlackNotification";
+export { default as useUploadChatImages } from "./postUploadChatImages";
 export { default as useUploadGpaReport } from "./postUploadGpaReport";
 export { default as useUploadLanguageTestReport } from "./postUploadLanguageTestReport";
 export { default as useUploadProfileImage } from "./postUploadProfileImage";

--- a/apps/web/src/apis/image-upload/postUploadChatImages.ts
+++ b/apps/web/src/apis/image-upload/postUploadChatImages.ts
@@ -1,0 +1,13 @@
+import { useMutation } from "@tanstack/react-query";
+import type { AxiosError } from "axios";
+import { SKIP_GLOBAL_ERROR_TOAST_META } from "@/lib/react-query/errorToastMeta";
+import { imageUploadApi } from "./api";
+
+const useUploadChatImages = () => {
+  return useMutation<string[], AxiosError, File[]>({
+    mutationFn: (files) => imageUploadApi.postUploadChatImages(files),
+    meta: SKIP_GLOBAL_ERROR_TOAST_META,
+  });
+};
+
+export default useUploadChatImages;

--- a/apps/web/src/app/mentor/chat/[chatId]/_ui/ChatContent/index.tsx
+++ b/apps/web/src/app/mentor/chat/[chatId]/_ui/ChatContent/index.tsx
@@ -4,7 +4,7 @@ import clsx from "clsx";
 import Link from "next/link";
 import { toast } from "react-hot-toast";
 import { useGetPartnerInfo } from "@/apis/chat";
-import { useUploadProfileImage } from "@/apis/image-upload";
+import { useUploadChatImages } from "@/apis/image-upload";
 import ProfileWithBadge from "@/components/ui/ProfileWithBadge";
 import useAuthStore from "@/lib/zustand/useAuthStore";
 import { ConnectionStatus } from "@/types/chat";
@@ -49,7 +49,7 @@ const ChatContent = ({ chatId }: ChatContentProps) => {
     addImageMessagePreview,
   } = useChatListHandler(chatId);
 
-  const uploadProfileImageMutation = useUploadProfileImage();
+  const uploadChatImagesMutation = useUploadChatImages();
 
   const { data: partnerInfo } = useGetPartnerInfo(chatId);
 
@@ -181,11 +181,7 @@ const ChatContent = ({ chatId }: ChatContentProps) => {
         }}
         onSendImages={async (data) => {
           try {
-            const uploadedImages = await Promise.all(
-              data.images.map((image) => uploadProfileImageMutation.mutateAsync(image)),
-            );
-
-            const imageUrls = uploadedImages.map((image) => image.fileUrl);
+            const imageUrls = await uploadChatImagesMutation.mutateAsync(data.images);
             const isSent = sendImageMessage(imageUrls);
 
             if (!isSent) {


### PR DESCRIPTION
## 작업 배경
- 채팅 이미지 업로드 요청이 `POST /file/chat/post`로 나가면서 백엔드에서 `No static resource file/chat/post` 오류가 발생했습니다.
- Bruno 명세(채팅 사진 업로드) 기준 경로는 `POST /file/chat`이며, multipart key는 `files`, 응답은 배열 형태입니다.

## 변경 내용
- 채팅 업로드 API를 프로필 업로드 API와 분리했습니다.
- `postUploadProfileImage`는 다시 `POST /file/profile/post`로 복원했습니다.
- 신규 `postUploadChatImages(files: File[])` 추가
  - 경로: `POST /file/chat`
  - multipart key: `files`
  - 배열 응답을 `string[]`(fileUrl 목록)로 정규화
- 신규 훅 `useUploadChatImages` 추가 및 export
- 채팅 화면에서 `useUploadProfileImage` 사용을 제거하고 `useUploadChatImages`로 교체
- 이미지 업로드를 `Promise.all` 단건 반복 호출에서 다건 1회 호출로 변경

## 검증
- `pnpm --filter @solid-connect/web run lint:check` 통과
- `pnpm --filter @solid-connect/web run typecheck:ci` 통과
- pre-push 훅의 `@solid-connect/web ci:check` + `next build` 통과
- 코드 검색 기준 `file/chat/post` 호출 0건 확인

## 기대 효과
- Bruno 명세와 실제 프론트 업로드 라우트가 일치합니다.
- 채팅 이미지 업로드 실패(`No static resource file/chat/post`)를 방지합니다.
