### PR TITLE
feat: 어드민 미구현 관리 플로우 추가

### DIFF
--- a/apps/admin/src/app/regions-countries/page.tsx
+++ b/apps/admin/src/app/regions-countries/page.tsx
@@ -1,0 +1,10 @@
+import { RequireAdminSession } from "@/components/features/auth/RequireAdminSession";
+import { RegionsCountriesPageContent } from "@/components/features/regions-countries/RegionsCountriesPageContent";
+
+export default function RegionsCountriesPage() {
+	return (
+		<RequireAdminSession>
+			<RegionsCountriesPageContent />
+		</RequireAdminSession>
+	);
+}

--- a/apps/admin/src/components/features/mentor-applications/MentorApplicationsPageContent.tsx
+++ b/apps/admin/src/components/features/mentor-applications/MentorApplicationsPageContent.tsx
@@ -123,6 +123,12 @@ const getUniversityName = (application: MentorApplicationListItem) => {
 	return pickString(core.universityName, university?.koreanName, university?.name, core.universityId, university?.id);
 };
 
+const getUniversityId = (application: MentorApplicationListItem) => {
+	const core = getApplicationCore(application);
+	const university = getUniversity(application);
+	return pickString(core.universityId, university?.universityId, university?.id);
+};
+
 const getTerm = (application: MentorApplicationListItem) => {
 	const core = getApplicationCore(application);
 	return pickString(core.term);
@@ -175,6 +181,46 @@ const formatDateTime = (value: string | number | null | undefined) => {
 const getHistoryItems = (data: MentorApplicationHistoryResponse | undefined) => {
 	if (!data) return [];
 	return Array.isArray(data) ? data : (data.content ?? []);
+};
+
+type MentorApplicationCountData = Awaited<ReturnType<typeof adminApi.getCountMentorApplicationByStatus>>;
+
+const toCountNumber = (value: unknown): number | undefined => {
+	if (typeof value === "number" && Number.isFinite(value)) return value;
+	if (typeof value === "string" && value.trim().length > 0) {
+		const parsed = Number(value);
+		return Number.isFinite(parsed) ? parsed : undefined;
+	}
+	if (typeof value === "object" && value !== null) {
+		const record = value as Record<string, unknown>;
+		return toCountNumber(record.count ?? record.total ?? record.value);
+	}
+
+	return undefined;
+};
+
+const getCountByStatus = (data: MentorApplicationCountData | undefined, status: MentorApplicationStatus) => {
+	if (!data) return undefined;
+
+	if (Array.isArray(data)) {
+		const item = data.find(
+			(entry) => normalizeStatus(entry.mentorApplicationStatus ?? entry.status ?? entry.name) === status,
+		);
+		return toCountNumber(item);
+	}
+
+	const record = data as Record<string, unknown>;
+	const collection = record.content ?? record.data ?? record.items ?? record.result;
+	if (Array.isArray(collection)) {
+		const item = collection.find((entry) => {
+			if (typeof entry !== "object" || entry === null) return false;
+			const nextRecord = entry as Record<string, unknown>;
+			return normalizeStatus(nextRecord.mentorApplicationStatus ?? nextRecord.status ?? nextRecord.name) === status;
+		});
+		return toCountNumber(item);
+	}
+
+	return toCountNumber(record[status] ?? record[status.toLowerCase()]);
 };
 
 function MentorApplicationStatusBadge({ status }: { status: MentorApplicationStatus | null }) {
@@ -265,6 +311,8 @@ export function MentorApplicationsPageContent() {
 	const [expandedSiteUserId, setExpandedSiteUserId] = useState<string | null>(null);
 	const [rejectingApplicationId, setRejectingApplicationId] = useState<string | null>(null);
 	const [rejectReason, setRejectReason] = useState("");
+	const [mappingApplicationId, setMappingApplicationId] = useState<string | null>(null);
+	const [mappingUniversityId, setMappingUniversityId] = useState("");
 
 	const normalizedNickname = nickname.trim();
 
@@ -281,11 +329,23 @@ export function MentorApplicationsPageContent() {
 		placeholderData: keepPreviousData,
 	});
 
+	const countQuery = useQuery({
+		queryKey: ["mentorApplications", "count"],
+		queryFn: adminApi.getCountMentorApplicationByStatus,
+		placeholderData: keepPreviousData,
+	});
+
 	useEffect(() => {
 		if (isError) {
 			toast.error("멘토 승격 요청 목록을 불러오지 못했습니다.");
 		}
 	}, [isError]);
+
+	useEffect(() => {
+		if (countQuery.isError) {
+			toast.error("멘토 승격 요청 상태별 개수를 불러오지 못했습니다.");
+		}
+	}, [countQuery.isError]);
 
 	const applications = data?.content ?? [];
 	const totalPages = Math.max(1, data?.totalPages ?? 1);
@@ -313,6 +373,20 @@ export function MentorApplicationsPageContent() {
 		},
 		onError: () => {
 			toast.error("멘토 승격 요청 반려에 실패했습니다.");
+		},
+	});
+
+	const mapUniversityMutation = useMutation({
+		mutationFn: ({ mentorApplicationId, universityId }: { mentorApplicationId: string; universityId: number }) =>
+			adminApi.assignMentorApplicationUniversity(mentorApplicationId, universityId),
+		onSuccess: async () => {
+			await queryClient.invalidateQueries({ queryKey: ["mentorApplications"] });
+			setMappingApplicationId(null);
+			setMappingUniversityId("");
+			toast.success("멘토 지원서 대학을 매핑했습니다.");
+		},
+		onError: () => {
+			toast.error("멘토 지원서 대학 매핑에 실패했습니다.");
 		},
 	});
 
@@ -372,12 +446,61 @@ export function MentorApplicationsPageContent() {
 		await rejectMutation.mutateAsync({ mentorApplicationId, rejectedReason: normalizedReason });
 	};
 
+	const handleStartMapUniversity = (application: MentorApplicationListItem) => {
+		const applicationId = getApplicationId(application);
+		if (!applicationId) {
+			toast.error("신청 ID를 확인할 수 없습니다.");
+			return;
+		}
+
+		setMappingApplicationId(applicationId);
+		setMappingUniversityId(getUniversityId(application) ?? "");
+	};
+
+	const handleCancelMapUniversity = () => {
+		setMappingApplicationId(null);
+		setMappingUniversityId("");
+	};
+
+	const handleMapUniversity = async (mentorApplicationId: string) => {
+		const normalizedUniversityId = Number(mappingUniversityId.trim());
+		if (!Number.isInteger(normalizedUniversityId) || normalizedUniversityId <= 0) {
+			toast.error("대학 ID를 숫자로 입력해주세요.");
+			return;
+		}
+
+		await mapUniversityMutation.mutateAsync({ mentorApplicationId, universityId: normalizedUniversityId });
+	};
+
 	return (
 		<AdminLayout
 			activeMenu="mentorApplications"
 			title="멘토 승격 요청"
 			description="멘토 전환 신청 내역을 확인하고 승인 또는 반려합니다."
 		>
+			<div className="mt-4 grid gap-3 sm:grid-cols-3">
+				{STATUS_OPTIONS.map((option) => {
+					const count = getCountByStatus(countQuery.data, option.value);
+					const isActive = statusFilter === option.value;
+
+					return (
+						<button
+							key={option.value}
+							type="button"
+							onClick={() => handleFilterStatus(option.value)}
+							className={`rounded-xl border px-4 py-3 text-left transition-colors ${
+								isActive ? "border-primary bg-primary-100" : "border-k-100 bg-k-0 hover:bg-k-50"
+							}`}
+						>
+							<p className="typo-medium-4 text-k-500">{option.label}</p>
+							<p className="mt-1 typo-bold-4 text-k-900">
+								{countQuery.isLoading ? "..." : typeof count === "number" ? count.toLocaleString() : "-"}
+							</p>
+						</button>
+					);
+				})}
+			</div>
+
 			<div className="mt-4 grid gap-3 rounded-xl border border-k-100 bg-k-0 p-4 sm:grid-cols-[180px_minmax(180px,1fr)_180px_auto]">
 				<label className="block">
 					<span className="mb-1 block typo-sb-11 text-k-600">상태</span>
@@ -489,9 +612,12 @@ export function MentorApplicationsPageContent() {
 									const status = getApplicationStatus(application);
 									const fileUrl = getVerificationFileUrl(application);
 									const profileImageUrl = getProfileImageUrl(application);
+									const universityId = getUniversityId(application);
 									const isRejecting = Boolean(applicationId && rejectingApplicationId === applicationId);
+									const isMappingUniversity = Boolean(applicationId && mappingApplicationId === applicationId);
 									const isExpanded = Boolean(siteUserId && expandedSiteUserId === siteUserId);
-									const isActionPending = approveMutation.isPending || rejectMutation.isPending;
+									const isActionPending =
+										approveMutation.isPending || rejectMutation.isPending || mapUniversityMutation.isPending;
 
 									return (
 										<Fragment key={applicationId ?? `${siteUserId ?? "unknown"}-${getCreatedAt(application) ?? index}`}>
@@ -525,6 +651,7 @@ export function MentorApplicationsPageContent() {
 														<p className="typo-regular-4 text-k-500">
 															{toDisplayText(getCountry(application))} / {toDisplayText(getTerm(application))}
 														</p>
+														<p className="typo-regular-4 text-k-400">대학 ID {toDisplayText(universityId)}</p>
 													</div>
 												</TableCell>
 												<TableCell>{formatDateTime(getCreatedAt(application))}</TableCell>
@@ -560,7 +687,28 @@ export function MentorApplicationsPageContent() {
 												</TableCell>
 												<TableCell>
 													{status === "PENDING" && applicationId ? (
-														isRejecting ? (
+														isMappingUniversity ? (
+															<div className="flex min-w-[240px] items-center gap-2">
+																<input
+																	type="number"
+																	value={mappingUniversityId}
+																	onChange={(event) => setMappingUniversityId(event.target.value)}
+																	placeholder="대학 ID"
+																	className="h-8 w-[120px] rounded-md border border-k-200 bg-k-0 px-2 typo-regular-4 text-k-700 outline-none placeholder:text-k-400 focus-visible:border-primary"
+																/>
+																<Button
+																	type="button"
+																	size="sm"
+																	disabled={mapUniversityMutation.isPending}
+																	onClick={() => handleMapUniversity(applicationId)}
+																>
+																	확인
+																</Button>
+																<Button type="button" size="sm" variant="secondary" onClick={handleCancelMapUniversity}>
+																	취소
+																</Button>
+															</div>
+														) : isRejecting ? (
 															<div className="flex min-w-[280px] items-center gap-2">
 																<input
 																	type="text"
@@ -584,6 +732,15 @@ export function MentorApplicationsPageContent() {
 															</div>
 														) : (
 															<div className="flex items-center gap-2">
+																<Button
+																	type="button"
+																	size="sm"
+																	variant="secondary"
+																	disabled={isActionPending}
+																	onClick={() => handleStartMapUniversity(application)}
+																>
+																	대학 매핑
+																</Button>
 																<Button
 																	type="button"
 																	size="sm"

--- a/apps/admin/src/components/features/regions-countries/RegionsCountriesPageContent.tsx
+++ b/apps/admin/src/components/features/regions-countries/RegionsCountriesPageContent.tsx
@@ -1,0 +1,526 @@
+"use client";
+
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { type FormEvent, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { AdminLayout } from "@/components/layout/AdminLayout";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { type AdminCollection, adminApi, type CountryResponse, type RegionResponse } from "@/lib/api/admin";
+
+const toOptionalString = (value: string | number | null | undefined) => {
+	if (value === null || value === undefined) return undefined;
+	const normalized = String(value).trim();
+	return normalized.length > 0 ? normalized : undefined;
+};
+
+const toDisplayText = (value: string | number | null | undefined) => toOptionalString(value) ?? "-";
+
+const normalizeCollection = <T,>(data: AdminCollection<T> | undefined) => {
+	if (!data) return [];
+	if (Array.isArray(data)) return data;
+	return data.content ?? data.data ?? data.items ?? data.result ?? [];
+};
+
+const getRegionCode = (region: RegionResponse) => toOptionalString(region.code);
+const getRegionName = (region: RegionResponse) => toOptionalString(region.koreanName ?? region.name);
+const getCountryCode = (country: CountryResponse) => toOptionalString(country.code);
+const getCountryName = (country: CountryResponse) => toOptionalString(country.koreanName ?? country.name);
+
+const getCountryRegionCode = (country: CountryResponse) => {
+	if (typeof country.region === "string") {
+		return toOptionalString(country.region);
+	}
+
+	return toOptionalString(country.regionCode ?? country.region?.code ?? country.region?.regionCode);
+};
+
+export function RegionsCountriesPageContent() {
+	const queryClient = useQueryClient();
+	const [regionCode, setRegionCode] = useState("");
+	const [regionName, setRegionName] = useState("");
+	const [countryCode, setCountryCode] = useState("");
+	const [countryName, setCountryName] = useState("");
+	const [countryRegionCode, setCountryRegionCode] = useState("");
+	const [editingRegionCode, setEditingRegionCode] = useState<string | null>(null);
+	const [editingRegionName, setEditingRegionName] = useState("");
+	const [editingCountryCode, setEditingCountryCode] = useState<string | null>(null);
+	const [editingCountryName, setEditingCountryName] = useState("");
+	const [editingCountryRegionCode, setEditingCountryRegionCode] = useState("");
+
+	const regionsQuery = useQuery({
+		queryKey: ["admin", "regions"],
+		queryFn: adminApi.getRegions,
+		placeholderData: keepPreviousData,
+	});
+
+	const countriesQuery = useQuery({
+		queryKey: ["admin", "countries"],
+		queryFn: adminApi.getCountries,
+		placeholderData: keepPreviousData,
+	});
+
+	const regions = useMemo(() => normalizeCollection(regionsQuery.data), [regionsQuery.data]);
+	const countries = useMemo(() => normalizeCollection(countriesQuery.data), [countriesQuery.data]);
+	const regionOptions = useMemo(
+		() =>
+			regions
+				.map((region) => ({ code: getRegionCode(region), name: getRegionName(region) }))
+				.filter((region): region is { code: string; name: string | undefined } => Boolean(region.code)),
+		[regions],
+	);
+
+	useEffect(() => {
+		if (!countryRegionCode && regionOptions[0]?.code) {
+			setCountryRegionCode(regionOptions[0].code);
+		}
+	}, [countryRegionCode, regionOptions]);
+
+	useEffect(() => {
+		if (regionsQuery.isError) {
+			toast.error("권역 목록을 불러오지 못했습니다.");
+		}
+	}, [regionsQuery.isError]);
+
+	useEffect(() => {
+		if (countriesQuery.isError) {
+			toast.error("지역 목록을 불러오지 못했습니다.");
+		}
+	}, [countriesQuery.isError]);
+
+	const invalidateRegions = async () => {
+		await queryClient.invalidateQueries({ queryKey: ["admin", "regions"] });
+	};
+
+	const invalidateCountries = async () => {
+		await queryClient.invalidateQueries({ queryKey: ["admin", "countries"] });
+	};
+
+	const createRegionMutation = useMutation({
+		mutationFn: adminApi.createRegion,
+		onSuccess: async () => {
+			await invalidateRegions();
+			setRegionCode("");
+			setRegionName("");
+			toast.success("권역을 생성했습니다.");
+		},
+		onError: () => toast.error("권역 생성에 실패했습니다."),
+	});
+
+	const updateRegionMutation = useMutation({
+		mutationFn: ({ code, koreanName }: { code: string; koreanName: string }) =>
+			adminApi.updateRegion(code, { koreanName }),
+		onSuccess: async () => {
+			await invalidateRegions();
+			setEditingRegionCode(null);
+			setEditingRegionName("");
+			toast.success("권역을 수정했습니다.");
+		},
+		onError: () => toast.error("권역 수정에 실패했습니다."),
+	});
+
+	const deleteRegionMutation = useMutation({
+		mutationFn: adminApi.deleteRegion,
+		onSuccess: async () => {
+			await Promise.all([invalidateRegions(), invalidateCountries()]);
+			toast.success("권역을 삭제했습니다.");
+		},
+		onError: () => toast.error("권역 삭제에 실패했습니다."),
+	});
+
+	const createCountryMutation = useMutation({
+		mutationFn: adminApi.createCountry,
+		onSuccess: async () => {
+			await invalidateCountries();
+			setCountryCode("");
+			setCountryName("");
+			setCountryRegionCode(regionOptions[0]?.code ?? "");
+			toast.success("지역을 생성했습니다.");
+		},
+		onError: () => toast.error("지역 생성에 실패했습니다."),
+	});
+
+	const updateCountryMutation = useMutation({
+		mutationFn: ({ code, koreanName, regionCode }: { code: string; koreanName: string; regionCode: string }) =>
+			adminApi.updateCountry(code, { koreanName, regionCode }),
+		onSuccess: async () => {
+			await invalidateCountries();
+			setEditingCountryCode(null);
+			setEditingCountryName("");
+			setEditingCountryRegionCode("");
+			toast.success("지역을 수정했습니다.");
+		},
+		onError: () => toast.error("지역 수정에 실패했습니다."),
+	});
+
+	const deleteCountryMutation = useMutation({
+		mutationFn: adminApi.deleteCountry,
+		onSuccess: async () => {
+			await invalidateCountries();
+			toast.success("지역을 삭제했습니다.");
+		},
+		onError: () => toast.error("지역 삭제에 실패했습니다."),
+	});
+
+	const isRegionMutating =
+		createRegionMutation.isPending || updateRegionMutation.isPending || deleteRegionMutation.isPending;
+	const isCountryMutating =
+		createCountryMutation.isPending || updateCountryMutation.isPending || deleteCountryMutation.isPending;
+
+	const handleCreateRegion = (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		const normalizedCode = regionCode.trim();
+		const normalizedName = regionName.trim();
+
+		if (!normalizedCode || !normalizedName) {
+			toast.error("권역 코드와 이름을 입력해주세요.");
+			return;
+		}
+
+		createRegionMutation.mutate({ code: normalizedCode, koreanName: normalizedName });
+	};
+
+	const handleCreateCountry = (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		const normalizedCode = countryCode.trim();
+		const normalizedName = countryName.trim();
+		const normalizedRegionCode = countryRegionCode.trim();
+
+		if (!normalizedCode || !normalizedName || !normalizedRegionCode) {
+			toast.error("지역 코드, 이름, 권역 코드를 입력해주세요.");
+			return;
+		}
+
+		createCountryMutation.mutate({
+			code: normalizedCode,
+			koreanName: normalizedName,
+			regionCode: normalizedRegionCode,
+		});
+	};
+
+	const handleStartEditRegion = (region: RegionResponse) => {
+		const code = getRegionCode(region);
+		if (!code) {
+			toast.error("권역 코드를 확인할 수 없습니다.");
+			return;
+		}
+
+		setEditingRegionCode(code);
+		setEditingRegionName(getRegionName(region) ?? "");
+	};
+
+	const handleUpdateRegion = (code: string) => {
+		const normalizedName = editingRegionName.trim();
+		if (!normalizedName) {
+			toast.error("권역 이름을 입력해주세요.");
+			return;
+		}
+
+		updateRegionMutation.mutate({ code, koreanName: normalizedName });
+	};
+
+	const handleDeleteRegion = (code: string) => {
+		const confirmed = window.confirm(`권역 ${code}를 삭제할까요? 연결된 지역에 영향이 있을 수 있습니다.`);
+		if (!confirmed) return;
+
+		deleteRegionMutation.mutate(code);
+	};
+
+	const handleStartEditCountry = (country: CountryResponse) => {
+		const code = getCountryCode(country);
+		if (!code) {
+			toast.error("지역 코드를 확인할 수 없습니다.");
+			return;
+		}
+
+		setEditingCountryCode(code);
+		setEditingCountryName(getCountryName(country) ?? "");
+		setEditingCountryRegionCode(getCountryRegionCode(country) ?? "");
+	};
+
+	const handleUpdateCountry = (code: string) => {
+		const normalizedName = editingCountryName.trim();
+		const normalizedRegionCode = editingCountryRegionCode.trim();
+
+		if (!normalizedName || !normalizedRegionCode) {
+			toast.error("지역 이름과 권역 코드를 입력해주세요.");
+			return;
+		}
+
+		updateCountryMutation.mutate({ code, koreanName: normalizedName, regionCode: normalizedRegionCode });
+	};
+
+	const handleDeleteCountry = (code: string) => {
+		const confirmed = window.confirm(`지역 ${code}를 삭제할까요?`);
+		if (!confirmed) return;
+
+		deleteCountryMutation.mutate(code);
+	};
+
+	return (
+		<AdminLayout
+			activeMenu="regionsCountries"
+			title="권역/지역 관리"
+			description="서비스 권역과 국가 지역 코드를 관리합니다."
+		>
+			<div className="mt-4 grid gap-4 xl:grid-cols-2">
+				<section className="rounded-xl border border-k-100 bg-k-0 p-4">
+					<div className="flex items-center justify-between gap-3">
+						<div>
+							<h2 className="typo-sb-9 text-k-900">권역</h2>
+							<p className="mt-1 typo-regular-4 text-k-500">예: EUROPE, AMERICAS</p>
+						</div>
+						<p className="typo-regular-4 text-k-500">총 {regions.length.toLocaleString()}건</p>
+					</div>
+
+					<form onSubmit={handleCreateRegion} className="mt-4 grid gap-2 sm:grid-cols-[140px_minmax(0,1fr)_auto]">
+						<Input value={regionCode} onChange={(event) => setRegionCode(event.target.value)} placeholder="권역 코드" />
+						<Input value={regionName} onChange={(event) => setRegionName(event.target.value)} placeholder="권역 이름" />
+						<Button type="submit" disabled={createRegionMutation.isPending}>
+							생성
+						</Button>
+					</form>
+
+					<div className="mt-4 overflow-x-auto rounded-lg border border-k-100">
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>코드</TableHead>
+									<TableHead>이름</TableHead>
+									<TableHead>작업</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{regionsQuery.isLoading ? (
+									<TableRow>
+										<TableCell colSpan={3} className="text-center typo-regular-4 text-k-500">
+											권역을 불러오는 중...
+										</TableCell>
+									</TableRow>
+								) : regionsQuery.isError ? (
+									<TableRow>
+										<TableCell colSpan={3} className="text-center typo-regular-4 text-[#E22A2D]">
+											권역을 불러오지 못했습니다.
+										</TableCell>
+									</TableRow>
+								) : regions.length === 0 ? (
+									<TableRow>
+										<TableCell colSpan={3} className="text-center typo-regular-4 text-k-500">
+											권역이 없습니다.
+										</TableCell>
+									</TableRow>
+								) : (
+									regions.map((region, index) => {
+										const code = getRegionCode(region);
+										const isEditing = Boolean(code && editingRegionCode === code);
+
+										return (
+											<TableRow key={code ?? `region-${index}`} className="hover:bg-bg-50">
+												<TableCell>{toDisplayText(code)}</TableCell>
+												<TableCell>
+													{isEditing ? (
+														<Input
+															value={editingRegionName}
+															onChange={(event) => setEditingRegionName(event.target.value)}
+														/>
+													) : (
+														toDisplayText(getRegionName(region))
+													)}
+												</TableCell>
+												<TableCell>
+													{isEditing && code ? (
+														<div className="flex items-center gap-2">
+															<Button
+																size="sm"
+																onClick={() => handleUpdateRegion(code)}
+																disabled={updateRegionMutation.isPending}
+															>
+																저장
+															</Button>
+															<Button size="sm" variant="secondary" onClick={() => setEditingRegionCode(null)}>
+																취소
+															</Button>
+														</div>
+													) : (
+														<div className="flex items-center gap-2">
+															<Button
+																size="sm"
+																variant="secondary"
+																onClick={() => handleStartEditRegion(region)}
+																disabled={!code}
+															>
+																수정
+															</Button>
+															<Button
+																size="sm"
+																variant="destructive"
+																onClick={() => code && handleDeleteRegion(code)}
+																disabled={!code || isRegionMutating}
+															>
+																삭제
+															</Button>
+														</div>
+													)}
+												</TableCell>
+											</TableRow>
+										);
+									})
+								)}
+							</TableBody>
+						</Table>
+					</div>
+				</section>
+
+				<section className="rounded-xl border border-k-100 bg-k-0 p-4">
+					<div className="flex items-center justify-between gap-3">
+						<div>
+							<h2 className="typo-sb-9 text-k-900">지역</h2>
+							<p className="mt-1 typo-regular-4 text-k-500">예: AT, US, JP</p>
+						</div>
+						<p className="typo-regular-4 text-k-500">총 {countries.length.toLocaleString()}건</p>
+					</div>
+
+					<form
+						onSubmit={handleCreateCountry}
+						className="mt-4 grid gap-2 sm:grid-cols-[110px_minmax(0,1fr)_150px_auto]"
+					>
+						<Input
+							value={countryCode}
+							onChange={(event) => setCountryCode(event.target.value)}
+							placeholder="지역 코드"
+						/>
+						<Input
+							value={countryName}
+							onChange={(event) => setCountryName(event.target.value)}
+							placeholder="지역 이름"
+						/>
+						<select
+							value={countryRegionCode}
+							onChange={(event) => setCountryRegionCode(event.target.value)}
+							className="h-9 rounded-md border border-k-200 bg-k-0 px-3 typo-regular-4 text-k-700 outline-none focus-visible:border-primary"
+						>
+							<option value="">권역 선택</option>
+							{regionOptions.map((region) => (
+								<option key={region.code} value={region.code}>
+									{region.name ? `${region.name} (${region.code})` : region.code}
+								</option>
+							))}
+						</select>
+						<Button type="submit" disabled={createCountryMutation.isPending}>
+							생성
+						</Button>
+					</form>
+
+					<div className="mt-4 overflow-x-auto rounded-lg border border-k-100">
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>코드</TableHead>
+									<TableHead>이름</TableHead>
+									<TableHead>권역</TableHead>
+									<TableHead>작업</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{countriesQuery.isLoading ? (
+									<TableRow>
+										<TableCell colSpan={4} className="text-center typo-regular-4 text-k-500">
+											지역을 불러오는 중...
+										</TableCell>
+									</TableRow>
+								) : countriesQuery.isError ? (
+									<TableRow>
+										<TableCell colSpan={4} className="text-center typo-regular-4 text-[#E22A2D]">
+											지역을 불러오지 못했습니다.
+										</TableCell>
+									</TableRow>
+								) : countries.length === 0 ? (
+									<TableRow>
+										<TableCell colSpan={4} className="text-center typo-regular-4 text-k-500">
+											지역이 없습니다.
+										</TableCell>
+									</TableRow>
+								) : (
+									countries.map((country, index) => {
+										const code = getCountryCode(country);
+										const isEditing = Boolean(code && editingCountryCode === code);
+
+										return (
+											<TableRow key={code ?? `country-${index}`} className="hover:bg-bg-50">
+												<TableCell>{toDisplayText(code)}</TableCell>
+												<TableCell>
+													{isEditing ? (
+														<Input
+															value={editingCountryName}
+															onChange={(event) => setEditingCountryName(event.target.value)}
+														/>
+													) : (
+														toDisplayText(getCountryName(country))
+													)}
+												</TableCell>
+												<TableCell>
+													{isEditing ? (
+														<select
+															value={editingCountryRegionCode}
+															onChange={(event) => setEditingCountryRegionCode(event.target.value)}
+															className="h-9 min-w-[150px] rounded-md border border-k-200 bg-k-0 px-3 typo-regular-4 text-k-700 outline-none focus-visible:border-primary"
+														>
+															<option value="">권역 선택</option>
+															{regionOptions.map((region) => (
+																<option key={region.code} value={region.code}>
+																	{region.name ? `${region.name} (${region.code})` : region.code}
+																</option>
+															))}
+														</select>
+													) : (
+														toDisplayText(getCountryRegionCode(country))
+													)}
+												</TableCell>
+												<TableCell>
+													{isEditing && code ? (
+														<div className="flex items-center gap-2">
+															<Button
+																size="sm"
+																onClick={() => handleUpdateCountry(code)}
+																disabled={updateCountryMutation.isPending}
+															>
+																저장
+															</Button>
+															<Button size="sm" variant="secondary" onClick={() => setEditingCountryCode(null)}>
+																취소
+															</Button>
+														</div>
+													) : (
+														<div className="flex items-center gap-2">
+															<Button
+																size="sm"
+																variant="secondary"
+																onClick={() => handleStartEditCountry(country)}
+																disabled={!code}
+															>
+																수정
+															</Button>
+															<Button
+																size="sm"
+																variant="destructive"
+																onClick={() => code && handleDeleteCountry(code)}
+																disabled={!code || isCountryMutating}
+															>
+																삭제
+															</Button>
+														</div>
+													)}
+												</TableCell>
+											</TableRow>
+										);
+									})
+								)}
+							</TableBody>
+						</Table>
+					</div>
+				</section>
+			</div>
+		</AdminLayout>
+	);
+}

--- a/apps/admin/src/components/layout/AdminSidebar.tsx
+++ b/apps/admin/src/components/layout/AdminSidebar.tsx
@@ -1,11 +1,12 @@
-import { FileText, FlaskConical, MessageSquare, UserCheck } from "lucide-react";
+import { FileText, FlaskConical, MapPinned, MessageSquare, UserCheck } from "lucide-react";
 import { cn } from "@/lib/utils";
 
-export type ActiveAdminMenu = "scores" | "mentorApplications" | "bruno" | "chatSocket";
+export type ActiveAdminMenu = "scores" | "mentorApplications" | "regionsCountries" | "bruno" | "chatSocket";
 
 const sideMenus = [
 	{ key: "scores", label: "성적 관리", icon: FileText, to: "/scores" as const },
 	{ key: "mentorApplications", label: "멘토 승격 요청", icon: UserCheck, to: "/mentor-applications" as const },
+	{ key: "regionsCountries", label: "권역/지역 관리", icon: MapPinned, to: "/regions-countries" as const },
 	{ key: "bruno", label: "Bruno API", icon: FlaskConical, to: "/bruno" as const },
 	{ key: "chatSocket", label: "채팅 소켓", icon: MessageSquare, to: "/chat-socket" as const },
 ] as const;

--- a/apps/admin/src/lib/api/admin.ts
+++ b/apps/admin/src/lib/api/admin.ts
@@ -5,6 +5,29 @@ import type {
 	MentorApplicationStatus,
 } from "@/types/mentorApplications";
 
+export interface AdminCollectionResponse<T> {
+	content?: T[];
+	data?: T[];
+	items?: T[];
+	result?: T[];
+}
+
+export type AdminCollection<T> = T[] | AdminCollectionResponse<T>;
+
+export interface MentorApplicationCountItem {
+	mentorApplicationStatus?: MentorApplicationStatus | string | null;
+	status?: MentorApplicationStatus | string | null;
+	name?: string | null;
+	count?: number | string | null;
+	total?: number | string | null;
+	value?: number | string | null;
+}
+
+export type MentorApplicationCountResponse =
+	| Partial<Record<MentorApplicationStatus, number | string | MentorApplicationCountItem>>
+	| MentorApplicationCountItem[]
+	| AdminCollectionResponse<MentorApplicationCountItem>;
+
 export interface MentorApplicationListParams {
 	page?: number;
 	size?: number;
@@ -13,9 +36,24 @@ export interface MentorApplicationListParams {
 	createdAt?: string;
 }
 
+export interface RegionResponse {
+	code?: string | null;
+	regionCode?: string | null;
+	koreanName?: string | null;
+	name?: string | null;
+}
+
 export interface RegionPayload {
 	code?: string;
 	koreanName: string;
+}
+
+export interface CountryResponse {
+	code?: string | null;
+	koreanName?: string | null;
+	name?: string | null;
+	regionCode?: string | null;
+	region?: string | RegionResponse | null;
 }
 
 export interface CountryPayload {
@@ -24,14 +62,17 @@ export interface CountryPayload {
 	regionCode: string;
 }
 
+const assignMentorApplicationUniversity = (mentorApplicationId: string | number, universityId: number) =>
+	axiosInstance
+		.post<void>(`/admin/mentor-applications/${mentorApplicationId}/assign-university`, { universityId })
+		.then((res) => res.data);
+
 export const adminApi = {
 	getMentorApplicationList: (params: MentorApplicationListParams) =>
 		axiosInstance.get<MentorApplicationPageResponse>("/admin/mentor-applications", { params }).then((res) => res.data),
 
 	getCountMentorApplicationByStatus: () =>
-		axiosInstance
-			.get<Partial<Record<MentorApplicationStatus, number>>>("/admin/mentor-applications/count")
-			.then((res) => res.data),
+		axiosInstance.get<MentorApplicationCountResponse>("/admin/mentor-applications/count").then((res) => res.data),
 
 	getMentorApplicationHistoryList: (siteUserId: string | number) =>
 		axiosInstance
@@ -46,12 +87,31 @@ export const adminApi = {
 			.post<void>(`/admin/mentor-applications/${mentorApplicationId}/reject`, { rejectedReason })
 			.then((res) => res.data),
 
-	postMappingMentorapplicationUniversity: (mentorApplicationId: string | number, universityId: number) =>
-		axiosInstance
-			.post<void>(`/admin/mentor-applications/${mentorApplicationId}/assign-university`, { universityId })
-			.then((res) => res.data),
+	postMappingMentorapplicationUniversity: assignMentorApplicationUniversity,
 
-	get권역조회: () => axiosInstance.get("/admin/regions").then((res) => res.data),
+	assignMentorApplicationUniversity,
+
+	getRegions: () => axiosInstance.get<AdminCollection<RegionResponse>>("/admin/regions").then((res) => res.data),
+
+	createRegion: (data: RegionPayload) =>
+		axiosInstance.post<RegionResponse>("/admin/regions", data).then((res) => res.data),
+
+	updateRegion: (code: string, data: RegionPayload) =>
+		axiosInstance.put<RegionResponse>(`/admin/regions/${code}`, data).then((res) => res.data),
+
+	deleteRegion: (code: string) => axiosInstance.delete<void>(`/admin/regions/${code}`).then((res) => res.data),
+
+	getCountries: () => axiosInstance.get<AdminCollection<CountryResponse>>("/admin/countries").then((res) => res.data),
+
+	createCountry: (data: CountryPayload) =>
+		axiosInstance.post<CountryResponse>("/admin/countries", data).then((res) => res.data),
+
+	updateCountry: (code: string, data: CountryPayload) =>
+		axiosInstance.put<CountryResponse>(`/admin/countries/${code}`, data).then((res) => res.data),
+
+	deleteCountry: (code: string) => axiosInstance.delete<void>(`/admin/countries/${code}`).then((res) => res.data),
+
+	get권역조회: () => axiosInstance.get<AdminCollection<RegionResponse>>("/admin/regions").then((res) => res.data),
 
 	post권역생성: (data: RegionPayload) => axiosInstance.post("/admin/regions", data).then((res) => res.data),
 
@@ -60,7 +120,7 @@ export const adminApi = {
 
 	delete권역삭제: (code: string) => axiosInstance.delete(`/admin/regions/${code}`).then((res) => res.data),
 
-	get지역조회: () => axiosInstance.get("/admin/countries").then((res) => res.data),
+	get지역조회: () => axiosInstance.get<AdminCollection<CountryResponse>>("/admin/countries").then((res) => res.data),
 
 	post지역생성: (data: CountryPayload) => axiosInstance.post("/admin/countries", data).then((res) => res.data),
 


### PR DESCRIPTION
## 관련 이슈

- resolves: 없음

## 작업 내용

- 멘토 승격 요청 페이지에 상태별 count 요약 카드를 추가했습니다.
- 멘토 승격 요청 행에서 대학 ID 기반 assign-university 매핑을 연결했습니다.
- 어드민 사이드바에 권역/지역 관리 메뉴를 추가하고 `/regions-countries` 페이지를 구현했습니다.
- 권역/지역 조회, 생성, 수정, 삭제 API wrapper와 응답 타입을 보강했습니다.
- 응답 shape가 배열 또는 content/data/items/result 형태로 내려와도 화면이 깨지지 않도록 방어했습니다.

## 특이 사항

- Bruno multipart 실행 기능은 파일 입력 UX와 FormData key 확정이 필요해 이번 PR 범위에서 제외했습니다.
- 대학 매핑은 현재 대학 검색 API가 없어 raw 대학 ID 입력 방식으로 최소 연결했습니다.
- 로컬 Node가 v23.10.0이라 `engines.node: 22.x` 경고가 출력되지만 검증은 통과했습니다.

## 리뷰 요구사항 (선택)

- 대학 매핑 v1 범위를 대학 ID 입력으로 제공하는 방식이 운영에 충분한지 확인 부탁드립니다.
- 권역/지역 API 응답 shape 방어 범위가 실제 응답과 맞는지 확인 부탁드립니다.

## 검증

- `pnpm --filter @solid-connect/admin lint:check`
- `pnpm --filter @solid-connect/admin typecheck`
- `pnpm --filter @solid-connect/admin build`
- commit hook: `@solid-connect/admin ci:check` 통과
- push hook: `@solid-connect/admin ci:check` 및 `@solid-connect/admin build` 통과