### PR TITLE
fix: 어드민 로그아웃 세션 정리

### DIFF
--- a/apps/admin/src/app/auth/login/page.tsx
+++ b/apps/admin/src/app/auth/login/page.tsx
@@ -11,6 +11,12 @@ export default function AuthLoginPage() {
 		let isMounted = true;
 
 		const redirectIfAuthenticated = async () => {
+			const shouldSkipSessionCheck = new URLSearchParams(window.location.search).get("loggedOut") === "1";
+			if (shouldSkipSessionCheck) {
+				setCanRenderLogin(true);
+				return;
+			}
+
 			try {
 				const token = await ensureSessionToken();
 				if (!isMounted) return;

--- a/apps/admin/src/components/layout/AdminLayout.tsx
+++ b/apps/admin/src/components/layout/AdminLayout.tsx
@@ -1,5 +1,9 @@
+"use client";
+
 import { LogOut } from "lucide-react";
+import { useState } from "react";
 import { toast } from "sonner";
+import { adminSignOutApi } from "@/lib/api/auth";
 import { clearSession } from "@/lib/auth/session";
 import { type ActiveAdminMenu, AdminSidebar } from "./AdminSidebar";
 
@@ -11,10 +15,26 @@ interface AdminLayoutProps {
 }
 
 export function AdminLayout({ children, activeMenu, title, description }: AdminLayoutProps) {
-	const handleLogout = () => {
-		clearSession();
-		toast.success("로그아웃되었습니다.");
-		window.location.assign("/auth/login");
+	const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+	const handleLogout = async () => {
+		if (isLoggingOut) {
+			return;
+		}
+
+		setIsLoggingOut(true);
+
+		try {
+			await adminSignOutApi();
+			toast.success("로그아웃되었습니다.");
+		} catch {
+			toast.error("서버 로그아웃 요청에 실패했습니다.", {
+				description: "로컬 세션을 정리하고 로그인 화면으로 이동합니다.",
+			});
+		} finally {
+			clearSession();
+			window.location.assign("/auth/login?loggedOut=1");
+		}
 	};
 
 	return (
@@ -35,10 +55,11 @@ export function AdminLayout({ children, activeMenu, title, description }: AdminL
 						<button
 							type="button"
 							onClick={handleLogout}
-							className="inline-flex items-center gap-1 rounded-md border border-k-200 px-3 py-1.5 text-k-700 typo-medium-4 hover:bg-k-50"
+							disabled={isLoggingOut}
+							className="inline-flex items-center gap-1 rounded-md border border-k-200 px-3 py-1.5 text-k-700 typo-medium-4 hover:bg-k-50 disabled:cursor-not-allowed disabled:opacity-60"
 						>
 							<LogOut className="h-4 w-4" />
-							로그아웃
+							{isLoggingOut ? "로그아웃 중..." : "로그아웃"}
 						</button>
 					</div>
 				</header>

--- a/apps/admin/src/lib/api/auth.ts
+++ b/apps/admin/src/lib/api/auth.ts
@@ -1,4 +1,5 @@
 import axios, { type AxiosResponse } from "axios";
+import { loadAccessToken } from "@/lib/utils/localStorage";
 import type { AdminSignInResponse, ReissueAccessTokenResponse } from "@/types/auth";
 
 const API_SERVER_URL = import.meta.env.VITE_API_SERVER_URL?.trim();
@@ -17,3 +18,11 @@ export const adminSignInApi = (email: string, password: string): Promise<AxiosRe
 
 export const reissueAccessTokenApi = (): Promise<AxiosResponse<ReissueAccessTokenResponse>> =>
 	authAxiosInstance.post("/auth/reissue");
+
+export const adminSignOutApi = (): Promise<AxiosResponse<void>> => {
+	const accessToken = loadAccessToken();
+
+	return authAxiosInstance.post("/auth/sign-out", undefined, {
+		headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : undefined,
+	});
+};

--- a/apps/admin/src/lib/auth/session.ts
+++ b/apps/admin/src/lib/auth/session.ts
@@ -3,6 +3,7 @@ import { isTokenExpired } from "@/lib/utils/jwtUtils";
 import { loadAccessToken, removeAccessToken, saveAccessToken } from "@/lib/utils/localStorage";
 
 let reissuePromise: Promise<string | null> | null = null;
+let sessionVersion = 0;
 
 const getValidAccessToken = (): string | null => {
 	const accessToken = loadAccessToken();
@@ -19,6 +20,8 @@ const getValidAccessToken = (): string | null => {
 };
 
 export const clearSession = () => {
+	sessionVersion += 1;
+	reissuePromise = null;
 	removeAccessToken();
 };
 
@@ -27,10 +30,16 @@ export const reissueAccessTokenIfPossible = async (): Promise<string | null> => 
 		return reissuePromise;
 	}
 
+	const reissueSessionVersion = sessionVersion;
+
 	reissuePromise = (async () => {
 		try {
 			const response = await reissueAccessTokenApi();
 			const nextAccessToken = response.data.accessToken;
+
+			if (reissueSessionVersion !== sessionVersion) {
+				return null;
+			}
 
 			if (!nextAccessToken) {
 				clearSession();


### PR DESCRIPTION
## 관련 이슈

- resolves: 없음

## 작업 내용

- 어드민 로그아웃 버튼에서 서버 `/auth/sign-out` API를 호출하도록 연결했습니다.
- 로그아웃 후 refresh cookie로 `/auth/reissue`가 다시 성공해 세션이 복구되는 흐름을 막기 위해 로그인 페이지의 로그아웃 직후 자동 세션 확인을 건너뜁니다.
- 진행 중이던 reissue 응답이 늦게 도착해 access token을 다시 저장하지 않도록 세션 버전 방어 로직을 추가했습니다.

## 특이 사항

- 서버 로그아웃 요청이 실패해도 로컬 세션은 정리하고 로그인 화면으로 이동합니다.
- 로컬 Node 버전이 `v23.10.0`이라 루트 `engines.node: 22.x` 경고가 출력되지만 검증은 통과했습니다.

## 리뷰 요구사항 (선택)

- 로그아웃 직후 `/auth/login?loggedOut=1`에서 reissue를 건너뛰는 방식이 운영 플로우에 맞는지 확인 부탁드립니다.

## 검증

- `pnpm --filter @solid-connect/admin lint:check`
- `pnpm --filter @solid-connect/admin typecheck`
- `pnpm --filter @solid-connect/admin build`
- commit hook: `@solid-connect/admin ci:check`
- push hook: `@solid-connect/admin ci:check`, `@solid-connect/admin build`