### PR TITLE
feat: 어드민 Bruno API 테스트베드 개선

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@solid-connect/api-schema": "workspace:^",
     "@stomp/stompjs": "^7.1.1",
     "@tailwindcss/vite": "^4.0.6",
     "@tanstack/react-query": "^5.84.1",

--- a/apps/admin/src/components/features/bruno/BrunoApiPageContent.tsx
+++ b/apps/admin/src/components/features/bruno/BrunoApiPageContent.tsx
@@ -36,7 +36,7 @@ interface EditorState {
 	headersText: string;
 }
 
-const ALL_ENDPOINTS = [...brunoApiDefinitionRegistry].sort((a, b) => {
+const ALL_ENDPOINTS: EndpointItem[] = [...brunoApiDefinitionRegistry].sort((a, b) => {
 	if (a.domain === b.domain) {
 		return a.displayName.localeCompare(b.displayName);
 	}
@@ -140,6 +140,8 @@ const isRemoteApiServer = (url: string) => {
 	return !/^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?/i.test(url);
 };
 
+const isAbsoluteUrl = (url: string) => /^https?:\/\//i.test(url);
+
 const getEndpointKey = (endpoint: EndpointItem) => `${endpoint.domain}:${endpoint.name}:${endpoint.sourceFile ?? ""}`;
 
 const getMethodClassName = (method: DefinitionMethod) =>
@@ -188,9 +190,17 @@ export function BrunoApiPageContent() {
 		return ALL_ENDPOINTS.find((endpoint) => getEndpointKey(endpoint) === selectedKey) ?? null;
 	}, [selectedKey]);
 
+	const selectedCanExecute = selectedEndpoint
+		? (selectedEndpoint.definition.canExecute ?? selectedEndpoint.definition.bodyType !== "multipart-form")
+		: false;
 	const selectedIsMultipart = selectedEndpoint?.definition.bodyType === "multipart-form";
+	const selectedExecutionBlocked = selectedEndpoint ? !selectedCanExecute : false;
 	const selectedIsMutating = selectedEndpoint ? MUTATING_METHODS.has(selectedEndpoint.definition.method) : false;
-	const showRemoteWarning = isRemoteApiServer(apiServerUrl);
+	const remoteWarningUrl =
+		selectedEndpoint && isAbsoluteUrl(selectedEndpoint.definition.path)
+			? selectedEndpoint.definition.path
+			: apiServerUrl;
+	const showRemoteWarning = isRemoteApiServer(remoteWarningUrl);
 
 	useEffect(() => {
 		setEditorState(buildEditorState(selectedEndpoint));
@@ -224,8 +234,8 @@ export function BrunoApiPageContent() {
 			return;
 		}
 
-		if (selectedIsMultipart) {
-			toast.warning("파일 업로드 API는 현재 테스트베드에서 실행할 수 없습니다.");
+		if (selectedExecutionBlocked) {
+			toast.warning("이 API는 현재 테스트베드에서 실행할 수 없습니다.");
 			return;
 		}
 
@@ -278,7 +288,11 @@ export function BrunoApiPageContent() {
 				headers: responseHeaders,
 				body: response.data,
 			});
-			toast.success("요청이 완료되었습니다.");
+			if (response.status >= 200 && response.status < 300) {
+				toast.success("요청이 완료되었습니다.");
+			} else {
+				toast.error(`요청이 실패했습니다. (HTTP ${response.status})`);
+			}
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "요청 중 오류가 발생했습니다.";
 			setEditorError(message);
@@ -375,7 +389,7 @@ export function BrunoApiPageContent() {
 							<AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
 							<div className="min-w-0">
 								<p className="typo-sb-11">원격 API 서버에 연결되어 있습니다.</p>
-								<p className="mt-1 break-all typo-regular-4">{apiServerUrl}</p>
+								<p className="mt-1 break-all typo-regular-4">{remoteWarningUrl}</p>
 							</div>
 						</div>
 					) : null}
@@ -392,7 +406,7 @@ export function BrunoApiPageContent() {
 									<Button
 										type="button"
 										onClick={handleSendRequest}
-										disabled={isSending || !selectedEndpoint || selectedIsMultipart}
+										disabled={isSending || !selectedEndpoint || selectedExecutionBlocked}
 									>
 										<Play className="h-4 w-4" />
 										{isSending ? "요청 중..." : "요청 보내기"}
@@ -417,9 +431,9 @@ export function BrunoApiPageContent() {
 							) : (
 								<p className="typo-regular-4 text-k-500">왼쪽에서 API를 선택해주세요.</p>
 							)}
-							{selectedIsMultipart ? (
+							{selectedExecutionBlocked ? (
 								<div className="rounded-md border border-k-200 bg-k-50 px-3 py-2 typo-regular-4 text-k-600">
-									파일 업로드 API는 v1 테스트베드에서 실행을 막아두었습니다.
+									이 API는 v1 테스트베드에서 실행을 막아두었습니다.
 								</div>
 							) : null}
 							{editorError ? (

--- a/apps/admin/src/components/features/bruno/BrunoApiPageContent.tsx
+++ b/apps/admin/src/components/features/bruno/BrunoApiPageContent.tsx
@@ -1,7 +1,11 @@
 "use client";
 
-import { Copy, Play, RotateCcw } from "lucide-react";
-import { useMemo, useState } from "react";
+import {
+	type BrunoApiDefinitionRegistryItem,
+	brunoApiDefinitionRegistry,
+} from "@solid-connect/api-schema/api-definition-registry";
+import { AlertTriangle, Copy, Play, RotateCcw } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { AdminLayout } from "@/components/layout/AdminLayout";
 import { Button } from "@/components/ui/button";
@@ -13,23 +17,10 @@ import { Textarea } from "@/components/ui/textarea";
 import { axiosInstance } from "@/lib/api/client";
 import { cn } from "@/lib/utils";
 
-type DefinitionMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS";
+type EndpointItem = BrunoApiDefinitionRegistryItem;
+type DefinitionMethod = EndpointItem["definition"]["method"];
 type MethodFilter = "ALL" | DefinitionMethod;
-
-interface ApiDefinitionEntry {
-	method: DefinitionMethod;
-	path: string;
-	pathParams: Record<string, unknown>;
-	queryParams: Record<string, unknown>;
-	body: unknown;
-	response: unknown;
-}
-
-interface EndpointItem {
-	domain: string;
-	name: string;
-	definition: ApiDefinitionEntry;
-}
+type DomainFilter = "ALL" | string;
 
 interface RequestResult {
 	status: number;
@@ -38,80 +29,50 @@ interface RequestResult {
 	body: unknown;
 }
 
-const definitionModules = import.meta.glob("../../../../../../packages/api-schema/src/apis/*/apiDefinitions.ts", {
-	eager: true,
-}) as Record<string, Record<string, unknown>>;
+interface EditorState {
+	pathParamsText: string;
+	queryParamsText: string;
+	bodyText: string;
+	headersText: string;
+}
 
-const normalizeTokenKey = (value: string) => value.replace(/[^a-zA-Z0-9]/g, "").toLowerCase();
+const ALL_ENDPOINTS = [...brunoApiDefinitionRegistry].sort((a, b) => {
+	if (a.domain === b.domain) {
+		return a.displayName.localeCompare(b.displayName);
+	}
+	return a.domain.localeCompare(b.domain);
+});
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-	typeof value === "object" && value !== null && !Array.isArray(value);
+const METHOD_FILTERS: MethodFilter[] = ["ALL", "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"];
+const MUTATING_METHODS = new Set<DefinitionMethod>(["POST", "PUT", "PATCH", "DELETE"]);
+const METHODS_WITHOUT_BODY = new Set<string>(["GET", "HEAD"]);
+const apiServerUrl = import.meta.env.VITE_API_SERVER_URL?.trim() ?? "";
 
-const isDefinitionMethod = (value: unknown): value is DefinitionMethod =>
-	value === "GET" ||
-	value === "POST" ||
-	value === "PUT" ||
-	value === "PATCH" ||
-	value === "DELETE" ||
-	value === "HEAD" ||
-	value === "OPTIONS";
-
-const isApiDefinitionEntry = (value: unknown): value is ApiDefinitionEntry => {
-	if (!isRecord(value)) {
-		return false;
+const toPrettyJson = (value: unknown): string => {
+	if (value === undefined) {
+		return "";
 	}
 
-	return (
-		isDefinitionMethod(value.method) &&
-		typeof value.path === "string" &&
-		isRecord(value.pathParams) &&
-		isRecord(value.queryParams) &&
-		"body" in value &&
-		"response" in value
-	);
+	return JSON.stringify(value, null, 2) ?? "";
 };
 
-const parseDefinitionRegistry = (): EndpointItem[] => {
-	const endpoints: EndpointItem[] = [];
-
-	for (const [modulePath, moduleExports] of Object.entries(definitionModules)) {
-		const domainMatch = modulePath.match(/apis\/([^/]+)\/apiDefinitions\.ts$/);
-		if (!domainMatch) {
-			continue;
-		}
-
-		const domain = domainMatch[1];
-
-		for (const exportedValue of Object.values(moduleExports)) {
-			if (!isRecord(exportedValue)) {
-				continue;
-			}
-
-			for (const [endpointName, endpointDefinition] of Object.entries(exportedValue)) {
-				if (!isApiDefinitionEntry(endpointDefinition)) {
-					continue;
-				}
-
-				endpoints.push({
-					domain,
-					name: endpointName,
-					definition: endpointDefinition,
-				});
-			}
-		}
+const buildEditorState = (endpoint: EndpointItem | null): EditorState => {
+	if (!endpoint) {
+		return {
+			pathParamsText: "{}",
+			queryParamsText: "{}",
+			bodyText: "{}",
+			headersText: "{}",
+		};
 	}
 
-	return endpoints.sort((a, b) => {
-		if (a.domain === b.domain) {
-			return a.name.localeCompare(b.name);
-		}
-		return a.domain.localeCompare(b.domain);
-	});
+	return {
+		pathParamsText: toPrettyJson(endpoint.definition.pathParamsExample),
+		queryParamsText: toPrettyJson(endpoint.definition.queryParamsExample),
+		bodyText: endpoint.definition.hasBody ? toPrettyJson(endpoint.definition.bodyExample ?? {}) : "{}",
+		headersText: "{}",
+	};
 };
-
-const ALL_ENDPOINTS = parseDefinitionRegistry();
-
-const toPrettyJson = (value: unknown) => JSON.stringify(value, null, 2);
 
 const parseJsonValue = (text: string, label: string): unknown => {
 	if (!text.trim()) {
@@ -138,25 +99,28 @@ const toStringRecord = (value: Record<string, unknown>): Record<string, string> 
 	return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, String(entry)]));
 };
 
+const resolvePathParamValue = (pathParams: Record<string, unknown>, tokenName: string) => {
+	const value = pathParams[tokenName];
+	if (value !== undefined && value !== null && String(value).trim().length > 0) {
+		return encodeURIComponent(String(value));
+	}
+
+	throw new Error(`경로 파라미터 '${tokenName}' 값이 필요합니다.`);
+};
+
 const resolvePath = (rawPath: string, pathParams: Record<string, unknown>) => {
 	const withoutBaseToken = rawPath.replace("{{URL}}", "");
-
-	return withoutBaseToken.replace(/\{\{([^}]+)\}\}/g, (_full, tokenName: string) => {
-		const exact = pathParams[tokenName];
-		if (exact !== undefined && exact !== null) {
-			return encodeURIComponent(String(exact));
+	const resolvedBrunoPath = withoutBaseToken.replace(/\{\{([^}]+)\}\}/g, (_full, tokenName: string) => {
+		if (tokenName === "URL") {
+			return "";
 		}
 
-		const normalizedToken = normalizeTokenKey(tokenName);
-		const similarEntry = Object.entries(pathParams).find(
-			([key, value]) => normalizeTokenKey(key) === normalizedToken && value !== undefined && value !== null,
-		);
+		return resolvePathParamValue(pathParams, tokenName);
+	});
 
-		if (similarEntry) {
-			return encodeURIComponent(String(similarEntry[1]));
-		}
-
-		throw new Error(`경로 파라미터 '${tokenName}' 값이 필요합니다.`);
+	return resolvedBrunoPath.replace(/:(\w+)|\{(\w+)\}/g, (_full, colonParam: string, braceParam: string) => {
+		const tokenName = colonParam || braceParam;
+		return resolvePathParamValue(pathParams, tokenName);
 	});
 };
 
@@ -168,50 +132,81 @@ const splitPathAndInlineQuery = (pathWithInlineQuery: string) => {
 	return { path, inlineQuery };
 };
 
-const METHOD_FILTERS: MethodFilter[] = ["ALL", "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"];
+const isRemoteApiServer = (url: string) => {
+	if (!url) {
+		return false;
+	}
+
+	return !/^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?/i.test(url);
+};
+
+const getEndpointKey = (endpoint: EndpointItem) => `${endpoint.domain}:${endpoint.name}:${endpoint.sourceFile ?? ""}`;
+
+const getMethodClassName = (method: DefinitionMethod) =>
+	cn(
+		"rounded px-1.5 py-0.5 typo-regular-4",
+		method === "GET" && "bg-[#E8F3FF] text-[#1D4ED8]",
+		method === "POST" && "bg-[#ECFDF3] text-[#047857]",
+		method === "PUT" && "bg-[#FFF7ED] text-[#C2410C]",
+		method === "PATCH" && "bg-[#FEF3C7] text-[#B45309]",
+		method === "DELETE" && "bg-[#FEE2E2] text-[#B91C1C]",
+		(method === "HEAD" || method === "OPTIONS") && "bg-k-100 text-k-700",
+	);
 
 export function BrunoApiPageContent() {
 	const [search, setSearch] = useState("");
 	const [methodFilter, setMethodFilter] = useState<MethodFilter>("ALL");
-	const [selectedKey, setSelectedKey] = useState(
-		ALL_ENDPOINTS[0] ? `${ALL_ENDPOINTS[0].domain}:${ALL_ENDPOINTS[0].name}` : "",
-	);
-	const [pathParamsText, setPathParamsText] = useState("{}");
-	const [queryParamsText, setQueryParamsText] = useState("{}");
-	const [bodyText, setBodyText] = useState("{}");
-	const [headersText, setHeadersText] = useState("{}");
+	const [domainFilter, setDomainFilter] = useState<DomainFilter>("ALL");
+	const [selectedKey, setSelectedKey] = useState(ALL_ENDPOINTS[0] ? getEndpointKey(ALL_ENDPOINTS[0]) : "");
+	const [editorState, setEditorState] = useState<EditorState>(() => buildEditorState(ALL_ENDPOINTS[0] ?? null));
 	const [isSending, setIsSending] = useState(false);
 	const [requestResult, setRequestResult] = useState<RequestResult | null>(null);
+	const [editorError, setEditorError] = useState<string | null>(null);
+
+	const domains = useMemo(() => Array.from(new Set(ALL_ENDPOINTS.map((endpoint) => endpoint.domain))).sort(), []);
 
 	const visibleEndpoints = useMemo(() => {
 		const normalized = search.trim().toLowerCase();
 		return ALL_ENDPOINTS.filter((endpoint) => {
-			const matchesMethod = methodFilter === "ALL" || endpoint.definition.method === methodFilter;
-			if (!matchesMethod) {
+			if (methodFilter !== "ALL" && endpoint.definition.method !== methodFilter) {
+				return false;
+			}
+			if (domainFilter !== "ALL" && endpoint.domain !== domainFilter) {
 				return false;
 			}
 			if (!normalized) {
 				return true;
 			}
 
-			const matchesSearch =
-				`${endpoint.domain} ${endpoint.name} ${endpoint.definition.method} ${endpoint.definition.path}`
-					.toLowerCase()
-					.includes(normalized);
-			return matchesSearch;
+			return `${endpoint.domain} ${endpoint.name} ${endpoint.displayName} ${endpoint.definition.method} ${endpoint.definition.path}`
+				.toLowerCase()
+				.includes(normalized);
 		});
-	}, [methodFilter, search]);
+	}, [domainFilter, methodFilter, search]);
 
 	const selectedEndpoint = useMemo(() => {
-		return ALL_ENDPOINTS.find((endpoint) => `${endpoint.domain}:${endpoint.name}` === selectedKey) ?? null;
+		return ALL_ENDPOINTS.find((endpoint) => getEndpointKey(endpoint) === selectedKey) ?? null;
 	}, [selectedKey]);
 
-	const handleResetEditors = () => {
-		setPathParamsText("{}");
-		setQueryParamsText("{}");
-		setBodyText("{}");
-		setHeadersText("{}");
+	const selectedIsMultipart = selectedEndpoint?.definition.bodyType === "multipart-form";
+	const selectedIsMutating = selectedEndpoint ? MUTATING_METHODS.has(selectedEndpoint.definition.method) : false;
+	const showRemoteWarning = isRemoteApiServer(apiServerUrl);
+
+	useEffect(() => {
+		setEditorState(buildEditorState(selectedEndpoint));
 		setRequestResult(null);
+		setEditorError(null);
+	}, [selectedEndpoint]);
+
+	const updateEditorState = (key: keyof EditorState, value: string) => {
+		setEditorState((prev) => ({ ...prev, [key]: value }));
+		setEditorError(null);
+	};
+
+	const handleResetEditors = () => {
+		setEditorState(buildEditorState(selectedEndpoint));
+		setRequestResult(null);
+		setEditorError(null);
 	};
 
 	const handleCopyResponse = async () => {
@@ -229,27 +224,42 @@ export function BrunoApiPageContent() {
 			return;
 		}
 
+		if (selectedIsMultipart) {
+			toast.warning("파일 업로드 API는 현재 테스트베드에서 실행할 수 없습니다.");
+			return;
+		}
+
+		if (selectedIsMutating) {
+			const confirmed = window.confirm(
+				`${selectedEndpoint.definition.method} ${selectedEndpoint.definition.path}\n\n실제 API에 변경 요청을 보냅니다. 계속할까요?`,
+			);
+
+			if (!confirmed) {
+				return;
+			}
+		}
+
 		try {
 			setIsSending(true);
+			setEditorError(null);
 
-			const pathParams = parseJsonRecord(pathParamsText, "Path Params");
-			const queryParams = parseJsonRecord(queryParamsText, "Query Params");
-			const headers = toStringRecord(parseJsonRecord(headersText, "Headers"));
-			const body = parseJsonValue(bodyText, "Body");
+			const pathParams = parseJsonRecord(editorState.pathParamsText, "Path Params");
+			const queryParams = parseJsonRecord(editorState.queryParamsText, "Query Params");
+			const headers = toStringRecord(parseJsonRecord(editorState.headersText, "Headers"));
+			const body = parseJsonValue(editorState.bodyText, "Body");
 
 			const resolvedPath = resolvePath(selectedEndpoint.definition.path, pathParams);
 			const { path, inlineQuery } = splitPathAndInlineQuery(resolvedPath);
 			const mergedQueryParams = { ...inlineQuery, ...queryParams };
+			const method: DefinitionMethod = selectedEndpoint.definition.method;
+			const shouldSendBody = !METHODS_WITHOUT_BODY.has(method);
 			const startedAt = performance.now();
 
 			const response = await axiosInstance.request({
 				url: path,
-				method: selectedEndpoint.definition.method,
+				method,
 				params: mergedQueryParams,
-				data:
-					selectedEndpoint.definition.method === "GET" || selectedEndpoint.definition.method === "HEAD"
-						? undefined
-						: body,
+				data: shouldSendBody ? body : undefined,
 				headers,
 				validateStatus: () => true,
 			});
@@ -271,6 +281,7 @@ export function BrunoApiPageContent() {
 			toast.success("요청이 완료되었습니다.");
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "요청 중 오류가 발생했습니다.";
+			setEditorError(message);
 			toast.error(message);
 		} finally {
 			setIsSending(false);
@@ -279,73 +290,110 @@ export function BrunoApiPageContent() {
 
 	return (
 		<AdminLayout activeMenu="bruno" title="Bruno API" description="정의된 API를 조회하고 요청/응답을 검증합니다.">
-			<div className="grid gap-4 lg:grid-cols-[320px_minmax(0,1fr)]">
+			<div className="grid gap-4 lg:grid-cols-[360px_minmax(0,1fr)]">
 				<Card className="border-k-100">
 					<CardHeader className="pb-3">
 						<CardTitle className="typo-sb-9 text-k-800">Bruno API 목록</CardTitle>
 						<Input
-							placeholder="도메인/엔드포인트 검색"
+							placeholder="도메인/엔드포인트/경로 검색"
 							value={search}
 							onChange={(event) => setSearch(event.target.value)}
 						/>
-						<div className="flex flex-wrap gap-1">
-							{METHOD_FILTERS.map((method) => {
-								const active = methodFilter === method;
-								return (
-									<Button
-										key={method}
-										type="button"
-										size="sm"
-										variant={active ? "default" : "outline"}
-										onClick={() => setMethodFilter(method)}
-									>
+						<div className="grid grid-cols-2 gap-2">
+							<select
+								value={domainFilter}
+								onChange={(event) => setDomainFilter(event.target.value)}
+								className="h-8 rounded-md border border-k-200 bg-k-0 px-2 typo-regular-4 text-k-700 outline-none focus-visible:border-primary"
+							>
+								<option value="ALL">모든 도메인</option>
+								{domains.map((domain) => (
+									<option key={domain} value={domain}>
+										{domain}
+									</option>
+								))}
+							</select>
+							<select
+								value={methodFilter}
+								onChange={(event) => setMethodFilter(event.target.value as MethodFilter)}
+								className="h-8 rounded-md border border-k-200 bg-k-0 px-2 typo-regular-4 text-k-700 outline-none focus-visible:border-primary"
+							>
+								{METHOD_FILTERS.map((method) => (
+									<option key={method} value={method}>
 										{method}
-									</Button>
-								);
-							})}
+									</option>
+								))}
+							</select>
 						</div>
+						<p className="typo-regular-4 text-k-500">
+							{visibleEndpoints.length} / {ALL_ENDPOINTS.length}개
+						</p>
 					</CardHeader>
-					<CardContent className="max-h-[680px] overflow-auto pt-0">
+					<CardContent className="max-h-[720px] overflow-auto pt-0">
 						<div className="space-y-2">
-							{visibleEndpoints.map((endpoint) => {
-								const key = `${endpoint.domain}:${endpoint.name}`;
-								const active = key === selectedKey;
+							{visibleEndpoints.length > 0 ? (
+								visibleEndpoints.map((endpoint) => {
+									const key = getEndpointKey(endpoint);
+									const active = key === selectedKey;
 
-								return (
-									<button
-										key={key}
-										type="button"
-										onClick={() => setSelectedKey(key)}
-										className={cn(
-											"w-full rounded-md border px-3 py-2 text-left transition-colors",
-											active ? "border-primary bg-primary-100" : "border-k-100 bg-k-0 hover:bg-k-50",
-										)}
-									>
-										<div className="flex items-center justify-between gap-2">
-											<span className="truncate typo-sb-11 text-k-800">{endpoint.name}</span>
-											<span className="rounded bg-k-100 px-1.5 py-0.5 typo-regular-4 text-k-700">
-												{endpoint.definition.method}
-											</span>
-										</div>
-										<p className="mt-1 truncate typo-regular-4 text-k-500">{endpoint.domain}</p>
-									</button>
-								);
-							})}
+									return (
+										<button
+											key={key}
+											type="button"
+											onClick={() => setSelectedKey(key)}
+											className={cn(
+												"w-full rounded-md border px-3 py-2 text-left transition-colors",
+												active ? "border-primary bg-primary-100" : "border-k-100 bg-k-0 hover:bg-k-50",
+											)}
+										>
+											<div className="flex items-start justify-between gap-2">
+												<div className="min-w-0">
+													<p className="truncate typo-sb-11 text-k-800">{endpoint.displayName}</p>
+													<p className="mt-1 truncate typo-regular-4 text-k-500">{endpoint.domain}</p>
+												</div>
+												<span className={getMethodClassName(endpoint.definition.method)}>
+													{endpoint.definition.method}
+												</span>
+											</div>
+											<p className="mt-2 break-all font-mono text-[11px] leading-4 text-k-500">
+												{endpoint.definition.path}
+											</p>
+										</button>
+									);
+								})
+							) : (
+								<div className="rounded-md border border-dashed border-k-200 bg-bg-50 px-4 py-8 text-center typo-regular-4 text-k-500">
+									표시할 API가 없습니다.
+								</div>
+							)}
 						</div>
 					</CardContent>
 				</Card>
 
 				<div className="space-y-4">
+					{showRemoteWarning ? (
+						<div className="flex items-start gap-2 rounded-md border border-[#FACC15] bg-[#FEFCE8] px-4 py-3 text-[#854D0E]">
+							<AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+							<div className="min-w-0">
+								<p className="typo-sb-11">원격 API 서버에 연결되어 있습니다.</p>
+								<p className="mt-1 break-all typo-regular-4">{apiServerUrl}</p>
+							</div>
+						</div>
+					) : null}
+
 					<Card className="border-k-100">
 						<CardHeader className="pb-3">
-							<div className="flex items-center justify-between gap-2">
+							<div className="flex flex-wrap items-center justify-between gap-2">
 								<CardTitle className="typo-sb-9 text-k-800">요청 빌더</CardTitle>
 								<div className="flex gap-2">
 									<Button type="button" variant="outline" onClick={handleResetEditors}>
 										<RotateCcw className="h-4 w-4" />
 										초기화
 									</Button>
-									<Button type="button" onClick={handleSendRequest} disabled={isSending || !selectedEndpoint}>
+									<Button
+										type="button"
+										onClick={handleSendRequest}
+										disabled={isSending || !selectedEndpoint || selectedIsMultipart}
+									>
 										<Play className="h-4 w-4" />
 										{isSending ? "요청 중..." : "요청 보내기"}
 									</Button>
@@ -353,47 +401,70 @@ export function BrunoApiPageContent() {
 							</div>
 							{selectedEndpoint ? (
 								<div className="rounded-md border border-k-100 bg-bg-50 px-3 py-2">
-									<p className="typo-sb-11 text-k-700">{selectedEndpoint.definition.method}</p>
-									<p className="mt-1 break-all typo-regular-4 text-k-600">{selectedEndpoint.definition.path}</p>
+									<div className="flex flex-wrap items-center gap-2">
+										<span className={getMethodClassName(selectedEndpoint.definition.method)}>
+											{selectedEndpoint.definition.method}
+										</span>
+										<span className="typo-sb-11 text-k-700">{selectedEndpoint.displayName}</span>
+									</div>
+									<p className="mt-1 break-all font-mono text-xs leading-5 text-k-600">
+										{selectedEndpoint.definition.path}
+									</p>
+									{selectedEndpoint.sourceFile ? (
+										<p className="mt-1 break-all typo-regular-4 text-k-400">{selectedEndpoint.sourceFile}</p>
+									) : null}
 								</div>
 							) : (
 								<p className="typo-regular-4 text-k-500">왼쪽에서 API를 선택해주세요.</p>
 							)}
+							{selectedIsMultipart ? (
+								<div className="rounded-md border border-k-200 bg-k-50 px-3 py-2 typo-regular-4 text-k-600">
+									파일 업로드 API는 v1 테스트베드에서 실행을 막아두었습니다.
+								</div>
+							) : null}
+							{editorError ? (
+								<div className="rounded-md border border-[#FCA5A5] bg-[#FEF2F2] px-3 py-2 typo-regular-4 text-[#B91C1C]">
+									{editorError}
+								</div>
+							) : null}
 						</CardHeader>
 						<CardContent className="pt-0">
 							<Tabs defaultValue="path">
 								<TabsList>
 									<TabsTrigger value="path">Path Params</TabsTrigger>
 									<TabsTrigger value="query">Query</TabsTrigger>
-									<TabsTrigger value="body">Body</TabsTrigger>
+									<TabsTrigger value="body" disabled={!selectedEndpoint?.definition.hasBody}>
+										Body
+									</TabsTrigger>
 									<TabsTrigger value="headers">Headers</TabsTrigger>
 								</TabsList>
 
 								<TabsContent value="path">
 									<Textarea
-										value={pathParamsText}
-										onChange={(event) => setPathParamsText(event.target.value)}
+										value={editorState.pathParamsText}
+										onChange={(event) => updateEditorState("pathParamsText", event.target.value)}
 										className="min-h-36 font-mono"
 									/>
 								</TabsContent>
 								<TabsContent value="query">
 									<Textarea
-										value={queryParamsText}
-										onChange={(event) => setQueryParamsText(event.target.value)}
+										value={editorState.queryParamsText}
+										onChange={(event) => updateEditorState("queryParamsText", event.target.value)}
 										className="min-h-36 font-mono"
 									/>
 								</TabsContent>
 								<TabsContent value="body">
 									<Textarea
-										value={bodyText}
-										onChange={(event) => setBodyText(event.target.value)}
+										value={editorState.bodyText}
+										onChange={(event) => updateEditorState("bodyText", event.target.value)}
 										className="min-h-44 font-mono"
+										disabled={!selectedEndpoint?.definition.hasBody || selectedIsMultipart}
 									/>
 								</TabsContent>
 								<TabsContent value="headers">
 									<Textarea
-										value={headersText}
-										onChange={(event) => setHeadersText(event.target.value)}
+										value={editorState.headersText}
+										onChange={(event) => updateEditorState("headersText", event.target.value)}
 										className="min-h-36 font-mono"
 									/>
 								</TabsContent>
@@ -403,7 +474,7 @@ export function BrunoApiPageContent() {
 
 					<Card className="border-k-100">
 						<CardHeader className="pb-3">
-							<div className="flex items-center justify-between gap-2">
+							<div className="flex flex-wrap items-center justify-between gap-2">
 								<CardTitle className="typo-sb-9 text-k-800">응답</CardTitle>
 								<Button type="button" variant="outline" onClick={handleCopyResponse} disabled={!requestResult}>
 									<Copy className="h-4 w-4" />
@@ -412,7 +483,16 @@ export function BrunoApiPageContent() {
 							</div>
 							{requestResult ? (
 								<div className="flex items-center gap-2 typo-regular-4 text-k-600">
-									<span className="rounded bg-k-100 px-2 py-1">HTTP {requestResult.status}</span>
+									<span
+										className={cn(
+											"rounded px-2 py-1",
+											requestResult.status >= 200 && requestResult.status < 300
+												? "bg-[#ECFDF3] text-[#047857]"
+												: "bg-[#FEF2F2] text-[#B91C1C]",
+										)}
+									>
+										HTTP {requestResult.status}
+									</span>
 									<span>{requestResult.durationMs}ms</span>
 								</div>
 							) : null}

--- a/apps/web/src/apis/image-upload/api.ts
+++ b/apps/web/src/apis/image-upload/api.ts
@@ -28,11 +28,8 @@ export const imageUploadApi = {
    * 슬랙 알림 전송
    */
   postSlackNotification: async (params: { data?: SlackNotificationRequest }): Promise<SlackNotificationResponse> => {
-    const res = await axiosInstance.post<SlackNotificationResponse>(
-      `https://hooks.slack.com/services/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`,
-      params?.data,
-    );
-    return res.data;
+    void params;
+    throw new Error("Slack webhook notification must be proxied through a server-side endpoint.");
   },
 
   /**

--- a/packages/api-schema/package.json
+++ b/packages/api-schema/package.json
@@ -2,6 +2,11 @@
   "name": "@solid-connect/api-schema",
   "version": "0.0.0",
   "private": true,
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./api-definition-registry": "./src/apiDefinitionRegistry.ts"
+  },
   "scripts": {
     "sync:bruno": "node ./scripts/sync-bruno.mjs",
     "sync:bruno:remote": "BRUNO_SOURCE_MODE=remote node ./scripts/sync-bruno.mjs",

--- a/packages/api-schema/src/apiDefinitionRegistry.ts
+++ b/packages/api-schema/src/apiDefinitionRegistry.ts
@@ -1,0 +1,1572 @@
+export interface BrunoApiDefinitionRegistryItem {
+  domain: string;
+  name: string;
+  displayName: string;
+  sourceFile?: string;
+  definition: {
+    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS';
+    path: string;
+    pathParamsExample: Record<string, string>;
+    queryParamsExample: Record<string, unknown>;
+    bodyExample?: unknown;
+    hasBody: boolean;
+    bodyType: string | null;
+  };
+}
+
+export const brunoApiDefinitionRegistry = [
+  {
+    domain: "Admin",
+    name: "delete권역삭제",
+    displayName: "권역 삭제",
+    sourceFile: "7) 어드민 [Admin]/권역 관리 - region/권역 삭제.bru",
+    definition: {
+      method: "DELETE",
+      path: "{{URL}}/admin/regions/{{code}}",
+      pathParamsExample: {
+        "code": ""
+      },
+      queryParamsExample: {},
+      bodyExample: {
+        "koreanName": "미주권"
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "Admin",
+    name: "delete지역삭제",
+    displayName: "지역 삭제",
+    sourceFile: "7) 어드민 [Admin]/지역 관리 - country/지역 삭제.bru",
+    definition: {
+      method: "DELETE",
+      path: "{{URL}}/admin/countries/{{code}}",
+      pathParamsExample: {
+        "code": ""
+      },
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "Admin",
+    name: "getCountMentorApplicationByStatus",
+    displayName: "멘토 지원서 상태별 개수 조회",
+    sourceFile: "7) 어드민 [Admin]/멘토- mentor/멘토 지원서 상태별 개수 조회 [count-mentor-application-by-status].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/admin/mentor-applications/count",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "Admin",
+    name: "getGpaList",
+    displayName: "학점\u001b조회",
+    sourceFile: "7) 어드민 [Admin]/학점 조회 [gpa-list].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/admin/scores/gpas",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "Admin",
+    name: "getLanguageTestList",
+    displayName: "어학 조회",
+    sourceFile: "7) 어드민 [Admin]/어학 조회 [language-test-list].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/admin/scores/language-tests?page=1&size=10",
+      pathParamsExample: {},
+      queryParamsExample: {
+        "page": "1",
+        "size": "10"
+      },
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "Admin",
+    name: "getMentorApplicationHistoryList",
+    displayName: "멘토 지원서 이력 조회",
+    sourceFile: "7) 어드민 [Admin]/멘토- mentor/멘토 지원서 이력 조회 [mentor-application-history-list].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/admin/mentor-applications/{{site_user_id}}/history",
+      pathParamsExample: {
+        "site_user_id": ""
+      },
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "Admin",
+    name: "getMentorApplicationList",
+    displayName: "멘토 승격 요청 내역 조회",
+    sourceFile: "7) 어드민 [Admin]/멘토- mentor/멘토 승격 요청 내역 조회 [mentor-application-list].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/admin/mentor-applications?page=2&size=10&mentorApplicationStatus=PENDING&nickname&createdAt=2025-11-14",
+      pathParamsExample: {},
+      queryParamsExample: {
+        "page": "2",
+        "size": "10",
+        "mentorApplicationStatus": "PENDING",
+        "createdAt": "2025-11-14"
+      },
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "Admin",
+    name: "get권역조회",
+    displayName: "권역 조회",
+    sourceFile: "7) 어드민 [Admin]/권역 관리 - region/권역 조회.bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/admin/regions",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "Admin",
+    name: "get지역조회",
+    displayName: "지역 조회",
+    sourceFile: "7) 어드민 [Admin]/지역 관리 - country/지역 조회.bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/admin/countries",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "Admin",
+    name: "postApproveMentorApplication",
+    displayName: "멘토 요청 승격 처리",
+    sourceFile: "7) 어드민 [Admin]/멘토- mentor/멘토 요청 승격 처리 [approve-mentor-application].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/admin/mentor-applications/{{mentor-application-id}}/approve",
+      pathParamsExample: {
+        "mentor-application-id": ""
+      },
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "Admin",
+    name: "postMappingMentorapplicationUniversity",
+    displayName: "멘토 지원서 대학 매핑",
+    sourceFile: "7) 어드민 [Admin]/멘토- mentor/멘토 지원서 대학 매핑 [mapping-mentorapplication-university].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/admin/mentor-applications/{{mentor-application-id}}/assign-university",
+      pathParamsExample: {
+        "mentor-application-id": ""
+      },
+      queryParamsExample: {},
+      bodyExample: {
+        "universityId": 1
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "Admin",
+    name: "postRejectMentorApplication",
+    displayName: "멘토 승격 요청 거절",
+    sourceFile: "7) 어드민 [Admin]/멘토- mentor/멘토 승격 요청 거절 [reject-mentor-application].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/admin/mentor-applications/{{mentor-application-id}}/reject",
+      pathParamsExample: {
+        "mentor-application-id": ""
+      },
+      queryParamsExample: {},
+      bodyExample: {
+        "rejectedReason": "잘못됌"
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "Admin",
+    name: "post권역생성",
+    displayName: "권역 생성",
+    sourceFile: "7) 어드민 [Admin]/권역 관리 - region/권역 생성.bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/admin/regions",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      bodyExample: {
+        "code": "AMERICAS",
+        "koreanName": "미주권"
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "Admin",
+    name: "post지역생성",
+    displayName: "지역 생성",
+    sourceFile: "7) 어드민 [Admin]/지역 관리 - country/지역 생성.bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/admin/countries",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      bodyExample: {
+        "code": "AT",
+        "koreanName": "오스트리아",
+        "regionCode": "EUROPE"
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "Admin",
+    name: "putVerifyGpa",
+    displayName: "학점 검증 및 수정",
+    sourceFile: "7) 어드민 [Admin]/학점 검증 및 수정 [verify-gpa].bru",
+    definition: {
+      method: "PUT",
+      path: "{{URL}}/admin/scores/gpas/{{gpa-score-id}}",
+      pathParamsExample: {
+        "gpa-score-id": ""
+      },
+      queryParamsExample: {},
+      bodyExample: {
+        "gpa": 3.2,
+        "gpaCriteria": 4.5,
+        "verifyStatus": "REJECTED",
+        "rejectedReason": "유효하지 않은 성적표"
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "Admin",
+    name: "putVerifyLanguageTest",
+    displayName: "어학 검증 및 수정",
+    sourceFile: "7) 어드민 [Admin]/어학 검증 및 수정 [verify-language-test].bru",
+    definition: {
+      method: "PUT",
+      path: "{{URL}}/admin/scores/language-tests/{{language-test-score-id}}",
+      pathParamsExample: {
+        "language-test-score-id": ""
+      },
+      queryParamsExample: {},
+      bodyExample: {
+        "languageTestType": "TOEIC",
+        "languageTestScore": "990",
+        "verifyStatus": "REJECTED",
+        "rejectedReason": "유효 기간 만료"
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "Admin",
+    name: "put권역수정",
+    displayName: "권역 수정",
+    sourceFile: "7) 어드민 [Admin]/권역 관리 - region/권역 수정.bru",
+    definition: {
+      method: "PUT",
+      path: "{{URL}}/admin/regions/{{code}}",
+      pathParamsExample: {
+        "code": ""
+      },
+      queryParamsExample: {},
+      bodyExample: {
+        "koreanName": "미주권"
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "Admin",
+    name: "put지역수정",
+    displayName: "지역 수정",
+    sourceFile: "7) 어드민 [Admin]/지역 관리 - country/지역 수정.bru",
+    definition: {
+      method: "PUT",
+      path: "{{URL}}/admin/countries/{{code}}",
+      pathParamsExample: {
+        "code": ""
+      },
+      queryParamsExample: {},
+      bodyExample: {
+        "koreanName": "오스트리아",
+        "regionCode": "EUROPE"
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "applications",
+    name: "getApplicants",
+    displayName: "지원자 현황 조회",
+    sourceFile: "4) 지원정보 [applications]/지원자 현황 [applicants].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/applications",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "applications",
+    name: "getCompetitors",
+    displayName: "나의 지원과 동일한 지원자 현황 조회",
+    sourceFile: "4) 지원정보 [applications]/경쟁자 현황 [competitors].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/applications/competitors",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "applications",
+    name: "postSubmitApplication",
+    displayName: "지원서 제출",
+    sourceFile: "4) 지원정보 [applications]/지원서 제출 [submit-application].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/applications",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      bodyExample: {
+        "gpaScoreId": 1,
+        "languageTestScoreId": 1,
+        "universityChoiceRequest": {
+          "firstChoiceUniversityId": 1,
+          "secondChoiceUniversityId": 2,
+          "thirdChoiceUniversityId": 3
+        }
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "Auth",
+    name: "deleteAccount",
+    displayName: "회원 탈퇴",
+    sourceFile: "1) 인증 [Auth]/회원 탈퇴 [account].bru",
+    definition: {
+      method: "DELETE",
+      path: "{{URL}}/auth/quit",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "Auth",
+    name: "postAppleAuth",
+    displayName: "애플 인증 (로그인 or 가입 코드 발급)",
+    sourceFile: "1) 인증 [Auth]/애플 인증 [apple-auth].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/auth/apple",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      bodyExample: {
+        "code": "04XcLzhPY8BOihCltYUDXHrloUDYdLn3xQu1juGaoDkw2j6SyvHlsAAAAAQKPXPrAAABk7Gd_pJyxKx5jTsi9A"
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "Auth",
+    name: "postEmailLogin",
+    displayName: "이메일 로그인",
+    sourceFile: "1) 인증 [Auth]/이메일 로그인 [email-login].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/auth/email/sign-in",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      bodyExample: {
+        "email": "test0410@solid-connection.com",
+        "password": "12341234"
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "Auth",
+    name: "postEmailVerification",
+    displayName: "이메일 인증 (가입 코드 발급)",
+    sourceFile: "1) 인증 [Auth]/이메일 인증 [email-verification].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/auth/email/sign-up",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      bodyExample: {
+        "email": "test0410@solid-connection.com",
+        "password": "12341234"
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "Auth",
+    name: "postKakaoAuth",
+    displayName: "카카오 인증 (로그인 or 가입 코드 발급)",
+    sourceFile: "1) 인증 [Auth]/카카오 인증 [kakao-auth].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/auth/kakao",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      bodyExample: {
+        "code": "04XcLzhPY8BOihCltYUDXHrloUDYdLn3xQu1juGaoDkw2j6SyvHlsAAAAAQKPXPrAAABk7Gd_pJyxKx5jTsi9A"
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "Auth",
+    name: "postRefreshToken",
+    displayName: "엑세스 토큰 재발급",
+    sourceFile: "1) 인증 [Auth]/엑세스 토큰 재발급 [refresh-token].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/auth/reissue",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "Auth",
+    name: "postSignOut",
+    displayName: "로그아웃",
+    sourceFile: "1) 인증 [Auth]/로그아웃 [sign-out].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/auth/sign-out",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "Auth",
+    name: "postSignUp",
+    displayName: "회원가입",
+    sourceFile: "1) 인증 [Auth]/회원가입 [sign-up].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/auth/sign-up",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      bodyExample: {
+        "signUpToken": "1234token1234",
+        "interestedRegions": [
+          "미주권"
+        ],
+        "interestedCountries": [
+          "헝가리2"
+        ],
+        "preparationStatus": "CONSIDERING",
+        "nickname": "솔커0410",
+        "profileImageUrl": "http://k.kakaocdn.net/dn/DKxlu/btstVhE45Ub/lP9ZXHVRjFwTZDUqQxg7KK/img_640x640.jpg"
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "chat",
+    name: "getChatMessages",
+    displayName: "채팅 내역 조회",
+    sourceFile: "11) 채팅 [chat]/채팅 내역 [chat-messages].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/chats/rooms/{{room-id}}?size={{default-size}}&page={{default-page}}",
+      pathParamsExample: {
+        "room-id": "",
+        "default-size": "",
+        "default-page": ""
+      },
+      queryParamsExample: {
+        "size": "{{default-size}}",
+        "page": "{{default-page}}"
+      },
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "chat",
+    name: "getChatPartner",
+    displayName: "채팅방 파트너 조회",
+    sourceFile: "11) 채팅 [chat]/채팅방 파트너 [chat-partner].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/chats/rooms/{{room-id}}/partner",
+      pathParamsExample: {
+        "room-id": ""
+      },
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "chat",
+    name: "getChatRooms",
+    displayName: "채팅방 목록 조회",
+    sourceFile: "11) 채팅 [chat]/채팅방 목록 [chat-rooms].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/chats/rooms",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "chat",
+    name: "putReadChatRoom",
+    displayName: "채팅방 읽음 처리",
+    sourceFile: "11) 채팅 [chat]/채팅방 읽음 [read-chat-room].bru",
+    definition: {
+      method: "PUT",
+      path: "{{URL}}/chats/rooms/{{room-id}}/read",
+      pathParamsExample: {
+        "room-id": ""
+      },
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "community",
+    name: "deleteComment",
+    displayName: "댓글 삭제",
+    sourceFile: "5) 커뮤니티 [community]/comments/댓글 삭제 [comment].bru",
+    definition: {
+      method: "DELETE",
+      path: "{{URL}}/comments/{{comment-id}}",
+      pathParamsExample: {
+        "comment-id": ""
+      },
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "community",
+    name: "deleteLikePost",
+    displayName: "게시글 좋아요 삭제",
+    sourceFile: "5) 커뮤니티 [community]/posts/게시글 좋아요 취소 [like-post].bru",
+    definition: {
+      method: "DELETE",
+      path: "{{URL}}/posts/{{post-id}}/like",
+      pathParamsExample: {
+        "post-id": ""
+      },
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "community",
+    name: "deletePost",
+    displayName: "게시글 삭제",
+    sourceFile: "5) 커뮤니티 [community]/posts/게시글 삭제 [post].bru",
+    definition: {
+      method: "DELETE",
+      path: "{{URL}}/posts/{{post-id}}",
+      pathParamsExample: {
+        "post-id": ""
+      },
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "community",
+    name: "getBoard",
+    displayName: "게시판 조회",
+    sourceFile: "5) 커뮤니티 [community]/boards/게시판 조회 [board].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/boards/{{board-code}}",
+      pathParamsExample: {
+        "board-code": ""
+      },
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "community",
+    name: "getBoardList",
+    displayName: "게시판 목록 조회",
+    sourceFile: "5) 커뮤니티 [community]/boards/게시판 목록 [board-list].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/boards",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "community",
+    name: "getPostDetail",
+    displayName: "게시글 조회",
+    sourceFile: "5) 커뮤니티 [community]/posts/게시글 조회 [post-detail].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/posts/{{post-id}}",
+      pathParamsExample: {
+        "post-id": ""
+      },
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "community",
+    name: "patchUpdateComment",
+    displayName: "댓글 수정",
+    sourceFile: "5) 커뮤니티 [community]/comments/댓글 수정 [update-comment].bru",
+    definition: {
+      method: "PATCH",
+      path: "{{URL}}/comments/{{comment-id}}",
+      pathParamsExample: {
+        "comment-id": ""
+      },
+      queryParamsExample: {},
+      bodyExample: {
+        "content": "string222"
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "community",
+    name: "patchUpdatePost",
+    displayName: "게시글 수정",
+    sourceFile: "5) 커뮤니티 [community]/posts/게시글 수정 [update-post].bru",
+    definition: {
+      method: "PATCH",
+      path: "{{URL}}/posts/{{post-id}}",
+      pathParamsExample: {
+        "post-id": ""
+      },
+      queryParamsExample: {},
+      hasBody: true,
+      bodyType: "multipart-form",
+    },
+  },
+  {
+    domain: "community",
+    name: "postCreateComment",
+    displayName: "댓글 작성",
+    sourceFile: "5) 커뮤니티 [community]/comments/댓글 작성 [create-comment].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/comments",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      bodyExample: {
+        "postId": 1,
+        "content": "답변",
+        "parentId": null
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "community",
+    name: "postCreatePost",
+    displayName: "게시글 작성",
+    sourceFile: "5) 커뮤니티 [community]/posts/게시글 작성 [create-post].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/posts",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: true,
+      bodyType: "multipart-form",
+    },
+  },
+  {
+    domain: "community",
+    name: "postLikePost",
+    displayName: "게시글 좋아요 등록",
+    sourceFile: "5) 커뮤니티 [community]/posts/게시글 좋아요 [like-post].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/posts/{{post-id}}/like",
+      pathParamsExample: {
+        "post-id": ""
+      },
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "image-upload",
+    name: "postSlackNotification",
+    displayName: "슬랙 알림",
+    sourceFile: "이미지 업로드 [image-upload]/슬랙 알림 [slack-notification].bru",
+    definition: {
+      method: "POST",
+      path: "https://hooks.slack.com/services/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",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      bodyExample: {
+        "text": "테스트"
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "image-upload",
+    name: "postUploadGpaReport",
+    displayName: "학적 성적표 업로드",
+    sourceFile: "이미지 업로드 [image-upload]/학적 성적표 업로드 [upload-gpa-report].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/file/gpa",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "image-upload",
+    name: "postUploadLanguageTestReport",
+    displayName: "어학 성적표 업로드",
+    sourceFile: "이미지 업로드 [image-upload]/어학 성적표 업로드 [upload-language-test-report].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/file/language-test",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "image-upload",
+    name: "postUploadProfileImage",
+    displayName: "프로필 사진 업로드 (가입 후)",
+    sourceFile: "이미지 업로드 [image-upload]/프로필 사진 업로드 [upload-profile-image].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/file/profile/post",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "image-upload",
+    name: "postUploadProfileImageBeforeSignup",
+    displayName: "프로필 사진 업로드 (가입 전)",
+    sourceFile: "이미지 업로드 [image-upload]/프로필 사진 업로드 가입전 [upload-profile-image-before-signup].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/file/profile/pre",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "kakao-api",
+    name: "getKakaoInfo",
+    displayName: "정보 조회",
+    sourceFile: "99) 카카오 API [kakao-api]/카카오 정보 조회 [kakao-info].bru",
+    definition: {
+      method: "GET",
+      path: "https://kapi.kakao.com/v2/user/me?property_keys=[\"kakao_account.email\"]&target_id_type=user_id&target_id=3715136239",
+      pathParamsExample: {},
+      queryParamsExample: {
+        "property_keys": "[\"kakao_account.email\"]",
+        "target_id_type": "user_id",
+        "target_id": "3715136239"
+      },
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "kakao-api",
+    name: "getKakaoUserIds",
+    displayName: "사용자 id 목록 조회",
+    sourceFile: "99) 카카오 API [kakao-api]/카카오 사용자 ID 목록 [kakao-user-ids].bru",
+    definition: {
+      method: "GET",
+      path: "https://kapi.kakao.com/v1/user/ids?order=dsc",
+      pathParamsExample: {},
+      queryParamsExample: {
+        "order": "dsc"
+      },
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "kakao-api",
+    name: "postKakaoUnlink",
+    displayName: "연결 끊기",
+    sourceFile: "99) 카카오 API [kakao-api]/카카오 연결 끊기 [kakao-unlink].bru",
+    definition: {
+      method: "POST",
+      path: "https://kapi.kakao.com/v1/user/unlink?target_id_type=user_id&target_id=3715136239",
+      pathParamsExample: {},
+      queryParamsExample: {
+        "target_id_type": "user_id",
+        "target_id": "3715136239"
+      },
+      hasBody: true,
+      bodyType: "multipart-form",
+    },
+  },
+  {
+    domain: "mentor",
+    name: "getAppliedMentorings",
+    displayName: "신청한 멘토링 목록",
+    sourceFile: "9) 멘토 [mentor]/mentee-only/신청한 멘토링 목록 [applied-mentorings].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/mentee/mentorings?verify-status={{verify-status}}&size={{default-size}}&page={{default-page}}",
+      pathParamsExample: {
+        "verify-status": "",
+        "default-size": "",
+        "default-page": ""
+      },
+      queryParamsExample: {
+        "verify-status": "{{verify-status}}",
+        "size": "{{default-size}}",
+        "page": "{{default-page}}"
+      },
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "mentor",
+    name: "getMatchedMentors",
+    displayName: "매칭된 멘토 목록",
+    sourceFile: "9) 멘토 [mentor]/mentee-only/매칭된 멘토 목록 [matched-mentors].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/mentee/mentorings/matched-mentors?size={{default-size}}&page={{default-page}}",
+      pathParamsExample: {
+        "default-size": "",
+        "default-page": ""
+      },
+      queryParamsExample: {
+        "size": "{{default-size}}",
+        "page": "{{default-page}}"
+      },
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "mentor",
+    name: "getMentorDetail",
+    displayName: "멘토 상세 조회",
+    sourceFile: "9) 멘토 [mentor]/mentor/멘토 상세 [mentor-detail].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/mentors/{{site-user-id}}",
+      pathParamsExample: {
+        "site-user-id": ""
+      },
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "mentor",
+    name: "getMentorList",
+    displayName: "멘토 목록 조회",
+    sourceFile: "9) 멘토 [mentor]/mentor/멘토 목록 [mentor-list].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/mentors?region=미주권&size={{default-size}}&page={{default-page}}",
+      pathParamsExample: {
+        "default-size": "",
+        "default-page": ""
+      },
+      queryParamsExample: {
+        "region": "미주권",
+        "size": "{{default-size}}",
+        "page": "{{default-page}}"
+      },
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "mentor",
+    name: "getMyMentorPage",
+    displayName: "나의 멘토 페이지 조회",
+    sourceFile: "9) 멘토 [mentor]/mentor-only/나의 멘토 페이지 [my-mentor-page].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/mentor/my",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "mentor",
+    name: "getReceivedMentorings",
+    displayName: "신청받은 멘토링 목록",
+    sourceFile: "9) 멘토 [mentor]/mentor-only/신청받은 멘토링 목록 [received-mentorings].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/mentor/mentorings",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "mentor",
+    name: "getUnconfirmedMentoringCount",
+    displayName: "확인하지 않은 멘토링 수",
+    sourceFile: "9) 멘토 [mentor]/mentor-only/확인하지 않은 멘토링 수 [unconfirmed-mentoring-count].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/mentor/mentorings/check",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "mentor",
+    name: "patchConfirmMentoring",
+    displayName: "멘토링 확인",
+    sourceFile: "9) 멘토 [mentor]/mentee-only/멘토링 확인 [confirm-mentoring].bru",
+    definition: {
+      method: "PATCH",
+      path: "{{URL}}/mentee/mentorings/check",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      bodyExample: {
+        "checkedMentoringIds": [
+          1,
+          2,
+          3
+        ]
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "mentor",
+    name: "patchConfirmMentoring2",
+    displayName: "멘토링 확인",
+    sourceFile: "9) 멘토 [mentor]/mentor-only/멘토링 확인 [confirm-mentoring].bru",
+    definition: {
+      method: "PATCH",
+      path: "{{URL}}/mentor/mentorings/check",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      bodyExample: {
+        "checkedMentoringIds": [
+          1,
+          2,
+          3
+        ]
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "mentor",
+    name: "patchMentoringStatus",
+    displayName: "멘토링 수락/거절",
+    sourceFile: "9) 멘토 [mentor]/mentor-only/멘토링 수락-거절 [mentoring-status].bru",
+    definition: {
+      method: "PATCH",
+      path: "{{URL}}/mentor/mentorings/{{mentoring-id}}",
+      pathParamsExample: {
+        "mentoring-id": ""
+      },
+      queryParamsExample: {},
+      bodyExample: {
+        "status": "APPROVED"
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "mentor",
+    name: "postApplyMentorApplication",
+    displayName: "멘토 승격 요청",
+    sourceFile: "9) 멘토 [mentor]/mentee-only/멘토 승격 요청 [apply-mentor-application].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/mentees/mentor-applications",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: true,
+      bodyType: "multipart-form",
+    },
+  },
+  {
+    domain: "mentor",
+    name: "postApplyMentoring",
+    displayName: "멘토링 신청",
+    sourceFile: "9) 멘토 [mentor]/mentee-only/멘토링 신청 [apply-mentoring].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/mentee/mentorings",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "mentor",
+    name: "postCreateMentorMyPage",
+    displayName: "멘토 마이 페이지 생성",
+    sourceFile: "9) 멘토 [mentor]/mentor-only/멘토 마이 페이지 생성 [create-mentor-my-page].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/mentor/my",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "mentor",
+    name: "putUpdateMyMentorPage",
+    displayName: "나의 멘토 페이지 수정",
+    sourceFile: "9) 멘토 [mentor]/mentor-only/나의 멘토 페이지 수정 [update-my-mentor-page].bru",
+    definition: {
+      method: "PUT",
+      path: "{{URL}}/mentor/my",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      bodyExample: {
+        "channels": [
+          {
+            "type": "BLOG",
+            "url": "https://example.com/blog"
+          },
+          {
+            "type": "YOUTUBE",
+            "url": "https://youtube.com/channel"
+          }
+        ],
+        "passTip": "합격 레시피",
+        "introduction": "멘토 소개글입니다"
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "MyPage",
+    name: "getProfile",
+    displayName: "내 정보 조회",
+    sourceFile: "3) 마이페이지 [MyPage]/내 정보 조회 [profile].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/my",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "MyPage",
+    name: "patchInterestedRegionCountry",
+    displayName: "관심 권역/국가 변경",
+    sourceFile: "3) 마이페이지 [MyPage]/관심 권역-국가 변경 [interested-region-country].bru",
+    definition: {
+      method: "PATCH",
+      path: "{{URL}}/my/interested-location",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      bodyExample: {
+        "interestedRegions": [
+          "아시아권",
+          "유럽권"
+        ],
+        "interestedCountries": [
+          "일본",
+          "프랑스",
+          "미국"
+        ]
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "MyPage",
+    name: "patchPassword",
+    displayName: "비밀번호 변경",
+    sourceFile: "3) 마이페이지 [MyPage]/비밀번호 변경 [password].bru",
+    definition: {
+      method: "PATCH",
+      path: "{{URL}}/my/password",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      bodyExample: {
+        "currentPassword": "1q2w3e4r5t!!!!",
+        "newPassword": "1q2w3e4r5t!!!",
+        "newPasswordConfirmation": "1q2w3e4r5t!!!"
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "MyPage",
+    name: "patchProfile",
+    displayName: "내 정보 수정",
+    sourceFile: "3) 마이페이지 [MyPage]/내 정보 수정 [profile].bru",
+    definition: {
+      method: "PATCH",
+      path: "{{URL}}/my",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: true,
+      bodyType: "multipart-form",
+    },
+  },
+  {
+    domain: "news",
+    name: "deleteLikeNews",
+    displayName: "소식지 좋아요 삭제",
+    sourceFile: "10) 소식지 [news]/소식지 좋아요 취소 [like-news].bru",
+    definition: {
+      method: "DELETE",
+      path: "{{URL}}/news/{{news-id}}/like",
+      pathParamsExample: {
+        "news-id": ""
+      },
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "news",
+    name: "deleteNews",
+    displayName: "소식지 삭제",
+    sourceFile: "10) 소식지 [news]/소식지 삭제 [news].bru",
+    definition: {
+      method: "DELETE",
+      path: "{{URL}}/news/{{news-id}}",
+      pathParamsExample: {
+        "news-id": ""
+      },
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "news",
+    name: "getNewsList",
+    displayName: "소식지 목록 조회",
+    sourceFile: "10) 소식지 [news]/소식지 목록 [news-list].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/news?author-id=6",
+      pathParamsExample: {},
+      queryParamsExample: {
+        "author-id": "6"
+      },
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "news",
+    name: "postCreateNews",
+    displayName: "소식지 추가",
+    sourceFile: "10) 소식지 [news]/소식지 추가 [create-news].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/news",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: true,
+      bodyType: "multipart-form",
+    },
+  },
+  {
+    domain: "news",
+    name: "postLikeNews",
+    displayName: "소식지 좋아요 추가",
+    sourceFile: "10) 소식지 [news]/소식지 좋아요 [like-news].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/news/{{news-id}}/like",
+      pathParamsExample: {
+        "news-id": ""
+      },
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "news",
+    name: "putUpdateNews",
+    displayName: "소식지 수정",
+    sourceFile: "10) 소식지 [news]/소식지 수정 [update-news].bru",
+    definition: {
+      method: "PUT",
+      path: "{{URL}}/news/{{news-id}}",
+      pathParamsExample: {
+        "news-id": ""
+      },
+      queryParamsExample: {},
+      hasBody: true,
+      bodyType: "multipart-form",
+    },
+  },
+  {
+    domain: "reports",
+    name: "postReport",
+    displayName: "신고하기",
+    sourceFile: "11) 신고 [reports]/신고하기 [report].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/reports",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      bodyExample: {
+        "targetType": "POST",
+        "targetId": 1,
+        "reasonType": "SPAM"
+      },
+      hasBody: true,
+      bodyType: "json",
+    },
+  },
+  {
+    domain: "Scores",
+    name: "getGpaList",
+    displayName: "학점 조회",
+    sourceFile: "6) 성적 [Scores]/학점 조회 [gpa-list].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/scores/gpas",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "Scores",
+    name: "getLanguageTestList",
+    displayName: "어학 성적 조회",
+    sourceFile: "6) 성적 [Scores]/어학 성적 조회 [language-test-list].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/scores/language-tests",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "Scores",
+    name: "postCreateGpa",
+    displayName: "학점 등록",
+    sourceFile: "6) 성적 [Scores]/학점 등록 [create-gpa].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/scores/gpas",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: true,
+      bodyType: "multipart-form",
+    },
+  },
+  {
+    domain: "Scores",
+    name: "postCreateLanguageTest",
+    displayName: "어학 성적 등록",
+    sourceFile: "6) 성적 [Scores]/어학 성적 등록 [create-language-test].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/scores/language-tests",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: true,
+      bodyType: "multipart-form",
+    },
+  },
+  {
+    domain: "universities",
+    name: "deleteWish",
+    displayName: "위시 학교 삭제",
+    sourceFile: "2) 대학교 [universities]/univ-apply-infos/위시 학교 삭제 [wish].bru",
+    definition: {
+      method: "DELETE",
+      path: "{{URL}}/univ-apply-infos/{{univ-apply-info-id}}/like",
+      pathParamsExample: {
+        "univ-apply-info-id": ""
+      },
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "universities",
+    name: "getByRegionCountry",
+    displayName: "권역-국가에 해당하는 전체 대학",
+    sourceFile: "2) 대학교 [universities]/universities/권역-국가별 대학 [by-region-country].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/universities/search",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "universities",
+    name: "getIsWish",
+    displayName: "위시 학교인지 조회",
+    sourceFile: "2) 대학교 [universities]/univ-apply-infos/위시 학교 확인 [is-wish].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/univ-apply-infos/{{univ-apply-info-id}}/like",
+      pathParamsExample: {
+        "univ-apply-info-id": ""
+      },
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "universities",
+    name: "getRecommendedUniversities",
+    displayName: "맞춤 대학 추천",
+    sourceFile: "2) 대학교 [universities]/univ-apply-infos/맞춤 대학 추천 [recommended-universities].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/univ-apply-infos/recommend",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "universities",
+    name: "getSearchText",
+    displayName: "학교 텍스트 검색",
+    sourceFile: "2) 대학교 [universities]/univ-apply-infos/학교 텍스트 검색 [search-text].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/univ-apply-infos/search/text?value=일본",
+      pathParamsExample: {},
+      queryParamsExample: {
+        "value": "일본"
+      },
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "universities",
+    name: "getUniversityDetail",
+    displayName: "학교 상세 정보 조회",
+    sourceFile: "2) 대학교 [universities]/univ-apply-infos/학교 상세 정보 [university-detail].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/univ-apply-infos/{{univ-apply-info-id}}",
+      pathParamsExample: {
+        "univ-apply-info-id": ""
+      },
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "universities",
+    name: "getWishList",
+    displayName: "위시 학교 목록 조회",
+    sourceFile: "2) 대학교 [universities]/univ-apply-infos/위시 학교 목록 [wish-list].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/univ-apply-infos/like",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "universities",
+    name: "postAddWish",
+    displayName: "위시 학교 추가",
+    sourceFile: "2) 대학교 [universities]/univ-apply-infos/위시 학교 추가 [add-wish].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/univ-apply-infos/{{univ-apply-info-id}}/like",
+      pathParamsExample: {
+        "univ-apply-info-id": ""
+      },
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "users",
+    name: "deleteUnblockUser",
+    displayName: "유저 차단 취소",
+    sourceFile: "8) 사용자 [users]/유저 차단 취소 [unblock-user].bru",
+    definition: {
+      method: "DELETE",
+      path: "{{URL}}/users/block/{{blocked-id}}",
+      pathParamsExample: {
+        "blocked-id": ""
+      },
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "users",
+    name: "getBlockedUsers",
+    displayName: "차단한 유저 목록 조회",
+    sourceFile: "8) 사용자 [users]/차단한 유저 목록 [blocked-users].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/users/blocks",
+      pathParamsExample: {},
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "users",
+    name: "getNicknameExists",
+    displayName: "닉네임 중복 검증",
+    sourceFile: "8) 사용자 [users]/닉네임 중복 검증 [nickname-exists].bru",
+    definition: {
+      method: "GET",
+      path: "{{URL}}/users/exists?nickname=abc",
+      pathParamsExample: {},
+      queryParamsExample: {
+        "nickname": "abc"
+      },
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+  {
+    domain: "users",
+    name: "postBlockUser",
+    displayName: "유저 차단",
+    sourceFile: "8) 사용자 [users]/유저 차단 [block-user].bru",
+    definition: {
+      method: "POST",
+      path: "{{URL}}/users/block/{{blocked-id}}",
+      pathParamsExample: {
+        "blocked-id": ""
+      },
+      queryParamsExample: {},
+      hasBody: false,
+      bodyType: null,
+    },
+  },
+] as const satisfies readonly BrunoApiDefinitionRegistryItem[];
+
+export type BrunoApiDefinitionRegistry = typeof brunoApiDefinitionRegistry;

--- a/packages/api-schema/src/apiDefinitionRegistry.ts
+++ b/packages/api-schema/src/apiDefinitionRegistry.ts
@@ -11,6 +11,7 @@ export interface BrunoApiDefinitionRegistryItem {
     bodyExample?: unknown;
     hasBody: boolean;
     bodyType: string | null;
+    canExecute?: boolean;
   };
 }
 
@@ -124,6 +125,7 @@ export const brunoApiDefinitionRegistry = [
         "page": "2",
         "size": "10",
         "mentorApplicationStatus": "PENDING",
+        "nickname": "",
         "createdAt": "2025-11-14"
       },
       hasBody: false,
@@ -530,9 +532,7 @@ export const brunoApiDefinitionRegistry = [
       method: "GET",
       path: "{{URL}}/chats/rooms/{{room-id}}?size={{default-size}}&page={{default-page}}",
       pathParamsExample: {
-        "room-id": "",
-        "default-size": "",
-        "default-page": ""
+        "room-id": ""
       },
       queryParamsExample: {
         "size": "{{default-size}}",
@@ -773,7 +773,7 @@ export const brunoApiDefinitionRegistry = [
     sourceFile: "이미지 업로드 [image-upload]/슬랙 알림 [slack-notification].bru",
     definition: {
       method: "POST",
-      path: "https://hooks.slack.com/services/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",
+      path: "SLACK_WEBHOOK_URL",
       pathParamsExample: {},
       queryParamsExample: {},
       bodyExample: {
@@ -781,6 +781,7 @@ export const brunoApiDefinitionRegistry = [
       },
       hasBody: true,
       bodyType: "json",
+      canExecute: false,
     },
   },
   {
@@ -795,6 +796,7 @@ export const brunoApiDefinitionRegistry = [
       queryParamsExample: {},
       hasBody: false,
       bodyType: null,
+      canExecute: false,
     },
   },
   {
@@ -809,6 +811,7 @@ export const brunoApiDefinitionRegistry = [
       queryParamsExample: {},
       hasBody: false,
       bodyType: null,
+      canExecute: false,
     },
   },
   {
@@ -823,6 +826,7 @@ export const brunoApiDefinitionRegistry = [
       queryParamsExample: {},
       hasBody: false,
       bodyType: null,
+      canExecute: false,
     },
   },
   {
@@ -837,6 +841,7 @@ export const brunoApiDefinitionRegistry = [
       queryParamsExample: {},
       hasBody: false,
       bodyType: null,
+      canExecute: false,
     },
   },
   {
@@ -898,11 +903,7 @@ export const brunoApiDefinitionRegistry = [
     definition: {
       method: "GET",
       path: "{{URL}}/mentee/mentorings?verify-status={{verify-status}}&size={{default-size}}&page={{default-page}}",
-      pathParamsExample: {
-        "verify-status": "",
-        "default-size": "",
-        "default-page": ""
-      },
+      pathParamsExample: {},
       queryParamsExample: {
         "verify-status": "{{verify-status}}",
         "size": "{{default-size}}",
@@ -920,10 +921,7 @@ export const brunoApiDefinitionRegistry = [
     definition: {
       method: "GET",
       path: "{{URL}}/mentee/mentorings/matched-mentors?size={{default-size}}&page={{default-page}}",
-      pathParamsExample: {
-        "default-size": "",
-        "default-page": ""
-      },
+      pathParamsExample: {},
       queryParamsExample: {
         "size": "{{default-size}}",
         "page": "{{default-page}}"
@@ -956,10 +954,7 @@ export const brunoApiDefinitionRegistry = [
     definition: {
       method: "GET",
       path: "{{URL}}/mentors?region=미주권&size={{default-size}}&page={{default-page}}",
-      pathParamsExample: {
-        "default-size": "",
-        "default-page": ""
-      },
+      pathParamsExample: {},
       queryParamsExample: {
         "region": "미주권",
         "size": "{{default-size}}",

--- a/packages/bruno-api-typescript/src/generator/apiClientGenerator.ts
+++ b/packages/bruno-api-typescript/src/generator/apiClientGenerator.ts
@@ -17,6 +17,17 @@ export interface ApiFunction {
   hasBody: boolean;
 }
 
+const SLACK_WEBHOOK_URL_PLACEHOLDER = 'SLACK_WEBHOOK_URL';
+
+function getPathOnly(url: string): string {
+  const questionMarkIndex = url.indexOf('?');
+  return questionMarkIndex >= 0 ? url.slice(0, questionMarkIndex) : url;
+}
+
+function sanitizeGeneratedUrl(url: string): string {
+  return /^https:\/\/hooks\.slack\.com\/services\//i.test(url) ? SLACK_WEBHOOK_URL_PLACEHOLDER : url;
+}
+
 /**
  * Bruno 파일로부터 API 함수 정보 추출
  */
@@ -64,6 +75,8 @@ export function extractApiFunction(parsed: ParsedBrunoFile, filePath: string): A
  */
 export function generateApiFunction(apiFunc: ApiFunction, domain: string): string {
   const { name, method, url, responseType, hasParams, hasBody } = apiFunc;
+  const sanitizedUrl = sanitizeGeneratedUrl(url);
+  const pathOnlyUrl = getPathOnly(sanitizedUrl);
 
   const lines: string[] = [];
 
@@ -72,7 +85,7 @@ export function generateApiFunction(apiFunc: ApiFunction, domain: string): strin
   const urlParams: string[] = [];
 
   // URL 파라미터 추출
-  const urlParamMatches = url.matchAll(/:(\w+)|\{(\w+)\}/g);
+  const urlParamMatches = pathOnlyUrl.matchAll(/:(\w+)|\{(\w+)\}/g);
   for (const match of urlParamMatches) {
     const paramName = match[1] || match[2];
     urlParams.push(paramName);
@@ -94,7 +107,7 @@ export function generateApiFunction(apiFunc: ApiFunction, domain: string): strin
   const paramsType = paramsList.length > 0 ? `params: ${paramsStr}` : '';
 
   // URL 생성 로직
-  let urlExpression = `\`${url}\``;
+  let urlExpression = `\`${sanitizedUrl}\``;
   for (const param of urlParams) {
     urlExpression = urlExpression.replace(`:${param}`, `\${params.${param}}`);
     urlExpression = urlExpression.replace(`{${param}}`, `\${params.${param}}`);

--- a/packages/bruno-api-typescript/src/generator/apiDefinitionGenerator.ts
+++ b/packages/bruno-api-typescript/src/generator/apiDefinitionGenerator.ts
@@ -8,12 +8,26 @@ import { ApiFunction } from './apiClientGenerator';
 import { toCamelCase, toObjectPropertyKey } from './typeGenerator';
 
 export interface ApiDefinitionMeta {
+  displayName: string;
+  sourceFile?: string;
   method: string;
   path: string;
   pathParams: string;
   queryParams: string;
   body: string;
   response: string;
+  pathParamsExample: Record<string, string>;
+  queryParamsExample: Record<string, unknown>;
+  bodyExample: unknown;
+  hasBody: boolean;
+  bodyType: string | null;
+}
+
+export interface ApiDefinitionInput {
+  apiFunc: ApiFunction;
+  parsed: ParsedBrunoFile;
+  filePath?: string;
+  sourceFile?: string;
 }
 
 function toPascalCase(value: string): string {
@@ -54,15 +68,87 @@ function extractPathParams(url: string): string[] {
   return params;
 }
 
+function extractPathParamTokens(url: string): string[] {
+  const params: string[] = [];
+  let processedUrl = url.replace(/\{\{URL\}\}/g, '');
+
+  const brunoVarPattern = /\{\{([^}]+)\}\}/g;
+  let match;
+  while ((match = brunoVarPattern.exec(processedUrl)) !== null) {
+    const varName = match[1];
+    if (varName === 'URL') continue;
+    if (!params.includes(varName)) {
+      params.push(varName);
+    }
+  }
+
+  processedUrl = processedUrl.replace(/\{\{[^}]+\}\}/g, '');
+
+  const urlParamMatches = processedUrl.matchAll(/:(\w+)|\{(\w+)\}/g);
+  for (const match of urlParamMatches) {
+    const paramName = match[1] || match[2];
+    if (!params.includes(paramName)) {
+      params.push(paramName);
+    }
+  }
+
+  return params;
+}
+
+function extractInlineQueryParams(url: string): Record<string, string> {
+  const questionMarkIndex = url.indexOf('?');
+  if (questionMarkIndex < 0) {
+    return {};
+  }
+
+  const queryString = url.slice(questionMarkIndex + 1);
+  return Object.fromEntries(
+    Array.from(new URLSearchParams(queryString)).filter(([, value]) => value.trim().length > 0),
+  );
+}
+
+function parseBodyExample(parsed: ParsedBrunoFile): unknown {
+  if (!parsed.body?.content?.trim() || parsed.body.type !== 'json') {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(parsed.body.content);
+  } catch {
+    return undefined;
+  }
+}
+
+function toTsLiteral(value: unknown, indent = 0): string {
+  if (value === undefined) {
+    return 'undefined';
+  }
+
+  const literal = JSON.stringify(value, null, 2) ?? 'undefined';
+  if (indent === 0) {
+    return literal;
+  }
+
+  const padding = ' '.repeat(indent);
+  return literal
+    .split('\n')
+    .map((line, index) => (index === 0 ? line : `${padding}${line}`))
+    .join('\n');
+}
+
 /**
  * Generate API definition metadata for a single API function
  */
 export function generateApiDefinitionMeta(
   apiFunc: ApiFunction,
-  parsed: ParsedBrunoFile
+  parsed: ParsedBrunoFile,
+  sourceFile?: string
 ): ApiDefinitionMeta {
   const { method, url, responseType } = apiFunc;
   const pathParams = extractPathParams(url);
+  const pathParamTokens = extractPathParamTokens(url);
+  const bodyExample = parseBodyExample(parsed);
+  const bodyTypeName = parsed.body?.type ?? null;
   
   const pathParamsType = pathParams.length > 0 
     ? `{ ${pathParams.map(p => `${p}: string | number`).join('; ')} }`
@@ -77,12 +163,22 @@ export function generateApiDefinitionMeta(
   const bodyType = hasBody ? requestType : 'Record<string, never>';
   
   return {
+    displayName: parsed.meta.name || apiFunc.name,
+    sourceFile,
     method,
     path: url,
     pathParams: pathParamsType,
     queryParams: queryParamsType,
     body: bodyType,
     response: responseType,
+    pathParamsExample: Object.fromEntries(pathParamTokens.map((paramName) => [paramName, ''])),
+    queryParamsExample: {
+      ...extractInlineQueryParams(url),
+      ...(parsed.queryParams ?? {}),
+    },
+    bodyExample,
+    hasBody: method !== 'GET' && method !== 'HEAD' && Boolean(parsed.body?.content?.trim()),
+    bodyType: bodyTypeName,
   };
 }
 
@@ -90,15 +186,15 @@ export function generateApiDefinitionMeta(
  * Generate apiDefinitions.ts file content
  */
 export function generateApiDefinitionsFile(
-  apiFunctions: Array<{ apiFunc: ApiFunction; parsed: ParsedBrunoFile }>,
+  apiFunctions: ApiDefinitionInput[],
   domain: string
 ): string {
   const lines: string[] = [];
   
   const typeNames = new Set<string>();
   
-  for (const { apiFunc, parsed } of apiFunctions) {
-    const meta = generateApiDefinitionMeta(apiFunc, parsed);
+  for (const { apiFunc, parsed, sourceFile } of apiFunctions) {
+    const meta = generateApiDefinitionMeta(apiFunc, parsed, sourceFile);
     
     if (meta.response !== 'void') {
       typeNames.add(meta.response);
@@ -118,18 +214,27 @@ export function generateApiDefinitionsFile(
   const definitionsTypeName = `${toPascalCase(domain)}ApiDefinitions`;
   lines.push(`export const ${definitionsConstName} = {`);
   
-  for (const { apiFunc, parsed } of apiFunctions) {
-    const meta = generateApiDefinitionMeta(apiFunc, parsed);
+  for (const { apiFunc, parsed, sourceFile } of apiFunctions) {
+    const meta = generateApiDefinitionMeta(apiFunc, parsed, sourceFile);
     const bodyValue = `undefined as unknown as ${meta.body}`;
     const responseValue = `undefined as unknown as ${meta.response}`;
     
     lines.push(`  ${toObjectPropertyKey(apiFunc.name)}: {`);
-    lines.push(`    method: '${meta.method}' as const,`);
-    lines.push(`    path: '${meta.path}' as const,`);
+    lines.push(`    displayName: ${JSON.stringify(meta.displayName)},`);
+    if (sourceFile) {
+      lines.push(`    sourceFile: ${JSON.stringify(sourceFile)},`);
+    }
+    lines.push(`    method: ${JSON.stringify(meta.method)} as const,`);
+    lines.push(`    path: ${JSON.stringify(meta.path)} as const,`);
     lines.push(`    pathParams: {} as ${meta.pathParams},`);
     lines.push(`    queryParams: {} as ${meta.queryParams},`);
     lines.push(`    body: ${bodyValue},`);
     lines.push(`    response: ${responseValue},`);
+    lines.push(`    pathParamsExample: ${toTsLiteral(meta.pathParamsExample, 4)},`);
+    lines.push(`    queryParamsExample: ${toTsLiteral(meta.queryParamsExample, 4)},`);
+    lines.push(`    bodyExample: ${toTsLiteral(meta.bodyExample, 4)},`);
+    lines.push(`    hasBody: ${meta.hasBody},`);
+    lines.push(`    bodyType: ${toTsLiteral(meta.bodyType)},`);
     lines.push(`  },`);
   }
   
@@ -138,5 +243,58 @@ export function generateApiDefinitionsFile(
   
   lines.push(`export type ${definitionsTypeName} = typeof ${definitionsConstName};`);
   
+  return lines.join('\n');
+}
+
+export function generateApiDefinitionRegistryFile(
+  apiFunctions: Array<ApiDefinitionInput & { domain: string }>
+): string {
+  const lines: string[] = [
+    'export interface BrunoApiDefinitionRegistryItem {',
+    '  domain: string;',
+    '  name: string;',
+    '  displayName: string;',
+    '  sourceFile?: string;',
+    '  definition: {',
+    "    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS';",
+    '    path: string;',
+    '    pathParamsExample: Record<string, string>;',
+    '    queryParamsExample: Record<string, unknown>;',
+    '    bodyExample?: unknown;',
+    '    hasBody: boolean;',
+    '    bodyType: string | null;',
+    '  };',
+    '}',
+    '',
+    'export const brunoApiDefinitionRegistry = [',
+  ];
+
+  for (const { apiFunc, parsed, domain, sourceFile } of apiFunctions) {
+    const meta = generateApiDefinitionMeta(apiFunc, parsed, sourceFile);
+    lines.push('  {');
+    lines.push(`    domain: ${JSON.stringify(domain)},`);
+    lines.push(`    name: ${JSON.stringify(apiFunc.name)},`);
+    lines.push(`    displayName: ${JSON.stringify(meta.displayName)},`);
+    if (meta.sourceFile) {
+      lines.push(`    sourceFile: ${JSON.stringify(meta.sourceFile)},`);
+    }
+    lines.push('    definition: {');
+    lines.push(`      method: ${JSON.stringify(meta.method)},`);
+    lines.push(`      path: ${JSON.stringify(meta.path)},`);
+    lines.push(`      pathParamsExample: ${toTsLiteral(meta.pathParamsExample, 6)},`);
+    lines.push(`      queryParamsExample: ${toTsLiteral(meta.queryParamsExample, 6)},`);
+    if (meta.bodyExample !== undefined) {
+      lines.push(`      bodyExample: ${toTsLiteral(meta.bodyExample, 6)},`);
+    }
+    lines.push(`      hasBody: ${meta.hasBody},`);
+    lines.push(`      bodyType: ${toTsLiteral(meta.bodyType)},`);
+    lines.push('    },');
+    lines.push('  },');
+  }
+
+  lines.push('] as const satisfies readonly BrunoApiDefinitionRegistryItem[];');
+  lines.push('');
+  lines.push('export type BrunoApiDefinitionRegistry = typeof brunoApiDefinitionRegistry;');
+
   return lines.join('\n');
 }

--- a/packages/bruno-api-typescript/src/generator/apiDefinitionGenerator.ts
+++ b/packages/bruno-api-typescript/src/generator/apiDefinitionGenerator.ts
@@ -21,6 +21,7 @@ export interface ApiDefinitionMeta {
   bodyExample: unknown;
   hasBody: boolean;
   bodyType: string | null;
+  canExecute: boolean;
 }
 
 export interface ApiDefinitionInput {
@@ -35,17 +36,49 @@ function toPascalCase(value: string): string {
   return `${camel.charAt(0).toUpperCase()}${camel.slice(1)}`;
 }
 
+const SLACK_WEBHOOK_URL_PLACEHOLDER = 'SLACK_WEBHOOK_URL';
+
+function getPathOnly(url: string): string {
+  const questionMarkIndex = url.indexOf('?');
+  return questionMarkIndex >= 0 ? url.slice(0, questionMarkIndex) : url;
+}
+
+function isSensitiveWebhookUrl(url: string): boolean {
+  return /^https:\/\/hooks\.slack\.com\/services\//i.test(url);
+}
+
+function sanitizeApiDefinitionPath(url: string): string {
+  return isSensitiveWebhookUrl(url) ? SLACK_WEBHOOK_URL_PLACEHOLDER : url;
+}
+
+function isUploadLikeEndpoint(url: string, sourceFile?: string): boolean {
+  const path = getPathOnly(url).replace(/\{\{URL\}\}/g, '');
+  return /(?:^|\/)file(?:\/|$)/i.test(path) || /upload|업로드/i.test(sourceFile ?? '');
+}
+
+function shouldAllowExecution(method: string, url: string, parsed: ParsedBrunoFile, sourceFile?: string): boolean {
+  if (isSensitiveWebhookUrl(url) || parsed.body?.type === 'multipart-form') {
+    return false;
+  }
+
+  const hasParsedBody = Boolean(parsed.body?.content?.trim());
+  if (method !== 'GET' && method !== 'HEAD' && !hasParsedBody && isUploadLikeEndpoint(url, sourceFile)) {
+    return false;
+  }
+
+  return true;
+}
+
 /**
  * Extract URL parameters from a path
  */
 function extractPathParams(url: string): string[] {
   const params: string[] = [];
   
-  let processedUrl = url.replace(/\{\{URL\}\}/g, '');
+  let processedUrl = getPathOnly(url).replace(/\{\{URL\}\}/g, '');
   
   const brunoVarPattern = /\{\{([^}]+)\}\}/g;
-  let match;
-  while ((match = brunoVarPattern.exec(processedUrl)) !== null) {
+  for (const match of processedUrl.matchAll(brunoVarPattern)) {
     const varName = match[1];
     if (varName === 'URL') continue;
     const camelVarName = toCamelCase(varName);
@@ -70,11 +103,10 @@ function extractPathParams(url: string): string[] {
 
 function extractPathParamTokens(url: string): string[] {
   const params: string[] = [];
-  let processedUrl = url.replace(/\{\{URL\}\}/g, '');
+  let processedUrl = getPathOnly(url).replace(/\{\{URL\}\}/g, '');
 
   const brunoVarPattern = /\{\{([^}]+)\}\}/g;
-  let match;
-  while ((match = brunoVarPattern.exec(processedUrl)) !== null) {
+  for (const match of processedUrl.matchAll(brunoVarPattern)) {
     const varName = match[1];
     if (varName === 'URL') continue;
     if (!params.includes(varName)) {
@@ -102,9 +134,7 @@ function extractInlineQueryParams(url: string): Record<string, string> {
   }
 
   const queryString = url.slice(questionMarkIndex + 1);
-  return Object.fromEntries(
-    Array.from(new URLSearchParams(queryString)).filter(([, value]) => value.trim().length > 0),
-  );
+  return Object.fromEntries(Array.from(new URLSearchParams(queryString)).map(([key, value]) => [key, value.trim()]));
 }
 
 function parseBodyExample(parsed: ParsedBrunoFile): unknown {
@@ -145,6 +175,7 @@ export function generateApiDefinitionMeta(
   sourceFile?: string
 ): ApiDefinitionMeta {
   const { method, url, responseType } = apiFunc;
+  const sanitizedPath = sanitizeApiDefinitionPath(url);
   const pathParams = extractPathParams(url);
   const pathParamTokens = extractPathParamTokens(url);
   const bodyExample = parseBodyExample(parsed);
@@ -159,14 +190,14 @@ export function generateApiDefinitionMeta(
     : 'Record<string, never>';
     
   const requestType = responseType.replace('Response', 'Request');
-  const hasBody = ['POST', 'PUT', 'PATCH'].includes(method) && Boolean(parsed.body?.content?.trim());
+  const hasBody = method !== 'GET' && method !== 'HEAD' && Boolean(parsed.body?.content?.trim());
   const bodyType = hasBody ? requestType : 'Record<string, never>';
   
   return {
     displayName: parsed.meta.name || apiFunc.name,
     sourceFile,
     method,
-    path: url,
+    path: sanitizedPath,
     pathParams: pathParamsType,
     queryParams: queryParamsType,
     body: bodyType,
@@ -177,8 +208,9 @@ export function generateApiDefinitionMeta(
       ...(parsed.queryParams ?? {}),
     },
     bodyExample,
-    hasBody: method !== 'GET' && method !== 'HEAD' && Boolean(parsed.body?.content?.trim()),
+    hasBody,
     bodyType: bodyTypeName,
+    canExecute: shouldAllowExecution(method, url, parsed, sourceFile),
   };
 }
 
@@ -235,6 +267,7 @@ export function generateApiDefinitionsFile(
     lines.push(`    bodyExample: ${toTsLiteral(meta.bodyExample, 4)},`);
     lines.push(`    hasBody: ${meta.hasBody},`);
     lines.push(`    bodyType: ${toTsLiteral(meta.bodyType)},`);
+    lines.push(`    canExecute: ${meta.canExecute},`);
     lines.push(`  },`);
   }
   
@@ -263,6 +296,7 @@ export function generateApiDefinitionRegistryFile(
     '    bodyExample?: unknown;',
     '    hasBody: boolean;',
     '    bodyType: string | null;',
+    '    canExecute?: boolean;',
     '  };',
     '}',
     '',
@@ -288,6 +322,7 @@ export function generateApiDefinitionRegistryFile(
     }
     lines.push(`      hasBody: ${meta.hasBody},`);
     lines.push(`      bodyType: ${toTsLiteral(meta.bodyType)},`);
+    lines.push(`      canExecute: ${meta.canExecute},`);
     lines.push('    },');
     lines.push('  },');
   }

--- a/packages/bruno-api-typescript/src/generator/apiFactoryGenerator.ts
+++ b/packages/bruno-api-typescript/src/generator/apiFactoryGenerator.ts
@@ -7,6 +7,12 @@ import { ParsedBrunoFile, extractJsonFromDocs } from '../parser/bruParser';
 import { ApiFunction } from './apiClientGenerator';
 import { generateTypeScriptInterface, toCamelCase, functionNameToTypeName, toObjectPropertyKey } from './typeGenerator';
 
+const SLACK_WEBHOOK_URL_PLACEHOLDER = 'SLACK_WEBHOOK_URL';
+
+function sanitizeGeneratedUrl(url: string): string {
+  return /^https:\/\/hooks\.slack\.com\/services\//i.test(url) ? SLACK_WEBHOOK_URL_PLACEHOLDER : url;
+}
+
 /**
  * 빈 인터페이스를 Record<string, never> 타입으로 변환
  */
@@ -33,7 +39,7 @@ function generateApiFunctionForFactory(apiFunc: ApiFunction, parsed: ParsedBruno
 
   // URL 생성 로직
   // 1. {{URL}} 제거
-  let processedUrl = url.replace(/\{\{URL\}\}/g, '');
+  let processedUrl = sanitizeGeneratedUrl(url).replace(/\{\{URL\}\}/g, '');
 
   // 2. 브루노 변수 {{변수명}} 처리 (URL 파라미터로 변환)
   const brunoVarPattern = /\{\{([^}]+)\}\}/g;

--- a/packages/bruno-api-typescript/src/generator/index.ts
+++ b/packages/bruno-api-typescript/src/generator/index.ts
@@ -9,7 +9,7 @@ import { parseBrunoFile } from '../parser/bruParser';
 import { extractApiFunction } from './apiClientGenerator';
 import { generateMSWHandler, generateDomainHandlersIndex, generateMSWIndex } from './mswGenerator';
 import { generateApiFactory } from './apiFactoryGenerator';
-import { generateApiDefinitionsFile } from './apiDefinitionGenerator';
+import { generateApiDefinitionsFile, generateApiDefinitionRegistryFile } from './apiDefinitionGenerator';
 import { BrunoHashCache } from './brunoHashCache';
 import { functionNameToTypeName, toCamelCase } from './typeGenerator';
 
@@ -81,6 +81,7 @@ export async function generateHooks(options: GenerateHooksOptions): Promise<void
 
   const hashCache = new BrunoHashCache(outputDir);
   hashCache.load();
+  const registryPath = join(dirname(outputDir), 'apiDefinitionRegistry.ts');
 
   console.log('🔍 Searching for .bru files...');
   const brunoFiles = findBrunoFiles(brunoDir);
@@ -110,7 +111,7 @@ export async function generateHooks(options: GenerateHooksOptions): Promise<void
 
   console.log(`📊 Changed: ${changedFiles.length}, Skipped: ${skippedFiles.length}`);
 
-  if (changedFiles.length === 0) {
+  if (changedFiles.length === 0 && existsSync(registryPath)) {
     console.log('✅ All API clients are up to date!');
     return;
   }
@@ -165,7 +166,7 @@ export async function generateHooks(options: GenerateHooksOptions): Promise<void
 
   const affectedDomains = new Set(parsedChangedFiles.map(f => f.domain));
 
-  const domainApiFunctions = new Map<string, Array<{ apiFunc: any; parsed: any }>>();
+  const domainApiFunctions = new Map<string, Array<{ apiFunc: any; parsed: any; filePath: string; sourceFile: string }>>();
   const domainDirs = new Set<string>();
   const domainFunctionNameCounts = new Map<string, number>();
 
@@ -191,7 +192,12 @@ export async function generateHooks(options: GenerateHooksOptions): Promise<void
     if (!domainApiFunctions.has(domain)) {
       domainApiFunctions.set(domain, []);
     }
-    domainApiFunctions.get(domain)!.push({ apiFunc, parsed });
+    domainApiFunctions.get(domain)!.push({
+      apiFunc,
+      parsed,
+      filePath,
+      sourceFile: relative(brunoDir, filePath),
+    });
   }
 
   console.log('\n🏭 Generating API factories...');
@@ -268,6 +274,26 @@ export async function generateHooks(options: GenerateHooksOptions): Promise<void
   const rootIndexPath = join(outputDir, 'index.ts');
   writeFileSync(rootIndexPath, rootIndexContent, 'utf-8');
   console.log(`✅ Generated: ${rootIndexPath}`);
+
+  const registryEntries = Array.from(domainApiFunctions.entries())
+    .flatMap(([domain, apiFunctions]) => apiFunctions.map(apiFunction => ({ ...apiFunction, domain })))
+    .sort((a, b) => {
+      const domainCompare = a.domain.localeCompare(b.domain);
+      if (domainCompare !== 0) {
+        return domainCompare;
+      }
+
+      const nameCompare = a.apiFunc.name.localeCompare(b.apiFunc.name);
+      if (nameCompare !== 0) {
+        return nameCompare;
+      }
+
+      return a.sourceFile.localeCompare(b.sourceFile);
+    });
+
+  const registryContent = generateApiDefinitionRegistryFile(registryEntries);
+  writeFileSync(registryPath, registryContent, 'utf-8');
+  console.log(`✅ Generated: ${registryPath}`);
 
   hashCache.cleanup();
   hashCache.save();

--- a/packages/bruno-api-typescript/src/parser/bruParser.ts
+++ b/packages/bruno-api-typescript/src/parser/bruParser.ts
@@ -31,6 +31,8 @@ export interface ParsedBrunoFile {
     url: string;
   };
   headers?: Record<string, string>;
+  queryParams?: Record<string, string>;
+  disabledQueryParams?: Record<string, string>;
   auth?: {
     type: string;
     [key: string]: any;
@@ -68,6 +70,7 @@ export function parseBrunoFile(filePath: string): ParsedBrunoFile {
   let currentBlock: string | null = null;
   let blockContent: string[] = [];
   let inCodeBlock = false;
+  let bodyNestedBraceDepth = 0;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
@@ -99,9 +102,19 @@ export function parseBrunoFile(filePath: string): ParsedBrunoFile {
       currentBlock = 'headers';
       blockContent = [];
       continue;
-    } else if (trimmed === 'body:json {') {
-      currentBlock = 'body';
+    } else if (trimmed === 'params:query {') {
+      currentBlock = 'params:query';
       blockContent = [];
+      continue;
+    } else if (trimmed.match(/^body:([a-zA-Z0-9_-]+)\s*\{/)) {
+      currentBlock = 'body';
+      const bodyTypeMatch = trimmed.match(/^body:([a-zA-Z0-9_-]+)\s*\{/);
+      if (bodyTypeMatch) {
+        blockContent = [`__body_type__:${bodyTypeMatch[1]}`];
+      } else {
+        blockContent = [];
+      }
+      bodyNestedBraceDepth = 0;
       continue;
     } else if (trimmed === 'docs {') {
       currentBlock = 'docs';
@@ -123,7 +136,7 @@ export function parseBrunoFile(filePath: string): ParsedBrunoFile {
     }
 
     // 블록 종료 감지
-    if (trimmed === '}' && currentBlock && !inCodeBlock) {
+    if (trimmed === '}' && currentBlock && !inCodeBlock && !(currentBlock === 'body' && bodyNestedBraceDepth > 0)) {
       // 블록 파싱
       parseBlock(result, currentBlock, blockContent);
       currentBlock = null;
@@ -143,10 +156,51 @@ export function parseBrunoFile(filePath: string): ParsedBrunoFile {
         }
       }
       blockContent.push(line);
+      if (currentBlock === 'body') {
+        bodyNestedBraceDepth += countStructuralBraces(line);
+        if (bodyNestedBraceDepth < 0) {
+          bodyNestedBraceDepth = 0;
+        }
+      }
     }
   }
 
   return result;
+}
+
+function countStructuralBraces(line: string): number {
+  let delta = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (const char of line) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+
+    if (char === '"') {
+      inString = !inString;
+      continue;
+    }
+
+    if (inString) {
+      continue;
+    }
+
+    if (char === '{') {
+      delta += 1;
+    } else if (char === '}') {
+      delta -= 1;
+    }
+  }
+
+  return delta;
 }
 
 /**
@@ -162,6 +216,9 @@ function parseBlock(result: ParsedBrunoFile, blockName: string, content: string[
       break;
     case 'headers':
       parseHeaders(result, content);
+      break;
+    case 'params:query':
+      parseQueryParams(result, content);
       break;
     case 'body':
       parseBody(result, content);
@@ -232,12 +289,49 @@ function parseHeaders(result: ParsedBrunoFile, lines: string[]): void {
 }
 
 /**
+ * Query params 블록 파싱
+ */
+function parseQueryParams(result: ParsedBrunoFile, lines: string[]): void {
+  result.queryParams = {};
+  result.disabledQueryParams = {};
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    const disabled = trimmed.startsWith('~');
+    const normalizedLine = disabled ? trimmed.slice(1).trim() : trimmed;
+    const colonIndex = normalizedLine.indexOf(':');
+
+    if (colonIndex < 0) {
+      continue;
+    }
+
+    const key = normalizedLine.substring(0, colonIndex).trim();
+    const value = normalizedLine.substring(colonIndex + 1).trim();
+
+    if (!key || !value) {
+      continue;
+    }
+
+    if (disabled) {
+      result.disabledQueryParams[key] = value;
+    } else {
+      result.queryParams[key] = value;
+    }
+  }
+}
+
+/**
  * body 블록 파싱
  */
 function parseBody(result: ParsedBrunoFile, lines: string[]): void {
-  const content = lines.join('\n').trim();
+  const bodyTypeLine = lines[0]?.startsWith('__body_type__:') ? lines[0] : null;
+  const type = bodyTypeLine ? bodyTypeLine.replace('__body_type__:', '').trim() : 'json';
+  const bodyLines = bodyTypeLine ? lines.slice(1) : lines;
+  const content = bodyLines.join('\n').trim();
   result.body = {
-    type: 'json',
+    type,
     content,
   };
 }

--- a/packages/bruno-api-typescript/src/parser/bruParser.ts
+++ b/packages/bruno-api-typescript/src/parser/bruParser.ts
@@ -310,7 +310,7 @@ function parseQueryParams(result: ParsedBrunoFile, lines: string[]): void {
     const key = normalizedLine.substring(0, colonIndex).trim();
     const value = normalizedLine.substring(colonIndex + 1).trim();
 
-    if (!key || !value) {
+    if (!key) {
       continue;
     }
 

--- a/packages/bruno-api-typescript/tests/cli.test.js
+++ b/packages/bruno-api-typescript/tests/cli.test.js
@@ -150,6 +150,90 @@ describe('API 클라이언트 생성 테스트', () => {
     console.log('✅ API 정의 파일 내용 검증 테스트 통과');
   });
 
+  test('쿼리 문자열 변수와 빈 값은 queryParamsExample에만 포함', () => {
+    const queryFixtureDir = join(TEST_OUTPUT_DIR, 'query-fixture');
+    const chatDir = join(queryFixtureDir, 'chat');
+    mkdirSync(chatDir, { recursive: true });
+
+    const queryFile = join(chatDir, 'chat-messages.bru');
+    const queryContent = `meta {
+  name: Chat Messages
+  type: http
+}
+
+get /chats/rooms/{{room-id}}?size={{default-size}}&nickname&createdAt=2025-11-14
+
+docs {
+  \`\`\`json
+  {}
+  \`\`\`
+}
+`;
+    writeFileSync(queryFile, queryContent);
+
+    const outputDir = join(TEST_OUTPUT_DIR, 'query-output');
+    execSync(`node dist/cli/index.js generate-hooks -i ${queryFixtureDir} -o ${outputDir}`, {
+      cwd: join(__dirname, '..'),
+    });
+
+    const definitionsContent = readFileSync(join(outputDir, 'chat', 'apiDefinitions.ts'), 'utf-8');
+    assert.ok(
+      definitionsContent.includes('pathParams: {} as { roomId: string | number }'),
+      'query placeholder는 path param 타입에 포함되지 않아야 함',
+    );
+    assert.ok(definitionsContent.includes('"room-id": ""'), '실제 path param은 유지되어야 함');
+    assert.ok(!definitionsContent.includes('"default-size": ""'), 'query placeholder는 pathParamsExample에 없어야 함');
+    assert.ok(definitionsContent.includes('"size": "{{default-size}}"'), 'query placeholder는 queryParamsExample에 있어야 함');
+    assert.ok(definitionsContent.includes('"nickname": ""'), '값이 비어 있는 query key도 유지되어야 함');
+
+    console.log('✅ 쿼리 문자열 변수 및 빈 값 처리 테스트 통과');
+  });
+
+  test('민감한 Slack webhook URL은 placeholder로 생성', () => {
+    const webhookFixtureDir = join(TEST_OUTPUT_DIR, 'webhook-fixture');
+    const uploadDir = join(webhookFixtureDir, 'image-upload');
+    mkdirSync(uploadDir, { recursive: true });
+
+    const webhookFile = join(uploadDir, 'slack-notification.bru');
+    const webhookContent = `meta {
+  name: Slack Notification
+  type: http
+}
+
+post https://hooks.slack.com/services/T000/B000/SECRET
+
+body:json {
+  {
+    "text": "test"
+  }
+}
+
+docs {
+  \`\`\`json
+  {}
+  \`\`\`
+}
+`;
+    writeFileSync(webhookFile, webhookContent);
+
+    const outputDir = join(TEST_OUTPUT_DIR, 'webhook-output');
+    execSync(`node dist/cli/index.js generate-hooks -i ${webhookFixtureDir} -o ${outputDir}`, {
+      cwd: join(__dirname, '..'),
+    });
+
+    const definitionsContent = readFileSync(join(outputDir, 'image-upload', 'apiDefinitions.ts'), 'utf-8');
+    const apiContent = readFileSync(join(outputDir, 'image-upload', 'api.ts'), 'utf-8');
+    const registryContent = readFileSync(join(TEST_OUTPUT_DIR, 'apiDefinitionRegistry.ts'), 'utf-8');
+    assert.ok(!definitionsContent.includes('hooks.slack.com/services'), 'apiDefinitions에 실제 webhook URL이 없어야 함');
+    assert.ok(!apiContent.includes('hooks.slack.com/services'), 'api.ts에 실제 webhook URL이 없어야 함');
+    assert.ok(!registryContent.includes('hooks.slack.com/services'), 'registry에 실제 webhook URL이 없어야 함');
+    assert.ok(definitionsContent.includes('SLACK_WEBHOOK_URL'), 'apiDefinitions에 placeholder가 있어야 함');
+    assert.ok(apiContent.includes('SLACK_WEBHOOK_URL'), 'api.ts에 placeholder가 있어야 함');
+    assert.ok(registryContent.includes('canExecute: false'), '민감한 webhook endpoint는 실행 불가로 표시되어야 함');
+
+    console.log('✅ 민감한 webhook URL placeholder 생성 테스트 통과');
+  });
+
   test('API 팩토리 파일 내용 검증', () => {
     const inputDir = join(FIXTURES_DIR, 'bruno');
     const outputDir = join(TEST_OUTPUT_DIR, 'apis-factory');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@radix-ui/react-tabs':
         specifier: ^1.1.13
         version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@solid-connect/api-schema':
+        specifier: workspace:^
+        version: link:../../packages/api-schema
       '@stomp/stompjs':
         specifier: ^7.1.1
         version: 7.2.1


### PR DESCRIPTION
## 관련 이슈

- resolves: #이슈 번호

## 작업 내용

- Bruno codegen이 테스트베드용 API registry를 생성하도록 확장했습니다.
- 어드민 `/bruno` 화면을 generated registry 기반으로 변경해 API 목록, 도메인/메서드 필터, 요청 editor 자동 초기화를 지원합니다.
- Path/Query/Body/Headers를 수정해 실제 API 요청을 보낼 수 있게 하고, 응답 body/header/status/duration을 확인할 수 있게 했습니다.
- 원격 API 서버 경고, 변경성 메서드 실행 전 confirm, multipart-form API 실행 제한을 추가했습니다.

## 특이 사항

- 생성된 `packages/api-schema/src/apiDefinitionRegistry.ts`는 admin 테스트베드가 사용하는 self-contained registry입니다.
- 파일 업로드 API는 v1 테스트베드에서는 실행하지 않고 안내만 표시합니다.
- `packages/api-schema/src/apis/` 전체 생성물은 기존 ignore 정책에 따라 커밋하지 않았습니다.

## 리뷰 요구사항 (선택)

- Bruno parser의 `params:query`/body block 파싱 보강이 기존 codegen 산출물에 부작용이 없는지 봐주세요.
- 실제 API 호출 테스트베드라서 mutating method confirm 및 원격 API 경고 UX가 충분한지 확인 부탁드립니다.

## 검증

- `pnpm --filter bruno-api-typescript build`
- `BRUNO_COLLECTION_DIR='/Users/manwook-han/Desktop/hmw/code/solid-connect/api-docs/Solid Connection' BRUNO_SOURCE_MODE=local pnpm --filter @solid-connect/api-schema run verify:schema`
- `pnpm --filter @solid-connect/api-schema run typecheck`
- `pnpm --filter @solid-connect/admin lint:check`
- `pnpm --filter @solid-connect/admin typecheck`
- `pnpm --filter @solid-connect/admin build`
- commit/push hook CI parity checks passed
