### PR TITLE
feat(web): 멘토 회원전환 신청 플로우 연결

### DIFF
--- a/apps/web/src/apis/mentor/api.ts
+++ b/apps/web/src/apis/mentor/api.ts
@@ -5,6 +5,7 @@ import {
   MentoringApprovalStatus,
   type MentoringItem,
 } from "@/types/mentor";
+import type { CountryCode } from "@/types/university";
 import { axiosInstance } from "@/utils/axiosInstance";
 
 // QueryKeys for mentor domain
@@ -75,10 +76,11 @@ export interface PostApplyMentoringResponse {
 }
 
 export interface PostMentorApplicationRequest {
-  interestedCountries: string[];
-  country: string;
-  universityName: string;
-  studyStatus: "STUDYING" | "PLANNING" | "COMPLETED";
+  preparationStatus: "AFTER_EXCHANGE";
+  universitySelectType: "CATALOG";
+  country: CountryCode;
+  universityId: number;
+  term: string;
   verificationFile: File;
 }
 
@@ -127,17 +129,18 @@ export const mentorApi = {
   postMentorApplication: async (body: PostMentorApplicationRequest): Promise<void> => {
     const formData = new FormData();
     const applicationData = {
-      interestedCountries: body.interestedCountries,
+      preparationStatus: body.preparationStatus,
+      universitySelectType: body.universitySelectType,
       country: body.country,
-      universityName: body.universityName,
-      studyStatus: body.studyStatus,
+      universityId: body.universityId,
+      term: body.term,
     };
     formData.append(
       "mentorApplicationRequest",
       new Blob([JSON.stringify(applicationData)], { type: "application/json" }),
     );
     formData.append("file", body.verificationFile);
-    const res = await axiosInstance.post<void>("/mentor/verification", formData, {
+    const res = await axiosInstance.post<void>("/mentees/mentor-applications", formData, {
       headers: { "Content-Type": "multipart/form-data" },
     });
     return res.data;

--- a/apps/web/src/app/my/_ui/MyProfileContent/index.tsx
+++ b/apps/web/src/app/my/_ui/MyProfileContent/index.tsx
@@ -6,7 +6,6 @@ import { useDeleteUserAccount, usePostLogout } from "@/apis/Auth";
 import { type MyInfoResponse, useGetMyInfo } from "@/apis/MyPage";
 import LinkedTextWithIcon from "@/components/ui/LinkedTextWithIcon";
 import ProfileWithBadge from "@/components/ui/ProfileWithBadge";
-import { infoToastOptions } from "@/lib/toast/options";
 import useAuthStore from "@/lib/zustand/useAuthStore";
 import { IconLikeFill } from "@/public/svgs/mentor";
 import {
@@ -85,17 +84,12 @@ const MyProfileContent = () => {
             <div className="w-full cursor-pointer rounded-lg bg-secondary-500 py-2 text-center text-white typo-medium-2">
               <Link href={"/my/modify"}>프로필 변경</Link>
             </div>
-            {/* <Link className="w-full" href={"/my/apply-mentor"}>
-              <button className="w-full rounded-lg bg-secondary-800 py-2 typo-medium-2 text-white">멘토 회원 전환</button>
-            </Link> */}
-            <button
-              onClick={() => {
-                toast("조금만 기다려주세요. [업데이트 중]", infoToastOptions);
-              }}
-              className="w-full rounded-lg bg-secondary-800 py-2 text-white typo-medium-2"
+            <Link
+              href="/my/apply-mentor"
+              className="w-full rounded-lg bg-secondary-800 py-2 text-center text-white typo-medium-2"
             >
               멘토 회원 전환
-            </button>
+            </Link>
           </div>
         )}
       </div>

--- a/apps/web/src/app/my/apply-mentor/_components/CompletionScreen/index.tsx
+++ b/apps/web/src/app/my/apply-mentor/_components/CompletionScreen/index.tsx
@@ -20,25 +20,22 @@ const CompletionScreen = () => {
         </div>
 
         {/* 타이틀 */}
-        <h1 className="mb-4 text-center text-primary typo-bold-1">증명서 첨부 완료</h1>
+        <h1 className="mb-4 text-center text-primary typo-bold-1">멘토 전환 신청 완료</h1>
 
         {/* 설명 */}
         <p className="mb-12 text-center text-k-600 typo-regular-2">
-          승인은 최대 7일이 소요되며
+          관리자 검토가 완료되면
           <br />
-          마이페이지에서 확인할 수 있습니다.
+          멘토 회원으로 전환돼요.
         </p>
 
         {/* 버튼들 */}
         <div className="w-full max-w-sm space-y-3">
           <BlockBtn
-            onClick={() => router.push("/")}
+            onClick={() => router.push("/my")}
             className="hover:bg-primary-50 border border-primary bg-white text-primary"
           >
-            홈으로 이동하기
-          </BlockBtn>
-          <BlockBtn onClick={() => router.push("/mentor/modify")} className="bg-primary text-white">
-            멘토 프로필 작성하기
+            마이페이지로 이동하기
           </BlockBtn>
         </div>
       </div>

--- a/apps/web/src/app/my/apply-mentor/_components/InterestCountriesScreen/index.tsx
+++ b/apps/web/src/app/my/apply-mentor/_components/InterestCountriesScreen/index.tsx
@@ -6,11 +6,17 @@ import { useFormContext } from "react-hook-form";
 
 import BlockBtn from "@/components/button/BlockBtn";
 import { mentorRegionList } from "@/constants/regions";
-import type { MentorApplicationFormData } from "../../_lib/schema";
+import { COUNTRY_CODE_MAP } from "@/constants/university";
+import type { CountryCode } from "@/types/university";
+import type { MentorApplicationFormInputData } from "../../_lib/schema";
 
 type InterestCountriesScreenProps = {
   onNext: () => void;
 };
+
+const countryCodeByName = Object.fromEntries(
+  Object.entries(COUNTRY_CODE_MAP).map(([code, countryName]) => [countryName, code]),
+) as Record<string, CountryCode>;
 
 const InterestCountriesScreen = ({ onNext }: InterestCountriesScreenProps) => {
   const {
@@ -18,37 +24,31 @@ const InterestCountriesScreen = ({ onNext }: InterestCountriesScreenProps) => {
     setValue,
     trigger,
     formState: { errors },
-  } = useFormContext<MentorApplicationFormData>();
+  } = useFormContext<MentorApplicationFormInputData>();
 
   const [selectedRegion, setSelectedRegion] = useState<string>("미주권");
-  const selectedCountries = watch("interestedCountries") || [];
+  const selectedCountryCode = watch("country");
+
+  const selectedCountryName = selectedCountryCode ? COUNTRY_CODE_MAP[selectedCountryCode] : "";
 
   const handleNext = async () => {
-    const isValid = await trigger("interestedCountries");
+    const isValid = await trigger("country");
     if (isValid) {
       onNext();
     }
   };
 
-  const removeCountry = (country: string) => {
-    setValue(
-      "interestedCountries",
-      selectedCountries.filter((c) => c !== country),
-    );
-  };
+  const selectCountry = (country: string) => {
+    const countryCode = countryCodeByName[country];
+    if (!countryCode) return;
 
-  const toggleCountry = (country: string) => {
-    if (selectedCountries.includes(country)) {
-      setValue(
-        "interestedCountries",
-        selectedCountries.filter((c) => c !== country),
-      );
-    } else {
-      setValue("interestedCountries", [...selectedCountries, country]);
-    }
+    setValue("country", countryCode, { shouldValidate: true });
+    setValue("universityId", 0);
+    setValue("term", "");
   };
 
   const currentRegion = mentorRegionList.find((r) => r.name === selectedRegion);
+  const currentCountries = currentRegion?.countries.filter((country) => countryCodeByName[country]) ?? [];
 
   return (
     <div className="pb-28">
@@ -58,31 +58,30 @@ const InterestCountriesScreen = ({ onNext }: InterestCountriesScreenProps) => {
             나의
             <span className="text-primary"> 수학 국가</span>를
             <br />
-            선택해주세요
+            선택해주세요.
           </span>
         </div>
 
-        {/* Selected Countries Tags */}
-        {selectedCountries.length > 0 && (
+        {/* Selected Country Tag */}
+        {selectedCountryName && (
           <div className="mt-5 grid grid-cols-3 gap-3">
-            {selectedCountries.map((country) => (
-              <button
-                key={country}
-                className="relative h-10 rounded bg-primary-100 text-center text-k-800 typo-medium-2"
-                onClick={() => removeCountry(country)}
-                type="button"
-              >
-                {country}
-                <span className="absolute right-0 top-0 p-1 leading-none">✕</span>
-              </button>
-            ))}
+            <button
+              className="relative h-10 rounded bg-primary-100 text-center text-k-800 typo-medium-2"
+              onClick={() => {
+                setValue("country", "" as CountryCode, { shouldValidate: true });
+                setValue("universityId", 0);
+                setValue("term", "");
+              }}
+              type="button"
+            >
+              {selectedCountryName}
+              <span className="absolute right-0 top-0 p-1 leading-none">✕</span>
+            </button>
           </div>
         )}
 
         {/* Error Message */}
-        {errors.interestedCountries && (
-          <p className="mt-2 text-red-500 typo-regular-2">{errors.interestedCountries.message}</p>
-        )}
+        {errors.country && <p className="mt-2 text-red-500 typo-regular-2">{errors.country.message}</p>}
 
         {/* Region Tabs - Large Icon Buttons */}
         <div className="mt-10 grid grid-cols-3 gap-4">
@@ -114,14 +113,14 @@ const InterestCountriesScreen = ({ onNext }: InterestCountriesScreenProps) => {
 
         {/* Country Buttons - Only show current region's countries */}
         <div className="mt-8 grid grid-cols-3 gap-3">
-          {currentRegion?.countries.map((country) => (
+          {currentCountries.map((country) => (
             <button
               key={country}
               className={clsx("h-10 rounded border-none transition-colors typo-medium-2", {
-                "bg-k-50 text-k-600 hover:bg-k-100": !selectedCountries.includes(country),
-                "bg-primary-100 text-k-800": selectedCountries.includes(country),
+                "bg-k-50 text-k-600 hover:bg-k-100": selectedCountryName !== country,
+                "bg-primary-100 text-k-800": selectedCountryName === country,
               })}
-              onClick={() => toggleCountry(country)}
+              onClick={() => selectCountry(country)}
               type="button"
             >
               {country}
@@ -132,7 +131,7 @@ const InterestCountriesScreen = ({ onNext }: InterestCountriesScreenProps) => {
 
       <div className="fixed bottom-0 left-0 right-0 w-full bg-white pb-14">
         <div className="mx-auto w-full max-w-app px-5">
-          <BlockBtn className="mb-[29px]" disabled={selectedCountries.length === 0} onClick={handleNext}>
+          <BlockBtn className="mb-[29px]" disabled={!selectedCountryCode} onClick={handleNext}>
             다음
           </BlockBtn>
         </div>

--- a/apps/web/src/app/my/apply-mentor/_components/StudyStatusScreen/index.tsx
+++ b/apps/web/src/app/my/apply-mentor/_components/StudyStatusScreen/index.tsx
@@ -5,7 +5,7 @@ import { useFormContext } from "react-hook-form";
 
 import BlockBtn from "@/components/button/BlockBtn";
 import { IconPrepare1, IconPrepare2, IconPrepare3 } from "@/public/svgs/auth";
-import type { MentorApplicationFormData } from "../../_lib/schema";
+import type { MentorApplicationFormInputData } from "../../_lib/schema";
 
 type StudyStatusScreenProps = {
   onNext: () => void;
@@ -17,12 +17,12 @@ const StudyStatusScreen = ({ onNext }: StudyStatusScreenProps) => {
     setValue,
     trigger,
     formState: { errors },
-  } = useFormContext<MentorApplicationFormData>();
+  } = useFormContext<MentorApplicationFormInputData>();
 
-  const studyStatus = watch("studyStatus");
+  const preparationStatus = watch("preparationStatus");
 
   const handleNext = async () => {
-    const isValid = await trigger("studyStatus");
+    const isValid = await trigger("preparationStatus");
     if (isValid) {
       onNext();
     }
@@ -40,37 +40,40 @@ const StudyStatusScreen = ({ onNext }: StudyStatusScreenProps) => {
           </span>
         </div>
 
-        {errors.studyStatus && <p className="mt-2 text-red-500 typo-regular-2">{errors.studyStatus.message}</p>}
+        {errors.preparationStatus && (
+          <p className="mt-2 text-red-500 typo-regular-2">{errors.preparationStatus.message}</p>
+        )}
 
         <div className="mt-10">
           <div className="flex flex-col gap-5">
             {/* 지원 솔커 - 비활성화 */}
             <StatusChoiceButton
-              status="PLANNING"
+              status="BEFORE_EXCHANGE"
               description="교환학생을 준비 중이신가요?"
-              name="지원 슬커"
+              name="준비 중"
               icon={<IconPrepare1 />}
-              isSelected={studyStatus === "PLANNING"}
-              onClick={() => {}} // 클릭 불가
+              isSelected={false}
+              onClick={() => {}}
               disabled
             />
 
             <StatusChoiceButton
-              status="STUDYING"
+              status="DURING_EXCHANGE"
               description="합격했거나 수학 중이신가요?"
               name="수학 중"
               icon={<IconPrepare2 />}
-              isSelected={studyStatus === "STUDYING"}
-              onClick={() => setValue("studyStatus", "STUDYING")}
+              isSelected={false}
+              onClick={() => {}}
+              disabled
             />
 
             <StatusChoiceButton
-              status="COMPLETED"
+              status="AFTER_EXCHANGE"
               description="교환학생 후 귀국한 학생이신가요?"
               name="수학 완료"
               icon={<IconPrepare3 />}
-              isSelected={studyStatus === "COMPLETED"}
-              onClick={() => setValue("studyStatus", "COMPLETED")}
+              isSelected={preparationStatus === "AFTER_EXCHANGE"}
+              onClick={() => setValue("preparationStatus", "AFTER_EXCHANGE", { shouldValidate: true })}
             />
           </div>
         </div>
@@ -78,7 +81,7 @@ const StudyStatusScreen = ({ onNext }: StudyStatusScreenProps) => {
 
       <div className="fixed bottom-0 left-0 right-0 w-full bg-white pb-14">
         <div className="mx-auto w-full max-w-app px-5">
-          <BlockBtn className="mb-[29px]" disabled={!studyStatus} onClick={handleNext}>
+          <BlockBtn className="mb-[29px]" disabled={!preparationStatus} onClick={handleNext}>
             다음
           </BlockBtn>
         </div>

--- a/apps/web/src/app/my/apply-mentor/_components/UniversityScreen/index.tsx
+++ b/apps/web/src/app/my/apply-mentor/_components/UniversityScreen/index.tsx
@@ -7,16 +7,17 @@ import { toast } from "react-hot-toast";
 import type { z } from "zod";
 import { useUniversitySearch } from "@/apis/universities";
 import BlockBtn from "@/components/button/BlockBtn";
-import { mentorRegionList } from "@/constants/regions";
+import { COUNTRY_CODE_MAP } from "@/constants/university";
 import type { mentorApplicationSchema } from "../../_lib/schema";
 
 type FormValues = z.input<typeof mentorApplicationSchema>;
 
 type UniversityScreenProps = {
+  isSubmitting: boolean;
   onNext: () => void;
 };
 
-const UniversityScreen = ({ onNext }: UniversityScreenProps) => {
+const UniversityScreen = ({ isSubmitting, onNext }: UniversityScreenProps) => {
   const {
     watch,
     setValue,
@@ -26,27 +27,34 @@ const UniversityScreen = ({ onNext }: UniversityScreenProps) => {
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const country = watch("country");
-  const universityName = watch("universityName");
+  const countryCode = watch("country");
+  const universityId = watch("universityId");
+  const term = watch("term");
   const verificationFile = watch("verificationFile");
+  const selectedCountryName = countryCode ? COUNTRY_CODE_MAP[countryCode] : "";
 
   // 모든 대학 목록 가져오기
   const { data: allUniversities = [], isLoading } = useUniversitySearch("");
 
-  // regionList에서 모든 국가 추출 (중복 제거)
-  const availableCountries = useMemo(() => {
-    const countries = new Set<string>();
-    mentorRegionList.forEach((region) => {
-      region.countries.forEach((country) => countries.add(country));
-    });
-    return Array.from(countries).sort();
-  }, []);
-
   // 선택된 국가에 따라 대학 목록 필터링
   const filteredUniversities = useMemo(() => {
-    if (!country || !allUniversities) return [];
-    return allUniversities.filter((uni) => uni.country === country);
-  }, [country, allUniversities]);
+    if (!selectedCountryName || !allUniversities) return [];
+    return allUniversities.filter((uni) => uni.country === selectedCountryName);
+  }, [selectedCountryName, allUniversities]);
+
+  const handleUniversityChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const nextUniversityId = Number(e.target.value);
+
+    if (!nextUniversityId) {
+      setValue("universityId", 0, { shouldValidate: true });
+      setValue("term", "", { shouldValidate: true });
+      return;
+    }
+
+    const selectedUniversity = filteredUniversities.find((university) => university.id === nextUniversityId);
+    setValue("universityId", nextUniversityId, { shouldValidate: true });
+    setValue("term", selectedUniversity?.term ?? "", { shouldValidate: true });
+  };
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -84,7 +92,7 @@ const UniversityScreen = ({ onNext }: UniversityScreenProps) => {
   };
 
   const handleNext = async () => {
-    const isValid = await trigger(["country", "universityName", "verificationFile"]);
+    const isValid = await trigger(["universityId", "term", "verificationFile"]);
     if (isValid) {
       onNext();
     }
@@ -103,30 +111,12 @@ const UniversityScreen = ({ onNext }: UniversityScreenProps) => {
         </div>
 
         <div className="mt-10 flex flex-col gap-5">
-          {/* 국가 선택 */}
+          {/* 선택한 국가 */}
           <div className="flex flex-col gap-2">
             <label className="text-k-900 typo-sb-9">국가</label>
-            <select
-              value={country || ""}
-              onChange={(e) => {
-                setValue("country", e.target.value);
-                setValue("universityName", ""); // 국가 변경 시 학교 선택 초기화
-              }}
-              className={clsx(
-                "h-12 rounded-lg border border-k-200 bg-k-50 px-4 typo-regular-2 focus:border-primary focus:outline-none [&>option:checked]:text-primary",
-                country && "text-accent-custom-indigo",
-              )}
-            >
-              <option value="" className="text-k-400">
-                국가를 선택해주세요
-              </option>
-              {availableCountries.map((countryName) => (
-                <option key={countryName} value={countryName} className="text-primary">
-                  {countryName}
-                </option>
-              ))}
-            </select>
-            {errors.country && <p className="text-red-500 typo-regular-2">{errors.country.message}</p>}
+            <div className="flex h-12 items-center rounded-lg border border-k-200 bg-k-50 px-4 text-accent-custom-indigo typo-regular-2">
+              {selectedCountryName || "이전 단계에서 국가를 선택해주세요"}
+            </div>
           </div>
 
           {/* 학교 선택 */}
@@ -138,29 +128,30 @@ const UniversityScreen = ({ onNext }: UniversityScreenProps) => {
               </div>
             ) : (
               <select
-                value={universityName || ""}
-                onChange={(e) => setValue("universityName", e.target.value)}
-                disabled={!country || filteredUniversities.length === 0}
+                value={universityId || ""}
+                onChange={handleUniversityChange}
+                disabled={!selectedCountryName || filteredUniversities.length === 0}
                 className={clsx(
                   "h-12 rounded-lg border border-k-200 bg-k-50 px-4 typo-regular-2 focus:border-primary focus:outline-none disabled:cursor-not-allowed disabled:opacity-60 [&>option:checked]:text-primary",
-                  universityName && "text-accent-custom-indigo",
+                  universityId > 0 && "text-accent-custom-indigo",
                 )}
               >
                 <option value="" className="text-k-400">
-                  {!country
+                  {!selectedCountryName
                     ? "먼저 국가를 선택해주세요"
                     : filteredUniversities.length === 0
                       ? "해당 국가에 등록된 학교가 없습니다"
                       : "학교를 선택해주세요"}
                 </option>
                 {filteredUniversities.map((university) => (
-                  <option key={university.id} value={university.koreanName} className="text-primary">
-                    {university.koreanName}
+                  <option key={university.id} value={university.id} className="text-primary">
+                    {university.koreanName} ({university.term})
                   </option>
                 ))}
               </select>
             )}
-            {errors.universityName && <p className="text-red-500 typo-regular-2">{errors.universityName.message}</p>}
+            {errors.universityId && <p className="text-red-500 typo-regular-2">{errors.universityId.message}</p>}
+            {errors.term && <p className="text-red-500 typo-regular-2">{errors.term.message}</p>}
           </div>
 
           {/* 증명서 첨부 */}
@@ -215,10 +206,10 @@ const UniversityScreen = ({ onNext }: UniversityScreenProps) => {
         <div className="mx-auto w-full max-w-app px-5">
           <BlockBtn
             className="mb-[29px]"
-            disabled={!country || !universityName || !verificationFile}
+            disabled={isSubmitting || !selectedCountryName || !universityId || !term || !verificationFile}
             onClick={handleNext}
           >
-            다음
+            {isSubmitting ? "신청 중..." : "신청하기"}
           </BlockBtn>
         </div>
       </div>

--- a/apps/web/src/app/my/apply-mentor/_lib/schema.ts
+++ b/apps/web/src/app/my/apply-mentor/_lib/schema.ts
@@ -1,4 +1,7 @@
 import { z } from "zod";
+import { CountryCode } from "@/types/university";
+
+const countryCodeValues = Object.values(CountryCode) as [CountryCode, ...CountryCode[]];
 
 const verificationFileSchema = z
   .union([z.instanceof(File), z.null(), z.undefined()])
@@ -18,35 +21,38 @@ const verificationFileSchema = z
   .transform((file) => file!);
 
 export const mentorApplicationSchema = z.object({
-  // Step 1: 관심 국가
-  interestedCountries: z.array(z.string()).min(1, "관심 국가를 하나 이상 선택해주세요."),
-
-  // Step 2: 수학 학교
-  country: z.string().min(1, "국가를 선택해주세요."),
-  universityName: z.string().min(1, "학교를 선택해주세요."),
-  verificationFile: verificationFileSchema,
-
-  // Step 3: 준비 단계
-  studyStatus: z.enum(["PLANNING", "STUDYING", "COMPLETED"], {
-    message: "준비 단계를 선택해주세요.",
+  // Step 1: 멘토 신청 가능 상태
+  preparationStatus: z.enum(["AFTER_EXCHANGE"], {
+    message: "수학 완료 상태만 멘토 전환을 신청할 수 있습니다.",
   }),
+
+  // Step 2: 수학 국가
+  country: z.enum(countryCodeValues, {
+    message: "국가를 선택해주세요.",
+  }),
+
+  // Step 3: 수학 학교 및 증명서
+  universityId: z.number().int().positive("학교를 선택해주세요."),
+  term: z.string().min(1, "파견 학기 정보를 확인할 수 없습니다."),
+  verificationFile: verificationFileSchema,
 });
 
-export type MentorApplicationFormData = z.infer<typeof mentorApplicationSchema>;
+export type MentorApplicationFormInputData = z.input<typeof mentorApplicationSchema>;
+export type MentorApplicationFormData = z.output<typeof mentorApplicationSchema>;
 
 // 단계별 부분 스키마
 export const step1Schema = mentorApplicationSchema.pick({
-  interestedCountries: true,
+  preparationStatus: true,
 });
 
 export const step2Schema = mentorApplicationSchema.pick({
   country: true,
-  universityName: true,
-  verificationFile: true,
 });
 
 export const step3Schema = mentorApplicationSchema.pick({
-  studyStatus: true,
+  universityId: true,
+  term: true,
+  verificationFile: true,
 });
 
 export type Step1FormData = z.infer<typeof step1Schema>;

--- a/apps/web/src/app/my/apply-mentor/page.tsx
+++ b/apps/web/src/app/my/apply-mentor/page.tsx
@@ -22,24 +22,23 @@ const ApplyMentorPage = () => {
   const router = useRouter();
   const [step, setStep] = useState<number>(1);
 
-  const methods = useForm<FormInputValues>({
+  const methods = useForm<FormInputValues, unknown, FormOutputValues>({
     resolver: zodResolver(mentorApplicationSchema),
     defaultValues: {
-      interestedCountries: [],
-      country: "",
-      universityName: "",
+      universityId: 0,
+      term: "",
       verificationFile: undefined,
-      studyStatus: undefined,
     },
     mode: "onChange",
   });
 
-  const { mutate: postMentorApplication } = usePostMentorApplication();
+  const { mutate: postMentorApplication, isPending } = usePostMentorApplication();
 
   const goNextStep = () => setStep((prev) => prev + 1);
   const goPrevStep = () => {
     if (step === 1) {
       router.back();
+      return;
     }
     setStep((prev) => Math.max(1, prev - 1));
   };
@@ -49,10 +48,11 @@ const ApplyMentorPage = () => {
   const onSubmit = methods.handleSubmit((data: FormOutputValues) => {
     postMentorApplication(
       {
-        interestedCountries: data.interestedCountries,
+        preparationStatus: data.preparationStatus,
+        universitySelectType: "CATALOG",
         country: data.country,
-        universityName: data.universityName,
-        studyStatus: data.studyStatus,
+        universityId: data.universityId,
+        term: data.term,
         verificationFile: data.verificationFile,
       },
       {
@@ -73,7 +73,7 @@ const ApplyMentorPage = () => {
       <FormProvider {...methods}>
         {/* Top Navigation */}
         <TopDetailNavigation
-          title={step === 1 ? "회원 유형 선택" : step === 2 ? "관심 지역 선택" : step === 3 ? "수학 학교 선택" : ""}
+          title={step === 1 ? "회원 유형 선택" : step === 2 ? "수학 국가 선택" : step === 3 ? "수학 학교 선택" : ""}
           handleBack={goPrevStep}
         />
 
@@ -85,7 +85,7 @@ const ApplyMentorPage = () => {
         {/* Step Content */}
         {step === 1 && <StudyStatusScreen onNext={goNextStep} />}
         {step === 2 && <InterestCountriesScreen onNext={goNextStep} />}
-        {step === 3 && <UniversityScreen onNext={onSubmit} />}
+        {step === 3 && <UniversityScreen isSubmitting={isPending} onNext={onSubmit} />}
       </FormProvider>
     </div>
   );


### PR DESCRIPTION
## 요약
- 마이페이지의 멘토 회원 전환 CTA를 실제 신청 페이지로 연결했습니다.
- 멘토 승격 요청 API를 Bruno 문서의 `POST /mentees/mentor-applications` multipart 형식에 맞췄습니다.
- v1 범위로 수학 완료 사용자만 `AFTER_EXCHANGE` 상태로 신청할 수 있게 제한했습니다.
- 신청 완료 화면을 관리자 검토 대기 안내로 변경했습니다.

## 변경 사항
- `mentorApplicationRequest`에 `preparationStatus`, `universitySelectType`, `country`, `universityId`, `term`을 담아 전송합니다.
- 한글 국가명은 `COUNTRY_CODE_MAP` reverse map으로 API 국가 코드로 변환합니다.
- 대학 선택은 선택 국가의 catalog 대학 `id`와 `term`을 사용합니다.
- 제출 중에는 신청 버튼을 비활성화하고 `신청 중...` 상태를 표시합니다.

## 검증
- `pnpm --filter @solid-connect/web run typecheck:ci`
- `pnpm --filter @solid-connect/web run lint:check`
- push hook: `@solid-connect/web ci:check` + `next build`

## 참고
- 로컬 Node가 repo engine(22.x)과 달라 `Unsupported engine` 경고는 표시됐지만 검증은 통과했습니다.
