### PR TITLE
chore: next 16 turbopack 빌드 전환

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -19,6 +19,14 @@ const imageRemotePatterns = [
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   transpilePackages: ["@solid-connect/ai-inspector"],
+  turbopack: {
+    rules: {
+      "*.svg": {
+        loaders: ["@svgr/webpack"],
+        as: "*.js",
+      },
+    },
+  },
   images: {
     unoptimized: true,
     remotePatterns: imageRemotePatterns,

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -3,8 +3,11 @@
 import bundleAnalyzer from "@next/bundle-analyzer";
 import { withSentryConfig } from "@sentry/nextjs";
 
+const shouldRunBundleAnalyzer = process.env.ANALYZE === "true";
+const svgComponentLoaders = ["@svgr/webpack"];
+
 const withBundleAnalyzer = bundleAnalyzer({
-  enabled: process.env.ANALYZE === "true",
+  enabled: shouldRunBundleAnalyzer,
 });
 
 const imageRemotePatterns = [
@@ -22,7 +25,7 @@ const nextConfig = {
   turbopack: {
     rules: {
       "*.svg": {
-        loaders: ["@svgr/webpack"],
+        loaders: svgComponentLoaders,
         as: "*.js",
       },
     },
@@ -56,31 +59,35 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
-  webpack: (config) => {
-    // CSS 최적화 - ensure nested objects exist
-    if (!config.optimization) {
-      config.optimization = {};
-    }
-    if (!config.optimization.splitChunks) {
-      config.optimization.splitChunks = {};
-    }
-    if (!config.optimization.splitChunks.cacheGroups) {
-      config.optimization.splitChunks.cacheGroups = {};
-    }
+  ...(shouldRunBundleAnalyzer
+    ? {
+        webpack: (config) => {
+          // Bundle analyzer still runs through webpack because it is webpack-plugin based.
+          if (!config.optimization) {
+            config.optimization = {};
+          }
+          if (!config.optimization.splitChunks) {
+            config.optimization.splitChunks = {};
+          }
+          if (!config.optimization.splitChunks.cacheGroups) {
+            config.optimization.splitChunks.cacheGroups = {};
+          }
 
-    config.optimization.splitChunks.cacheGroups.styles = {
-      name: "styles",
-      test: /\.(css|scss)$/,
-      chunks: "all",
-      enforce: true,
-    };
+          config.optimization.splitChunks.cacheGroups.styles = {
+            name: "styles",
+            test: /\.(css|scss)$/,
+            chunks: "all",
+            enforce: true,
+          };
 
-    config.module.rules.push({
-      test: /\.svg$/,
-      use: ["@svgr/webpack"],
-    });
-    return config;
-  },
+          config.module.rules.push({
+            test: /\.svg$/,
+            use: svgComponentLoaders,
+          });
+          return config;
+        },
+      }
+    : {}),
 };
 
 export default withSentryConfig(

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build --webpack",
+    "build": "next build",
     "start": "next start",
     "lint": "biome check --write .",
     "lint:check": "biome check .",
@@ -13,7 +13,7 @@
     "typecheck": "tsc --noEmit",
     "typecheck:ci": "tsc --noEmit -p tsconfig.ci.json",
     "ci:check": "pnpm run lint:check && pnpm run typecheck:ci",
-    "analyze": "ANALYZE=true next build --webpack"
+    "analyze": "ANALYZE=true next build"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc --noEmit",
     "typecheck:ci": "tsc --noEmit -p tsconfig.ci.json",
     "ci:check": "pnpm run lint:check && pnpm run typecheck:ci",
-    "analyze": "ANALYZE=true next build"
+    "analyze": "ANALYZE=true next build --webpack"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",


### PR DESCRIPTION
## 관련 이슈

- resolves: #300 
- 선행 PR: #533

## 작업 내용

- `apps/web`의 production build를 `next build --webpack`에서 Next 16 기본 `next build`로 되돌렸습니다.
- Turbopack에서도 기존 SVG React 컴포넌트 import가 동작하도록 `next.config.mjs`에 `turbopack.rules`를 추가했습니다.
- `@svgr/webpack`을 Turbopack loader로 연결해 기존 `@svgr/webpack` 기반 SVG 사용 방식을 유지합니다.

## 특이 사항

- 이 PR은 #533 위에 얹힌 stacked PR입니다. #533이 먼저 머지되면 이 PR을 main 기준으로 retarget하거나 그대로 이어서 머지하면 됩니다.
- npm 기준 최신 Next는 이미 #533의 `16.2.6`이라 추가 버전 상승은 없습니다. 이 PR은 Next 16 기본 빌더인 Turbopack 호환성 전환입니다.

## 리뷰 요구사항 (선택)

- Turbopack `rules` 설정이 기존 SVG import 사용처와 호환되는지 중점적으로 봐주세요.

## 검증

- `pnpm --filter @solid-connect/web build`
- `pnpm --filter @solid-connect/web lint:check`
- `pnpm --filter @solid-connect/web typecheck`
- `pnpm --filter @solid-connect/web ci:check`
- push hook CI parity checks 통과(web/admin ci:check 및 build)
