### PR TITLE
chore: 대학 정보 릴리즈 타깃 추가

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,16 @@ on:
   workflow_dispatch:
     inputs:
       target:
-        description: "Promote target"
+        description: "Promote target (both keeps the legacy web+admin selection)"
         required: true
-        default: "both"
+        default: "all"
         type: choice
         options:
+          - all
           - both
           - web
           - admin
+          - university
       force_redeploy:
         description: "When up to date, skip divergence and print manual redeploy guidance"
         required: true
@@ -70,6 +72,12 @@ jobs:
               ;;
             admin)
               RELEASE_BRANCHES="release-admin"
+              ;;
+            university)
+              RELEASE_BRANCHES="release-university"
+              ;;
+            all)
+              RELEASE_BRANCHES="release-web release-admin release-university"
               ;;
             both)
               RELEASE_BRANCHES="release-web release-admin"

--- a/docs/git-cicd.md
+++ b/docs/git-cicd.md
@@ -41,4 +41,16 @@ GitHub Actions, Vercel를 사용하여 CI/CD를 관리합니다.
 
 main 브랜치에 push가 되면 자동으로 CI가 진행되어 stage 환경에 배포됩니다.
 
-Github Actions의 'Build and Vercel Production Deployment' 를 가동시키면 CD가 진행되어 production 환경에 배포됩니다.
+Github Actions의 `Promote Main to Release Branches`를 가동시키면 선택한 release branch가 main으로 갱신되고, 각 Vercel Project의 production 환경에 배포됩니다.
+
+- `release-web`: web production 배포
+- `release-admin`: admin production 배포
+- `release-university`: university-web production 배포
+
+릴리즈 workflow의 target은 다음과 같이 사용합니다.
+
+- `all`: web, admin, university-web 전체 릴리즈
+- `both`: 기존 호환용 web + admin 릴리즈
+- `web`: web만 릴리즈
+- `admin`: admin만 릴리즈
+- `university`: university-web만 릴리즈

--- a/docs/university-multizone-deployment.md
+++ b/docs/university-multizone-deployment.md
@@ -63,6 +63,32 @@ Vercel에서는 같은 Git repository를 두 개의 Project로 연결한다.
 
 University project의 직접 배포 도메인은 검색엔진에 노출하지 않는다. 실제 사용자 URL은 main domain의 rewrite를 통해 제공한다.
 
+## Release 배포
+
+production 릴리즈는 GitHub Actions `Promote Main to Release Branches` workflow로 release branch를 갱신해 Vercel 배포를 트리거한다.
+
+- Main Web Project production branch: `release-web`
+- Admin Project production branch: `release-admin`
+- University Web Project production branch: `release-university`
+
+workflow target은 다음과 같이 사용한다.
+
+- `all`: `release-web`, `release-admin`, `release-university`를 모두 main으로 갱신
+- `university`: `release-university`만 main으로 갱신
+- `both`: 기존 호환용으로 `release-web`, `release-admin`만 갱신
+
+production web project의 `UNIVERSITY_WEB_DOMAIN`은 university web production origin을 가리켜야 한다. 예를 들어 사용자 production URL이 `https://www.solid-connection.com/university`라면 rewrite 대상은 별도 university web production origin이다.
+
+```bash
+UNIVERSITY_WEB_DOMAIN=https://<university-web-production-origin>
+```
+
+production university web project의 `NEXT_PUBLIC_WEB_URL`은 실제 사용자가 접근하는 main web production URL을 가리킨다.
+
+```bash
+NEXT_PUBLIC_WEB_URL=https://www.solid-connection.com
+```
+
 ## Local Development
 
 터미널 두 개에서 실행한다.


### PR DESCRIPTION
## 관련 이슈

- stacked on: #543

## 작업 내용

- release workflow의 target에 `university`와 `all`을 추가했습니다.
- `university` 선택 시 `main -> release-university` 승격이 실행되도록 했습니다.
- `all` 선택 시 `release-web`, `release-admin`, `release-university`를 함께 갱신하도록 했습니다.
- 기존 `both`는 web + admin 릴리즈 의미로 유지해 기존 사용 흐름을 보존했습니다.
- Git/CD 문서와 university 멀티존 배포 문서에 `release-university` production branch 설정을 추가했습니다.

## 특이 사항

- 이 PR은 #543 위에 쌓는 stacked PR입니다. #543이 먼저 머지되어야 diff가 깔끔합니다.
- Vercel university-web Project의 Production Branch는 `release-university`로 설정해야 합니다.
- production web Project의 `UNIVERSITY_WEB_DOMAIN`은 university-web production origin을 바라봐야 합니다.

## 검증

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml YAML parse passed"'`
- release target 매핑 shell 검증
- `git diff --check`
- commit hook CI parity checks 통과
- push hook CI parity checks + web/university-web/admin build 통과

## 리뷰 요구사항 (선택)

- `all`을 새 기본 target으로 둔 것이 운영 릴리즈 플로우에 맞는지 확인 부탁드립니다.
- `both`를 기존 호환용 web + admin으로 유지하는 네이밍이 괜찮은지 확인 부탁드립니다.
