### PR TITLE
fix: 멘토 UI 하단 요소 겹침과 날짜 색상 조정

### DIFF
--- a/apps/web/src/app/mentor/_ui/MentorClient/_ui/MentorFindSection/index.tsx
+++ b/apps/web/src/app/mentor/_ui/MentorClient/_ui/MentorFindSection/index.tsx
@@ -43,7 +43,7 @@ const MentorFindSection = () => {
       </div>
 
       {/* 멘토 리스트 */}
-      <div ref={listRef} className="space-y-4">
+      <div ref={listRef} className="space-y-4 pb-28">
         {mentorList.length === 0 ? (
           <EmptySdwBCards message="멘토가 없습니다. 필터를 변경해보세요." />
         ) : (

--- a/apps/web/src/app/mentor/chat/[chatId]/_ui/ChatContent/index.tsx
+++ b/apps/web/src/app/mentor/chat/[chatId]/_ui/ChatContent/index.tsx
@@ -155,7 +155,7 @@ const ChatContent = ({ chatId }: ChatContentProps) => {
                     {/* 날짜 구분선 */}
                     {showDateSeparator && (
                       <div className="my-4 mb-6 flex w-full justify-center">
-                        <span className="rounded-full bg-gray-100 px-3 py-1 text-gray-600 typo-regular-2">
+                        <span className="rounded-full bg-k-50 px-3 py-1 text-k-600 typo-regular-2">
                           {formatDateSeparator(message.createdAt)}
                         </span>
                       </div>


### PR DESCRIPTION
## 관련 이슈

- 없음

## 작업 내용

- 멘토 찾기 목록 하단에 여백을 추가해 마지막 멘토 카드의 상세보기 토글 버튼이 위로가기 버튼과 겹치지 않도록 수정했습니다.
- 멘토 채팅 날짜 구분선 pill 색상을 밝은 회색 배경(`bg-k-50`)과 진한 회색 텍스트(`text-k-600`) 조합으로 반전했습니다.

## 특이 사항

- 기존 SEO PR 브랜치에 얹혀 있던 변경 중 멘토 UI 관련 커밋 2개만 `origin/main` 기준 새 브랜치로 분리했습니다.
- 로컬 환경은 Node `v23.10.0`이고 저장소 요구 버전은 Node `22.x`라 engine warning이 출력됩니다.

## 리뷰 요구사항 (선택)

- 멘토 목록 마지막 카드가 펼쳐진 상태에서 하단 floating 위로가기 버튼과 상세보기 토글이 겹치지 않는지 확인 부탁드립니다.
- 채팅 날짜 구분선 색상이 의도한 밝은 회색 계열로 보이는지 확인 부탁드립니다.

## 검증

- `pnpm --filter @solid-connect/web run lint:check` 통과
- `pnpm --filter @solid-connect/web run typecheck:ci` 실패
  - 본 PR 변경 파일 밖의 기존 `apps/web/src/app/api/revalidate/route.ts`에서 `revalidateTag(..., { expire: 0 })` 타입 오류가 발생했습니다.
  - PR diff는 멘토 UI 2개 파일로만 제한했습니다.
