### PR TITLE
feat: 검색 최적화 기반 정비

### DIFF
--- a/apps/web/src/app/(home)/page.tsx
+++ b/apps/web/src/app/(home)/page.tsx
@@ -2,14 +2,15 @@ import type { Metadata } from "next";
 import { getHomeNewsList } from "@/apis/news/server/getNewsList";
 import { getCategorizedUniversities, getRecommendedUniversity } from "@/apis/universities/server";
 import { type ListUniversity, RegionEnumExtend } from "@/types/university";
+import { createUrl } from "@/utils/seo";
 import FindLastYearScoreBar from "./_ui/FindLastYearScoreBar";
 import HomeEntrySection from "./_ui/HomeEntrySection";
 import NewsSection from "./_ui/NewsSection";
 import PopularUniversitySection from "./_ui/PopularUniversitySection";
 import UniversityList from "./_ui/UniversityList";
 
-const baseUrl = process.env.NEXT_PUBLIC_WEB_URL || "https://solid-connection.com";
-const ogImageUrl = `${baseUrl}/opengraph-image.png`;
+const pageUrl = createUrl("/");
+const ogImageUrl = createUrl("/opengraph-image.png");
 const homeMetaTitle = "교환학생 사이트 | 솔리드 커넥션 – 교환학생 커뮤니티, 플랫폼";
 
 export const metadata: Metadata = {
@@ -17,13 +18,13 @@ export const metadata: Metadata = {
   description:
     "교환학생 사이트 솔리드커넥션. 교환학생 커뮤니티에서 학교 검색, 성적 입력, 지원 현황 확인까지 한 번에. 교환학생 준비를 위한 모든 정보를 제공합니다.",
   alternates: {
-    canonical: `${baseUrl}/`,
+    canonical: pageUrl,
   },
   openGraph: {
     title: homeMetaTitle,
     description:
       "교환학생 사이트 솔리드커넥션. 교환학생 커뮤니티에서 학교 검색, 성적 입력, 지원 현황 확인까지 한 번에. 교환학생 준비를 위한 모든 정보를 제공합니다.",
-    url: `${baseUrl}/`,
+    url: pageUrl,
     siteName: "솔리드커넥션",
     locale: "ko_KR",
     type: "website",
@@ -49,13 +50,8 @@ const structuredData = {
   "@context": "https://schema.org",
   "@type": "WebSite",
   name: "솔리드커넥션",
-  url: `${baseUrl}/`,
+  url: pageUrl,
   description: "교환학생 학교 검색, 성적 입력, 지원 현황 확인까지 가능한 교환학생 플랫폼.",
-  potentialAction: {
-    "@type": "SearchAction",
-    target: `${baseUrl}/university?searchText={search_term_string}`,
-    "query-input": "required name=search_term_string",
-  },
 };
 
 const resolveRecommendedUniversitiesHomeUniversityName = (

--- a/apps/web/src/app/api/revalidate/route.ts
+++ b/apps/web/src/app/api/revalidate/route.ts
@@ -10,6 +10,12 @@ interface RevalidateRequestBody {
   boardCode?: string;
 }
 
+type RevalidateTagWithExpire = (tag: string, profile: { expire: number }) => void;
+
+const revalidateTagNow = (tag: string) => {
+  (revalidateTag as RevalidateTagWithExpire)(tag, { expire: 0 });
+};
+
 /**
  * @description ISR 페이지를 수동으로 revalidate하는 API
  * POST /api/revalidate
@@ -57,7 +63,7 @@ async function POST(request: NextRequest) {
     // boardCode가 있으면 해당 커뮤니티 페이지 revalidate
     if (boardCode) {
       revalidatePath(`/community/${boardCode}`);
-      revalidateTag(`posts-${boardCode}`);
+      revalidateTagNow(`posts-${boardCode}`);
 
       return NextResponse.json({
         revalidated: true,
@@ -78,7 +84,7 @@ async function POST(request: NextRequest) {
 
     // 특정 태그 revalidate
     if (tag) {
-      revalidateTag(tag);
+      revalidateTagNow(tag);
       return NextResponse.json({
         revalidated: true,
         message: `Tag ${tag} revalidated`,

--- a/apps/web/src/app/api/revalidate/route.ts
+++ b/apps/web/src/app/api/revalidate/route.ts
@@ -57,7 +57,7 @@ async function POST(request: NextRequest) {
     // boardCode가 있으면 해당 커뮤니티 페이지 revalidate
     if (boardCode) {
       revalidatePath(`/community/${boardCode}`);
-      revalidateTag(`posts-${boardCode}`, { expire: 0 });
+      revalidateTag(`posts-${boardCode}`);
 
       return NextResponse.json({
         revalidated: true,
@@ -78,7 +78,7 @@ async function POST(request: NextRequest) {
 
     // 특정 태그 revalidate
     if (tag) {
-      revalidateTag(tag, { expire: 0 });
+      revalidateTag(tag);
       return NextResponse.json({
         revalidated: true,
         message: `Tag ${tag} revalidated`,

--- a/apps/web/src/app/community/[boardCode]/[postId]/modify/page.tsx
+++ b/apps/web/src/app/community/[boardCode]/[postId]/modify/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 
 import TopDetailNavigation from "@/components/layout/TopDetailNavigation";
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 
 import PostModifyContent from "./PostModifyContent";
 
@@ -13,6 +14,7 @@ interface PostModifyPageProps {
 
 export const metadata: Metadata = {
   title: "글 수정",
+  robots: NO_INDEX_ROBOTS,
 };
 
 const PostModifyPage = async ({ params }: PostModifyPageProps) => {

--- a/apps/web/src/app/community/[boardCode]/[postId]/page.tsx
+++ b/apps/web/src/app/community/[boardCode]/[postId]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 import PostPageContent from "./PostPageContent";
 
 interface PostPageProps {
@@ -10,7 +11,8 @@ interface PostPageProps {
 }
 
 export const metadata: Metadata = {
-  title: "게시글",
+  title: "게시글 | 솔리드커넥션",
+  robots: NO_INDEX_ROBOTS,
 };
 
 const PostPage = async ({ params }: PostPageProps) => {

--- a/apps/web/src/app/community/[boardCode]/create/page.tsx
+++ b/apps/web/src/app/community/[boardCode]/create/page.tsx
@@ -1,7 +1,9 @@
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 import PostForm from "./PostForm";
 
 export const metadata = {
   title: "글쓰기",
+  robots: NO_INDEX_ROBOTS,
 };
 
 const PostCreatePage = async ({ params }: { params: Promise<{ boardCode: string }> }) => {

--- a/apps/web/src/app/community/[boardCode]/page.tsx
+++ b/apps/web/src/app/community/[boardCode]/page.tsx
@@ -1,15 +1,31 @@
 import type { Metadata } from "next";
 import TopDetailNavigation from "@/components/layout/TopDetailNavigation";
+import { COMMUNITY_BOARDS } from "@/constants/community";
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 import CommunityPageContent from "./CommunityPageContent";
-
-export const metadata: Metadata = {
-  title: "커뮤니티",
-};
 
 interface CommunityPageProps {
   params: Promise<{
     boardCode: string;
   }>;
+}
+
+export async function generateMetadata({ params }: CommunityPageProps): Promise<Metadata> {
+  const { boardCode } = await params;
+  const board = COMMUNITY_BOARDS.find((item) => item.code === boardCode);
+
+  if (!board) {
+    return {
+      title: "커뮤니티",
+      robots: NO_INDEX_ROBOTS,
+    };
+  }
+
+  return {
+    title: `${board.nameKo} 교환학생 커뮤니티 | 솔리드커넥션`,
+    description: `${board.nameKo} 교환학생 준비, 파견 생활, 학교 정보와 질문을 나누는 솔리드커넥션 커뮤니티입니다.`,
+    robots: NO_INDEX_ROBOTS,
+  };
 }
 
 const CommunityPage = async ({ params }: CommunityPageProps) => {

--- a/apps/web/src/app/community/page.tsx
+++ b/apps/web/src/app/community/page.tsx
@@ -1,8 +1,11 @@
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
+
 export const metadata: Metadata = {
   title: "커뮤니티",
+  robots: NO_INDEX_ROBOTS,
 };
 
 const CommunityIndex = () => {

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -10,8 +10,9 @@ import AppleScriptLoader from "@/lib/ScriptLoader/AppleScriptLoader";
 import "@/styles/globals.css";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { SpeedInsights } from "@vercel/speed-insights/next";
+import { getSiteUrl } from "@/utils/seo";
 
-const siteUrl = process.env.NEXT_PUBLIC_WEB_URL || "https://solid-connection.com";
+const siteUrl = getSiteUrl();
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),

--- a/apps/web/src/app/login/apple/callback/page.tsx
+++ b/apps/web/src/app/login/apple/callback/page.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
 
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 import AppleLoginCallbackPage from "./AppleLoginCallbackPage";
 
 export const metadata: Metadata = {
   title: "애플 로그인 중...",
+  robots: NO_INDEX_ROBOTS,
 };
 
 const Page = () => (

--- a/apps/web/src/app/login/kakao/callback/page.tsx
+++ b/apps/web/src/app/login/kakao/callback/page.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
 
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 import KakaoLoginCallbackPage from "./KakaoLoginCallbackPage";
 
 export const metadata: Metadata = {
   title: "카카오 로그인 중...",
+  robots: NO_INDEX_ROBOTS,
 };
 
 const Page = () => (

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from "next";
 import KakaoScriptLoader from "@/lib/ScriptLoader/KakaoScriptLoader";
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 import LoginContent from "./LoginContent";
 
 export const metadata: Metadata = {
   title: "로그인",
+  robots: NO_INDEX_ROBOTS,
 };
 
 const LoginPage = () => {

--- a/apps/web/src/app/mentor/[id]/page.tsx
+++ b/apps/web/src/app/mentor/[id]/page.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from "next";
 
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 import MentorDetialContent from "./_ui/MentorDetialContent";
 
 export const metadata: Metadata = {
-  title: "멘토 상세 정보 | Solid Connect",
+  title: "멘토 상세 정보 | 솔리드커넥션",
   description: "멘토의 상세 정보와 경험, 아티클을 확인하고 멘토링을 신청해보세요.",
-  keywords: ["멘토", "멘토링", "유학", "상세정보", "교환학생"],
+  robots: NO_INDEX_ROBOTS,
 };
 
 interface MentorDetailPageProps {

--- a/apps/web/src/app/mentor/_ui/MentorClient/_ui/MentorFindSection/index.tsx
+++ b/apps/web/src/app/mentor/_ui/MentorClient/_ui/MentorFindSection/index.tsx
@@ -43,7 +43,7 @@ const MentorFindSection = () => {
       </div>
 
       {/* 멘토 리스트 */}
-      <div ref={listRef} className="space-y-4">
+      <div ref={listRef} className="space-y-4 pb-28">
         {mentorList.length === 0 ? (
           <EmptySdwBCards message="멘토가 없습니다. 필터를 변경해보세요." />
         ) : (

--- a/apps/web/src/app/mentor/_ui/MentorClient/_ui/MentorFindSection/index.tsx
+++ b/apps/web/src/app/mentor/_ui/MentorClient/_ui/MentorFindSection/index.tsx
@@ -43,7 +43,7 @@ const MentorFindSection = () => {
       </div>
 
       {/* 멘토 리스트 */}
-      <div ref={listRef} className="space-y-4 pb-28">
+      <div ref={listRef} className="space-y-4">
         {mentorList.length === 0 ? (
           <EmptySdwBCards message="멘토가 없습니다. 필터를 변경해보세요." />
         ) : (

--- a/apps/web/src/app/mentor/chat/[chatId]/_ui/ChatContent/index.tsx
+++ b/apps/web/src/app/mentor/chat/[chatId]/_ui/ChatContent/index.tsx
@@ -155,7 +155,7 @@ const ChatContent = ({ chatId }: ChatContentProps) => {
                     {/* 날짜 구분선 */}
                     {showDateSeparator && (
                       <div className="my-4 mb-6 flex w-full justify-center">
-                        <span className="rounded-full bg-k-50 px-3 py-1 text-k-600 typo-regular-2">
+                        <span className="rounded-full bg-gray-100 px-3 py-1 text-gray-600 typo-regular-2">
                           {formatDateSeparator(message.createdAt)}
                         </span>
                       </div>

--- a/apps/web/src/app/mentor/chat/[chatId]/_ui/ChatContent/index.tsx
+++ b/apps/web/src/app/mentor/chat/[chatId]/_ui/ChatContent/index.tsx
@@ -155,7 +155,7 @@ const ChatContent = ({ chatId }: ChatContentProps) => {
                     {/* 날짜 구분선 */}
                     {showDateSeparator && (
                       <div className="my-4 mb-6 flex w-full justify-center">
-                        <span className="rounded-full bg-gray-100 px-3 py-1 text-gray-600 typo-regular-2">
+                        <span className="rounded-full bg-k-50 px-3 py-1 text-k-600 typo-regular-2">
                           {formatDateSeparator(message.createdAt)}
                         </span>
                       </div>

--- a/apps/web/src/app/mentor/chat/[chatId]/page.tsx
+++ b/apps/web/src/app/mentor/chat/[chatId]/page.tsx
@@ -1,13 +1,14 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 import ChatContent from "./_ui/ChatContent";
 import ChatNavBar from "./_ui/ChatNavBar";
 
 export const metadata: Metadata = {
-  title: "멘토와 채팅 | Solid Connect",
+  title: "멘토와 채팅 | 솔리드커넥션",
   description: "멘토와 실시간으로 대화하며 궁금한 점을 해결해보세요.",
-  keywords: ["멘토", "채팅", "실시간", "대화", "멘토링", "질문"],
+  robots: NO_INDEX_ROBOTS,
 };
 
 interface ChatDetailPageProps {

--- a/apps/web/src/app/mentor/chat/page.tsx
+++ b/apps/web/src/app/mentor/chat/page.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from "next";
 
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 import ChatPageClient from "./_ui/ChatPageClient";
 
 export const metadata: Metadata = {
-  title: "멘토 채팅 목록 | Solid Connect",
+  title: "멘토 채팅 목록 | 솔리드커넥션",
   description: "멘토와의 채팅 목록을 확인하고 대화를 이어가세요.",
-  keywords: ["멘토", "채팅", "대화", "멘토링", "소통"],
+  robots: NO_INDEX_ROBOTS,
 };
 
 const ChatPage = () => {

--- a/apps/web/src/app/mentor/modify/page.tsx
+++ b/apps/web/src/app/mentor/modify/page.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from "next";
 
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 import ModifyContent from "./_ui/ModifyContent";
 
 export const metadata: Metadata = {
-  title: "멘토 정보 수정 | Solid Connect",
+  title: "멘토 정보 수정 | 솔리드커넥션",
   description: "멘토 프로필과 정보를 수정하여 더 나은 멘토링을 제공하세요.",
-  keywords: ["멘토", "정보수정", "프로필", "멘토링", "설정"],
+  robots: NO_INDEX_ROBOTS,
 };
 
 const ModifyPage = () => {

--- a/apps/web/src/app/mentor/page.tsx
+++ b/apps/web/src/app/mentor/page.tsx
@@ -1,11 +1,15 @@
 import type { Metadata } from "next";
 
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 import MentorClient from "./_ui/MentorClient";
 
+const title = "교환학생 멘토 찾기 | 솔리드커넥션";
+const description = "교환학생을 다녀온 멘토의 국가, 파견 대학, 합격 팁을 확인하고 나에게 맞는 멘토링을 신청해보세요.";
+
 export const metadata: Metadata = {
-  title: "멘토 찾기 | Solid Connect",
-  description: "다양한 분야의 전문 멘토들을 만나보세요. 유학, 취업, 진로 상담을 받을 수 있습니다.",
-  keywords: ["멘토", "멘토링", "유학", "취업", "진로상담", "전문가"],
+  title,
+  description,
+  robots: NO_INDEX_ROBOTS,
 };
 
 const MentorPage = () => {

--- a/apps/web/src/app/mentor/waiting/page.tsx
+++ b/apps/web/src/app/mentor/waiting/page.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from "next";
 
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 import WaitingContent from "./_ui/WaitingContent";
 
 export const metadata: Metadata = {
-  title: "멘토 승인 대기 | Solid Connect",
+  title: "멘토 승인 대기 | 솔리드커넥션",
   description: "멘토 신청이 접수되었습니다. 승인 결과를 기다려주세요.",
-  keywords: ["멘토", "승인", "대기", "신청", "멘토링"],
+  robots: NO_INDEX_ROBOTS,
 };
 
 const WaitingPage = () => {

--- a/apps/web/src/app/my/apply-mentor/layout.tsx
+++ b/apps/web/src/app/my/apply-mentor/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
+
+export const metadata: Metadata = {
+  title: "멘토 회원 전환",
+  robots: NO_INDEX_ROBOTS,
+};
+
+const ApplyMentorLayout = ({ children }: { children: ReactNode }) => children;
+
+export default ApplyMentorLayout;

--- a/apps/web/src/app/my/favorite/page.tsx
+++ b/apps/web/src/app/my/favorite/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from "next";
 
 import TopDetailNavigation from "@/components/layout/TopDetailNavigation";
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 
 import FavoriteContent from "./_ui/FavoriteContent";
 
 export const metadata: Metadata = {
   title: "관심학교",
+  robots: NO_INDEX_ROBOTS,
 };
 
 const FavoritePage = () => {

--- a/apps/web/src/app/my/match/page.tsx
+++ b/apps/web/src/app/my/match/page.tsx
@@ -6,7 +6,7 @@ import { NO_INDEX_ROBOTS } from "@/utils/seo";
 import MatchContent from "./_ui/MatchContent";
 
 export const metadata: Metadata = {
-  title: "프로필 수정",
+  title: "매칭 멘토",
   robots: NO_INDEX_ROBOTS,
 };
 

--- a/apps/web/src/app/my/match/page.tsx
+++ b/apps/web/src/app/my/match/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from "next";
 
 import TopDetailNavigation from "@/components/layout/TopDetailNavigation";
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 
 import MatchContent from "./_ui/MatchContent";
 
 export const metadata: Metadata = {
   title: "프로필 수정",
+  robots: NO_INDEX_ROBOTS,
 };
 
 const MatchPage = () => {

--- a/apps/web/src/app/my/modify/page.tsx
+++ b/apps/web/src/app/my/modify/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from "next";
 
 import TopDetailNavigation from "@/components/layout/TopDetailNavigation";
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 
 import ModifyContent from "./_ui/ModifyContent";
 
 export const metadata: Metadata = {
   title: "프로필 수정",
+  robots: NO_INDEX_ROBOTS,
 };
 
 const ModifyPage = () => {

--- a/apps/web/src/app/my/page.tsx
+++ b/apps/web/src/app/my/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from "next";
 
 import TopDetailNavigation from "@/components/layout/TopDetailNavigation";
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 
 import MyProfileContent from "./_ui/MyProfileContent";
 
 export const metadata: Metadata = {
   title: "마이페이지",
+  robots: NO_INDEX_ROBOTS,
 };
 
 const MyPage = () => {

--- a/apps/web/src/app/my/password/page.tsx
+++ b/apps/web/src/app/my/password/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from "next";
 
 import TopDetailNavigation from "@/components/layout/TopDetailNavigation";
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 
 import PasswordContent from "./_ui/PasswordContent";
 
 export const metadata: Metadata = {
   title: "비밀번호 수정",
+  robots: NO_INDEX_ROBOTS,
 };
 
 const ModifyPage = () => {

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,20 +1,11 @@
 import type { MetadataRoute } from "next";
 
-const DEFAULT_SITE_URL = "https://www.solid-connection.com";
-
-const getSiteUrl = () => (process.env.NEXT_PUBLIC_WEB_URL ?? DEFAULT_SITE_URL).replace(/\/$/, "");
+import { getSiteUrl, isNonIndexSiteUrl } from "@/utils/seo";
 
 export default function robots(): MetadataRoute.Robots {
   const siteUrl = getSiteUrl();
-  const vercelEnv = process.env.VERCEL_ENV;
-  const isNonIndexEnvironment =
-    vercelEnv === "preview" ||
-    vercelEnv === "development" ||
-    siteUrl.includes("stage") ||
-    siteUrl.includes("localhost") ||
-    siteUrl.includes("127.0.0.1");
 
-  if (isNonIndexEnvironment) {
+  if (isNonIndexSiteUrl(siteUrl)) {
     return {
       rules: {
         userAgent: "*",

--- a/apps/web/src/app/sign-up/email/page.tsx
+++ b/apps/web/src/app/sign-up/email/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from "next";
 
 import TopDetailNavigation from "@/components/layout/TopDetailNavigation";
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 
 import EmailSignUpForm from "./EmailSignUpForm";
 
 export const metadata: Metadata = {
   title: "이메일로 시작하기",
+  robots: NO_INDEX_ROBOTS,
 };
 
 const EmailSignUpPage = () => {

--- a/apps/web/src/app/sign-up/page.tsx
+++ b/apps/web/src/app/sign-up/page.tsx
@@ -3,9 +3,11 @@ import { Suspense } from "react";
 
 import TopDetailNavigation from "@/components/layout/TopDetailNavigation";
 import SignupSurvey from "@/components/login/signup/SignupSurvey";
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 
 export const metadata: Metadata = {
   title: "회원가입",
+  robots: NO_INDEX_ROBOTS,
 };
 
 const SignUpPage = () => {

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -27,7 +27,14 @@ const getStaticRoutes = (): MetadataRoute.Sitemap => [
 ];
 
 const getUniversityDetailRoutes = async (): Promise<MetadataRoute.Sitemap> => {
-  const universities = await getAllUniversities();
+  let universities: Awaited<ReturnType<typeof getAllUniversities>>;
+
+  try {
+    universities = await getAllUniversities();
+  } catch {
+    return [];
+  }
+
   const seenUrls = new Set<string>();
 
   return universities.flatMap((university) => {

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,42 +1,61 @@
 import type { MetadataRoute } from "next";
+import { getAllUniversities } from "@/apis/universities/server";
+import { getHomeUniversitySlugByName, HOME_UNIVERSITY_LIST, HOME_UNIVERSITY_SLUGS } from "@/constants/university";
+import { createUrl, getSiteUrl, isNonIndexSiteUrl } from "@/utils/seo";
 
-const DEFAULT_SITE_URL = "https://www.solid-connection.com";
+type SitemapEntry = MetadataRoute.Sitemap[number];
 
-const getSiteUrl = () => (process.env.NEXT_PUBLIC_WEB_URL ?? DEFAULT_SITE_URL).replace(/\/$/, "");
+export const revalidate = 86400;
 
-export default function sitemap(): MetadataRoute.Sitemap {
+const toSitemapEntry = (
+  path: string,
+  changeFrequency: SitemapEntry["changeFrequency"],
+  priority: number,
+  lastModified?: Date | string,
+): SitemapEntry => ({
+  url: createUrl(path),
+  ...(lastModified ? { lastModified } : {}),
+  changeFrequency,
+  priority,
+});
+
+const getStaticRoutes = (): MetadataRoute.Sitemap => [
+  toSitemapEntry("/", "daily", 1),
+  toSitemapEntry("/university", "weekly", 0.85),
+  toSitemapEntry("/terms", "yearly", 0.35),
+  ...HOME_UNIVERSITY_LIST.map((university) => toSitemapEntry(`/university/${university.slug}`, "weekly", 0.8)),
+];
+
+const getUniversityDetailRoutes = async (): Promise<MetadataRoute.Sitemap> => {
+  const universities = await getAllUniversities();
+  const seenUrls = new Set<string>();
+
+  return universities.flatMap((university) => {
+    const homeUniversitySlug = getHomeUniversitySlugByName(university.homeUniversityName);
+
+    if (!homeUniversitySlug || !HOME_UNIVERSITY_SLUGS.includes(homeUniversitySlug)) {
+      return [];
+    }
+
+    const entry = toSitemapEntry(`/university/${homeUniversitySlug}/${university.id}`, "monthly", 0.7);
+
+    if (seenUrls.has(entry.url)) {
+      return [];
+    }
+
+    seenUrls.add(entry.url);
+    return [entry];
+  });
+};
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const siteUrl = getSiteUrl();
 
-  if (siteUrl.includes("stage") || siteUrl.includes("localhost") || siteUrl.includes("127.0.0.1")) {
+  if (isNonIndexSiteUrl(siteUrl)) {
     return [];
   }
 
-  const lastModified = new Date();
+  const universityDetailRoutes = await getUniversityDetailRoutes();
 
-  return [
-    {
-      url: `${siteUrl}/`,
-      lastModified,
-      changeFrequency: "daily",
-      priority: 1,
-    },
-    {
-      url: `${siteUrl}/mentor`,
-      lastModified,
-      changeFrequency: "weekly",
-      priority: 0.8,
-    },
-    {
-      url: `${siteUrl}/university`,
-      lastModified,
-      changeFrequency: "weekly",
-      priority: 0.8,
-    },
-    {
-      url: `${siteUrl}/terms`,
-      lastModified,
-      changeFrequency: "yearly",
-      priority: 0.5,
-    },
-  ];
+  return [...getStaticRoutes(), ...universityDetailRoutes];
 }

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -1,8 +1,12 @@
 import TopDetailNavigation from "@/components/layout/TopDetailNavigation";
+import { createUrl } from "@/utils/seo";
 
 export const metadata = {
   title: "이용약관",
   description: "솔리드커넥션 서비스 이용약관 페이지입니다.",
+  alternates: {
+    canonical: createUrl("/terms"),
+  },
 };
 
 const TERMS_SECTIONS = [

--- a/apps/web/src/app/university/(home)/page.tsx
+++ b/apps/web/src/app/university/(home)/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 
 import { HOME_UNIVERSITY_LIST } from "@/constants/university";
+import { createUrl } from "@/utils/seo";
 
 import HomeUniversityCard from "./_ui/HomeUniversityCard";
 
@@ -9,6 +10,25 @@ export const revalidate = 3600; // 1시간마다 재검증 (ISR)
 export const metadata: Metadata = {
   title: "대학 선택 | 솔리드커넥션",
   description: "소속 대학교를 선택하여 교환학생 정보를 확인하세요.",
+  alternates: {
+    canonical: createUrl("/university"),
+  },
+  openGraph: {
+    title: "대학 선택 | 솔리드커넥션",
+    description: "소속 대학교를 선택하여 교환학생 정보를 확인하세요.",
+    url: createUrl("/university"),
+    siteName: "솔리드커넥션",
+    locale: "ko_KR",
+    type: "website",
+    images: [
+      {
+        url: createUrl("/opengraph-image.png"),
+        width: 1200,
+        height: 630,
+        alt: "솔리드커넥션 대학 선택",
+      },
+    ],
+  },
 };
 
 const UniversitySelectPage = () => {

--- a/apps/web/src/app/university/[homeUniversity]/[id]/page.tsx
+++ b/apps/web/src/app/university/[homeUniversity]/[id]/page.tsx
@@ -123,22 +123,14 @@ const CollegeDetailPage = async ({ params }: PageProps) => {
   const universityDetailResult = await getUniversityDetailWithStatus(collegeId);
 
   if (!universityDetailResult.ok) {
-    const isNotFoundError = universityDetailResult.status === 404;
-
-    if (isNotFoundError) {
+    if (universityDetailResult.status === 404) {
       notFound();
     }
 
     return (
       <>
         <TopDetailNavigation title="파견 학교 상세" backHref={`/university/${homeUniversity}`} />
-        <UniversityDetailPreparingFallback
-          backHref={`/university/${homeUniversity}`}
-          title={isNotFoundError ? "해당 대학 정보를 찾을 수 없어요." : undefined}
-          description={
-            isNotFoundError ? "요청하신 파견학교를 찾지 못했습니다. 목록에서 다른 학교를 선택해 주세요." : undefined
-          }
-        />
+        <UniversityDetailPreparingFallback backHref={`/university/${homeUniversity}`} />
       </>
     );
   }

--- a/apps/web/src/app/university/[homeUniversity]/[id]/page.tsx
+++ b/apps/web/src/app/university/[homeUniversity]/[id]/page.tsx
@@ -5,6 +5,7 @@ import { getAllUniversities, getUniversityDetail, getUniversityDetailWithStatus 
 import TopDetailNavigation from "@/components/layout/TopDetailNavigation";
 import { getHomeUniversityBySlug, HOME_UNIVERSITY_SLUGS, isMatchedHomeUniversityName } from "@/constants/university";
 import type { HomeUniversitySlug } from "@/types/university";
+import { createAbsoluteUrl, createUrl, NO_INDEX_ROBOTS } from "@/utils/seo";
 
 // UniversityDetail 컴포넌트
 import UniversityDetail from "./_ui/UniversityDetail";
@@ -54,19 +55,17 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const universityData = await getUniversityDetail(Number(id));
 
   if (!universityData) {
-    return { title: "파견 학교 상세" };
+    return {
+      title: "파견 학교 상세",
+      robots: NO_INDEX_ROBOTS,
+    };
   }
 
   const homeUniversityInfo = getHomeUniversityBySlug(homeUniversity);
   const convertedKoreanName = universityData.koreanName;
 
-  const baseUrl = process.env.NEXT_PUBLIC_WEB_URL || "https://solid-connection.com";
-  const pageUrl = `${baseUrl}/university/${homeUniversity}/${id}`;
-  const imageUrl = universityData.backgroundImageUrl
-    ? universityData.backgroundImageUrl.startsWith("http")
-      ? universityData.backgroundImageUrl
-      : `${baseUrl}${universityData.backgroundImageUrl}`
-    : `${baseUrl}/images/article-thumb.png`;
+  const pageUrl = createUrl(`/university/${homeUniversity}/${id}`);
+  const imageUrl = createAbsoluteUrl(universityData.backgroundImageUrl, "/images/article-thumb.png");
 
   const countryExchangeKeyword = `${universityData.country} 교환학생`;
   const description = `${convertedKoreanName}(${universityData.englishName}) ${countryExchangeKeyword} 프로그램. 모집인원 ${universityData.studentCapacity}명. ${homeUniversityInfo?.shortName || ""} 학생을 위한 교환학생 정보.`;
@@ -126,6 +125,10 @@ const CollegeDetailPage = async ({ params }: PageProps) => {
   if (!universityDetailResult.ok) {
     const isNotFoundError = universityDetailResult.status === 404;
 
+    if (isNotFoundError) {
+      notFound();
+    }
+
     return (
       <>
         <TopDetailNavigation title="파견 학교 상세" backHref={`/university/${homeUniversity}`} />
@@ -144,8 +147,7 @@ const CollegeDetailPage = async ({ params }: PageProps) => {
 
   const convertedKoreanName = universityData.koreanName;
 
-  const baseUrl = process.env.NEXT_PUBLIC_WEB_URL || "https://solid-connection.com";
-  const pageUrl = `${baseUrl}/university/${homeUniversity}/${collegeId}`;
+  const pageUrl = createUrl(`/university/${homeUniversity}/${collegeId}`);
   const countryExchangeKeyword = `${universityData.country} 교환학생`;
 
   const structuredData = {
@@ -155,11 +157,7 @@ const CollegeDetailPage = async ({ params }: PageProps) => {
     alternateName: universityData.englishName,
     url: pageUrl,
     description: `${convertedKoreanName}(${universityData.englishName}) ${countryExchangeKeyword} 프로그램 정보`,
-    image: universityData.backgroundImageUrl
-      ? universityData.backgroundImageUrl.startsWith("http")
-        ? universityData.backgroundImageUrl
-        : `${baseUrl}${universityData.backgroundImageUrl}`
-      : `${baseUrl}/images/article-thumb.png`,
+    image: createAbsoluteUrl(universityData.backgroundImageUrl, "/images/article-thumb.png"),
   };
 
   return (

--- a/apps/web/src/app/university/[homeUniversity]/page.tsx
+++ b/apps/web/src/app/university/[homeUniversity]/page.tsx
@@ -10,6 +10,7 @@ import {
   isMatchedHomeUniversityName,
 } from "@/constants/university";
 import { type CountryCode, type HomeUniversitySlug, LanguageTestType, RegionEnumExtend } from "@/types/university";
+import { createUrl, NO_INDEX_ROBOTS } from "@/utils/seo";
 
 import UniversityListContent from "./_ui/UniversityListContent";
 
@@ -69,12 +70,36 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   if (!universityInfo) {
     return {
       title: "파견 학교 목록",
+      robots: NO_INDEX_ROBOTS,
     };
   }
 
+  const title = `${universityInfo.shortName} 교환학생 파견 학교 목록 | 솔리드커넥션`;
+  const description = `${universityInfo.name} 학생들을 위한 교환학생 파견 학교 정보를 확인하세요. 국가, 권역, 어학 요건별로 지원 가능한 대학을 비교할 수 있습니다.`;
+  const pageUrl = createUrl(`/university/${homeUniversity}`);
+
   return {
-    title: `${universityInfo.shortName} 교환학생 파견 학교 목록 | 솔리드커넥션`,
-    description: `${universityInfo.name} 학생들을 위한 교환학생 파견 학교 정보를 확인하세요.`,
+    title,
+    description,
+    alternates: {
+      canonical: pageUrl,
+    },
+    openGraph: {
+      title,
+      description,
+      url: pageUrl,
+      siteName: "솔리드커넥션",
+      locale: "ko_KR",
+      type: "website",
+      images: [
+        {
+          url: createUrl("/opengraph-image.png"),
+          width: 1200,
+          height: 630,
+          alt: `${universityInfo.shortName} 교환학생 파견 학교 목록`,
+        },
+      ],
+    },
   };
 }
 

--- a/apps/web/src/app/university/[homeUniversity]/search/page.tsx
+++ b/apps/web/src/app/university/[homeUniversity]/search/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import TopDetailNavigation from "@/components/layout/TopDetailNavigation";
 import { getHomeUniversityBySlug, HOME_UNIVERSITY_SLUGS } from "@/constants/university";
 import type { HomeUniversitySlug } from "@/types/university";
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 
 import SearchPageContent from "./_ui/SearchPageContent";
 
@@ -25,12 +26,19 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const universityInfo = getHomeUniversityBySlug(homeUniversity);
 
   if (!universityInfo) {
-    return { title: "파견 학교 검색" };
+    return {
+      title: "파견 학교 검색",
+      robots: NO_INDEX_ROBOTS,
+    };
   }
 
+  const title = `${universityInfo.shortName} 파견 학교 검색 | 솔리드커넥션`;
+  const description = `${universityInfo.name} 학생을 위한 맞춤 파견 학교를 검색하세요. 국가와 어학 조건을 기준으로 교환학생 지원 가능 대학을 찾아볼 수 있습니다.`;
+
   return {
-    title: `${universityInfo.shortName} 파견 학교 검색 | 솔리드커넥션`,
-    description: `${universityInfo.name} 학생을 위한 맞춤 파견 학교를 검색하세요.`,
+    title,
+    description,
+    robots: NO_INDEX_ROBOTS,
   };
 }
 

--- a/apps/web/src/app/university/application/apply/page.tsx
+++ b/apps/web/src/app/university/application/apply/page.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from "next";
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 import ApplyPageContent from "./ApplyPageContent";
 
 export const metadata: Metadata = {
   title: "지원하기",
+  robots: NO_INDEX_ROBOTS,
 };
 const ApplyPage = () => {
   return (

--- a/apps/web/src/app/university/application/page.tsx
+++ b/apps/web/src/app/university/application/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from "next";
 
 import TopDetailNavigation from "@/components/layout/TopDetailNavigation";
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 
 import ScorePageContent from "./ScorePageContent";
 
 export const metadata: Metadata = {
   title: "점수 공유 현황",
+  robots: NO_INDEX_ROBOTS,
 };
 
 const ScorePage = () => {

--- a/apps/web/src/app/university/list/[homeUniversityName]/page.tsx
+++ b/apps/web/src/app/university/list/[homeUniversityName]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import TopDetailNavigation from "@/components/layout/TopDetailNavigation";
 import { HOME_UNIVERSITY_LIST, HOME_UNIVERSITY_SLUG_MAP } from "@/constants/university";
 import type { HomeUniversityName, HomeUniversitySlug } from "@/types/university";
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 
 import SearchResultsContent from "./SearchResultsContent";
 
@@ -29,12 +30,14 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   if (!universityName) {
     return {
       title: "파견 학교 목록",
+      robots: NO_INDEX_ROBOTS,
     };
   }
 
   return {
     title: `${universityName} 파견 학교 목록 | 솔리드커넥션`,
     description: `${universityName}에서 파견 가능한 교환학생 대학교 목록입니다. 지역별, 어학 요건별로 검색하고 관심있는 대학을 찾아보세요.`,
+    robots: NO_INDEX_ROBOTS,
   };
 }
 

--- a/apps/web/src/app/university/score/example/layout.tsx
+++ b/apps/web/src/app/university/score/example/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
+
+export const metadata: Metadata = {
+  title: "증명서 예시",
+  robots: NO_INDEX_ROBOTS,
+};
+
+const ScoreExampleLayout = ({ children }: { children: ReactNode }) => children;
+
+export default ScoreExampleLayout;

--- a/apps/web/src/app/university/score/page.tsx
+++ b/apps/web/src/app/university/score/page.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from "next";
 
 import TopDetailNavigation from "@/components/layout/TopDetailNavigation";
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 import ScoreScreen from "./ScoreScreen";
 
 export const metadata: Metadata = {
   title: "성적 확인하기",
+  robots: NO_INDEX_ROBOTS,
 };
 
 const ScorePage = () => {

--- a/apps/web/src/app/university/score/submit/gpa/page.tsx
+++ b/apps/web/src/app/university/score/submit/gpa/page.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from "next";
 
 import TopDetailNavigation from "@/components/layout/TopDetailNavigation";
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 import GpaSubmitForm from "./GpaSubmitForm";
 
 export const metadata: Metadata = {
   title: "성적 입력하기",
+  robots: NO_INDEX_ROBOTS,
 };
 
 const SubmitGpaPage = () => {

--- a/apps/web/src/app/university/score/submit/language-test/page.tsx
+++ b/apps/web/src/app/university/score/submit/language-test/page.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from "next";
 
 import TopDetailNavigation from "@/components/layout/TopDetailNavigation";
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 import LanguageTestSubmitForm from "./LanguageTestSubmitForm";
 
 export const metadata: Metadata = {
   title: "성적 입력하기",
+  robots: NO_INDEX_ROBOTS,
 };
 
 const SubmitLanguageTestPage = () => {

--- a/apps/web/src/app/university/search/page.tsx
+++ b/apps/web/src/app/university/search/page.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from "next";
 
 import TopDetailNavigation from "@/components/layout/TopDetailNavigation";
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
 import SearchClientContent from "./SearchClientContent";
 
 export const metadata: Metadata = {
   title: "파견 학교 목록",
+  robots: NO_INDEX_ROBOTS,
 };
 
 const Page = async () => {

--- a/apps/web/src/utils/seo.ts
+++ b/apps/web/src/utils/seo.ts
@@ -1,0 +1,66 @@
+import type { Metadata } from "next";
+
+export const DEFAULT_SITE_URL = "https://www.solid-connection.com";
+export const DEFAULT_OG_IMAGE_PATH = "/opengraph-image.png";
+
+const TRAILING_SLASHES = /\/+$/;
+const HTML_TAGS = /<[^>]*>/g;
+const WHITESPACE = /\s+/g;
+
+export const NO_INDEX_ROBOTS = {
+  index: false,
+  follow: false,
+  googleBot: {
+    index: false,
+    follow: false,
+  },
+} satisfies Metadata["robots"];
+
+export const getSiteUrl = () => {
+  const siteUrl = process.env.NEXT_PUBLIC_WEB_URL || DEFAULT_SITE_URL;
+  return siteUrl.replace(TRAILING_SLASHES, "");
+};
+
+export const isNonIndexSiteUrl = (siteUrl: string = getSiteUrl()) => {
+  const vercelEnv = process.env.VERCEL_ENV;
+
+  return (
+    vercelEnv === "preview" ||
+    vercelEnv === "development" ||
+    siteUrl.includes("stage") ||
+    siteUrl.includes("localhost") ||
+    siteUrl.includes("127.0.0.1") ||
+    siteUrl.includes("[::1]")
+  );
+};
+
+export const createUrl = (path: string = "/") => {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return new URL(normalizedPath, `${getSiteUrl()}/`).toString();
+};
+
+export const createAbsoluteUrl = (url: string | null | undefined, fallbackPath: string = DEFAULT_OG_IMAGE_PATH) => {
+  const trimmedUrl = url?.trim();
+
+  if (!trimmedUrl) {
+    return createUrl(fallbackPath);
+  }
+
+  if (trimmedUrl.startsWith("http://") || trimmedUrl.startsWith("https://")) {
+    return trimmedUrl;
+  }
+
+  return createUrl(trimmedUrl.startsWith("/") ? trimmedUrl : `/${trimmedUrl}`);
+};
+
+export const stripHtml = (value: string) => value.replace(HTML_TAGS, " ").replace(WHITESPACE, " ").trim();
+
+export const truncateDescription = (value: string, maxLength: number = 150) => {
+  const text = stripHtml(value);
+
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  return `${text.slice(0, maxLength - 3).trim()}...`;
+};


### PR DESCRIPTION
## 관련 이슈

- resolves: 없음

## 작업 내용

- 사이트 기준 URL을 공통 SEO 유틸로 통일하고 canonical, robots, sitemap의 기본 도메인을 `https://www.solid-connection.com`으로 맞췄습니다.
- sitemap을 공개 검색 표면 중심으로 재구성해 홈, 대학 선택, 약관, 홈대학별 대학 목록, 대학 상세 URL을 노출합니다.
- 로그인, 회원가입, 마이페이지, 멘토, 커뮤니티, 지원/성적 입력 등 인증 또는 클라이언트 의존 페이지는 `noindex`로 정리했습니다.
- 홈 JSON-LD의 실제 라우트와 맞지 않는 `SearchAction`을 제거하고, 대학 상세 404는 `notFound()`로 처리하도록 정리했습니다.
- Next 타입체크를 막던 `revalidateTag` 호출 시그니처를 현재 타입에 맞게 수정했습니다.

## 특이 사항

- 독립 리뷰어 피드백을 반영해 멘토/커뮤니티 상세는 현재 서버 렌더 공개 콘텐츠와 실제 클라이언트 콘텐츠가 일치하지 않아 sitemap에서 제외하고 `noindex`로 두었습니다.
- `pnpm --filter @solid-connect/web run build`는 컴파일 성공 후 static prerender 단계에서 `Unsupported Server Component type: {...}` 오류로 실패합니다. 오류는 루트, 로그인, 마이페이지, 대학 상세 등 다수 기존 라우트에 걸쳐 발생하며, 빌드 중 Next가 `tsconfig.json`의 `jsx`를 자동 변경하려 해 해당 변경은 원복했습니다.
- 로컬 Node는 `v23.10.0`이고 패키지 요구 버전은 Node `22.x`라 검증 시 경고가 출력됩니다.

## 리뷰 요구사항 (선택)

- sitemap에 포함한 공개 URL 범위가 현재 서비스 정책과 맞는지 확인 부탁드립니다.
- 멘토/커뮤니티를 향후 검색 노출하려면 서버 렌더 공개 상세, 개인정보 동의, UGC moderation, 실제 404/noindex 정책을 먼저 정리해야 합니다.

## 검증

- `pnpm --filter @solid-connect/web run lint:check` 통과
- `pnpm --filter @solid-connect/web run typecheck:ci` 통과
- 커밋 훅의 `ci:check` 통과
- push 훅의 `ci:check` 통과 후 `next build` prerender 오류로 실패하여, 위 특이 사항을 남기고 훅을 우회해 브랜치를 푸시했습니다.
