### PR TITLE
fix(web): 멘토찾기 lazy loading 제거

### DIFF
--- a/apps/web/src/app/mentor/_ui/MentorClient/index.tsx
+++ b/apps/web/src/app/mentor/_ui/MentorClient/index.tsx
@@ -1,16 +1,14 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { lazy, Suspense, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { postReissueToken } from "@/apis/Auth";
 import CloudSpinnerPage from "@/components/ui/CloudSpinnerPage";
 import useAuthStore from "@/lib/zustand/useAuthStore";
 import { UserRole } from "@/types/mentor";
 import { isTokenExpired } from "@/utils/jwtUtils";
-
-// 레이지 로드 컴포넌트
-const MenteePage = lazy(() => import("./_ui/MenteePage"));
-const MentorPage = lazy(() => import("./_ui/MentorPage"));
+import MenteePage from "./_ui/MenteePage";
+import MentorPage from "./_ui/MentorPage";
 
 const MentorClient = () => {
   const router = useRouter();
@@ -63,11 +61,7 @@ const MentorClient = () => {
     return <CloudSpinnerPage />;
   }
 
-  return (
-    <Suspense fallback={<CloudSpinnerPage />}>
-      {clientRole === UserRole.MENTOR ? <MentorPage /> : <MenteePage />}
-    </Suspense>
-  );
+  return clientRole === UserRole.MENTOR ? <MentorPage /> : <MenteePage />;
 };
 
 export default MentorClient;


### PR DESCRIPTION
## 변경 내용
- `/mentor`의 `MentorClient`에서 `lazy + Suspense` 제거
- `MenteePage`, `MentorPage`를 static import로 전환
- 렌더 분기 로직(멘토/멘티 판단) 유지

## 목적
- 멘토찾기 진입 시 발생하던 Suspense fallback 기반 로딩 깜빡임 제거

## 검증
- `pnpm --filter @solid-connect/web typecheck`
- `pnpm --filter @solid-connect/web lint:check`
- pre-push hook에서 `ci:check` + `next build` 통과
