### PR TITLE
fix(web): 전역 로딩 스피너 제거

### DIFF
--- a/apps/web/src/apis/chat/getChatMessages.ts
+++ b/apps/web/src/apis/chat/getChatMessages.ts
@@ -26,9 +26,6 @@ const useGetChatHistories = (roomId: number, size: number = 20) => {
     },
     staleTime: 1000 * 60 * 5, // 5분간 캐시
     enabled: !!roomId, // roomId가 있을 때만 쿼리 실행
-    meta: {
-      disableGlobalLoading: true, // 전역 로딩 비활성화
-    },
     select: (data) => ({
       pages: data.pages,
       pageParams: data.pageParams,

--- a/apps/web/src/apis/community/getPostDetail.ts
+++ b/apps/web/src/apis/community/getPostDetail.ts
@@ -10,7 +10,6 @@ const useGetPostDetail = (postId: number) => {
     queryKey: [CommunityQueryKeys.posts, postId],
     queryFn: () => communityApi.getPostDetail(postId),
     enabled: !!postId,
-    meta: { showGlobalSpinner: false },
   });
 };
 

--- a/apps/web/src/components/layout/GlobalLayout/ui/ClientModal/index.tsx
+++ b/apps/web/src/components/layout/GlobalLayout/ui/ClientModal/index.tsx
@@ -1,12 +1,10 @@
 "use client";
 
-import { useIsFetching } from "@tanstack/react-query";
 import { useEffect } from "react";
 import MentorApplyCountContent from "@/components/mentor/MentorApplyCountContent";
 import IconAlertModal from "@/components/modal/IconAlertModal";
 import IconConfirmModal from "@/components/modal/IconConfirmModal";
 import SurveyModal from "@/components/modal/SurveyModal";
-import CloudSpinner from "@/components/ui/CloudSpinner";
 import QueryProvider from "@/lib/react-query/QueryProvider";
 import { useAlertModalStore } from "@/lib/zustand/useAlertModalStore";
 import { useConfirmModalStore } from "@/lib/zustand/useConfirmModalStore";
@@ -22,10 +20,6 @@ const ClientModal = () => {
     checkAndOpen,
   } = useSurveyModalStore();
 
-  const isFetching = useIsFetching({
-    predicate: (query) => query.meta?.showGlobalSpinner !== false,
-  });
-
   // 페이지 로드 시 만족도 조사 모달 표시 여부 확인
   useEffect(() => {
     checkAndOpen();
@@ -33,16 +27,6 @@ const ClientModal = () => {
 
   return (
     <QueryProvider>
-      {isFetching ? (
-        <div
-          aria-live="polite"
-          aria-busy="true"
-          className="fixed inset-0 z-50 flex cursor-wait items-center justify-center bg-black/30"
-        >
-          <CloudSpinner />
-        </div>
-      ) : null}
-
       <MentorApplyCountContent />
 
       <SurveyModal isOpen={surveyOpen} onClose={closeSurvey} onCloseForWeek={closeSurveyForWeek} />


### PR DESCRIPTION
## 요약
- React Query fetch 상태에 따라 전체 화면을 덮던 전역 로딩 스피너를 제거했습니다.
- 전역 스피너 제어용 query meta 설정도 함께 정리했습니다.
- 개별 화면/콜백에서 명시적으로 사용하는 로딩 UI는 그대로 유지했습니다.

## 배경
짧은 요청마다 전체 화면 딤 + 스피너가 표시되면서 화면이 깜빡이는 문제가 있어, 앱 전역 fetch 오버레이를 제거했습니다.

## 검증
- `pnpm --filter @solid-connect/web run lint:check`
- `pnpm --filter @solid-connect/web run typecheck:ci`
- push hook: `@solid-connect/web ci:check` + `next build`

## 참고
- 로컬 Node가 repo engine(22.x)과 달라 `Unsupported engine` 경고는 표시됐지만 검증은 통과했습니다.
- 기존 채팅 훅의 exhaustive-deps warning이 하나 표시되지만 이번 변경 범위 밖이며 실패로 처리되지는 않습니다.
