### PR TITLE
fix: 채팅 이미지 렌더 URL 정리

### DIFF
--- a/apps/web/src/app/mentor/chat/[chatId]/_ui/ChatContent/_ui/ChatMessageBox/index.tsx
+++ b/apps/web/src/app/mentor/chat/[chatId]/_ui/ChatContent/_ui/ChatMessageBox/index.tsx
@@ -66,7 +66,7 @@ const useChatImageHealthCheck = (src: string, enabled: boolean) => {
       probeImage.onload = () => {
         if (isCancelled) return;
         setIsReady(true);
-        setReadySrc(probeImage?.src ?? src);
+        setReadySrc(src);
       };
 
       probeImage.onerror = () => {


### PR DESCRIPTION
## 관련 이슈

- resolves: #이슈 번호

## 작업 내용

- 채팅 이미지 health check probe는 기존처럼 cache-busting URL로 확인하되, 실제 렌더링되는 이미지 URL은 원본 clean URL을 사용하도록 수정했습니다.
- 최종 `<Image>` src에 `__chat_image_health_check` query param이 남지 않게 했습니다.

## 특이 사항

- CDN 반영 지연 대응을 위한 health check 재시도 흐름은 유지합니다.
- sender 로컬 preview(`blob:`/`data:`) 동작은 그대로 유지됩니다.

## 리뷰 요구사항 (선택)

- health check probe와 실제 렌더 URL 분리가 의도대로 동작하는지 확인 부탁드립니다.

## 검증

- `pnpm --filter @solid-connect/web lint:check`
- `pnpm --filter @solid-connect/web typecheck`
- commit hook CI parity checks passed
- push hook CI parity checks passed
