### PR TITLE
fix(web): 비밀번호 변경 페이지 확인 버튼 overflow 수정

### DIFF
--- a/apps/web/src/app/my/password/_ui/PasswordContent/index.tsx
+++ b/apps/web/src/app/my/password/_ui/PasswordContent/index.tsx
@@ -106,33 +106,35 @@ const PasswordContent = () => {
           </>
         )}
 
-        <div className="fixed bottom-0 left-0 mb-20 w-full px-5 py-4">
-          {step === 0 && (
-            <button
-              type="button"
-              onClick={handleNextStep}
-              disabled={!isStep1ButtonEnabled}
-              className={clsx(
-                "w-full rounded-lg py-4 text-white transition-colors typo-sb-9",
-                isStep1ButtonEnabled ? "bg-primary-600 hover:bg-primary-700" : "cursor-not-allowed bg-gray-400",
-              )}
-            >
-              확인
-            </button>
-          )}
+        <div className="fixed bottom-0 left-0 right-0 mb-20 w-full py-4">
+          <div className="mx-auto w-full max-w-app px-5">
+            {step === 0 && (
+              <button
+                type="button"
+                onClick={handleNextStep}
+                disabled={!isStep1ButtonEnabled}
+                className={clsx(
+                  "w-full rounded-lg py-4 text-white transition-colors typo-sb-9",
+                  isStep1ButtonEnabled ? "bg-primary-600 hover:bg-primary-700" : "cursor-not-allowed bg-gray-400",
+                )}
+              >
+                확인
+              </button>
+            )}
 
-          {step === 1 && (
-            <button
-              type="submit"
-              disabled={!isStep2ButtonEnabled}
-              className={clsx(
-                "w-full rounded-lg py-4 text-white transition-colors typo-sb-9",
-                isStep2ButtonEnabled ? "bg-primary-600 hover:bg-primary-700" : "cursor-not-allowed bg-gray-400",
-              )}
-            >
-              변경하기
-            </button>
-          )}
+            {step === 1 && (
+              <button
+                type="submit"
+                disabled={!isStep2ButtonEnabled}
+                className={clsx(
+                  "w-full rounded-lg py-4 text-white transition-colors typo-sb-9",
+                  isStep2ButtonEnabled ? "bg-primary-600 hover:bg-primary-700" : "cursor-not-allowed bg-gray-400",
+                )}
+              >
+                변경하기
+              </button>
+            )}
+          </div>
         </div>
       </form>
     </FormProvider>


### PR DESCRIPTION
## 작업 내용
- `/my/password` 하단 고정 CTA 래퍼를 `fixed + left/right + w-full` 구조로 정리했습니다.
- 내부 컨테이너를 `mx-auto w-full max-w-app px-5`로 감싸서 버튼 폭이 앱 컨테이너를 넘지 않도록 수정했습니다.
- 버튼 활성/비활성, step 전환, 제출 로직은 변경하지 않았습니다.

## 확인
- pre-push 훅에서 `ci:check` 및 `next build` 통과
- 수정 파일: `apps/web/src/app/my/password/_ui/PasswordContent/index.tsx`
