### PR TITLE
fix: 관심학교 카드 너비 보정

### DIFF
--- a/apps/web/src/components/ui/UniverSityCard/index.tsx
+++ b/apps/web/src/components/ui/UniverSityCard/index.tsx
@@ -24,7 +24,11 @@ const UniversityCard = ({ university, showCapacity = true, linkPrefix = "/univer
       : "/university";
 
   return (
-    <Link className="block" href={universityDetailHref} aria-labelledby={`university-name-${university.id}`}>
+    <Link
+      className="block w-full min-w-0 flex-1"
+      href={universityDetailHref}
+      aria-labelledby={`university-name-${university.id}`}
+    >
       <div className="relative h-[91px] w-full overflow-hidden rounded-lg border border-solid border-k-100 hover:-translate-y-0.5 hover:shadow-md hover:shadow-black/10">
         <div className="flex justify-between px-5 py-3.5">
           <div className="flex gap-[23.5px]">


### PR DESCRIPTION
## 관련 이슈

- resolves: #546

## 작업 내용

- 관심학교 목록에서 대학 카드가 콘텐츠 너비만큼만 렌더링되는 문제를 수정했습니다.
- 공통 `UniversityCard`의 최상위 `Link`가 부모 컨테이너 너비를 채우도록 `w-full`, `flex-1`, `min-w-0`을 적용했습니다.
- 카드 내부 영역은 기존처럼 `w-full`을 유지하되, flex row 내부에서도 동일한 폭으로 표시되도록 보정했습니다.

## 특이 사항

- 로컬 검증 중 `pnpm --filter @solid-connect/web run lint:check`, `pnpm --filter @solid-connect/web run typecheck:ci`는 통과했습니다.
- 로컬 pre-push 훅의 `next build`는 전체 정적 페이지 생성 단계에서 `Unsupported Server Component type` 에러로 실패했습니다. 변경 파일은 카드 스타일 1개뿐이고, 로컬 Node가 프로젝트 요구 버전(`22.x`)과 다른 `23.10.0`인 상태에서 발생한 전체 빌드 오류라 본 수정과는 별개로 보입니다.
- 위 빌드 실패 과정에서 Next가 `tsconfig.json`을 자동 변경했으나, 해당 변경은 작업 범위가 아니므로 반영하지 않았습니다.

## 리뷰 요구사항 (선택)

- 관심학교 편집 모드에서 체크 버튼이 노출될 때도 카드가 남은 영역을 자연스럽게 채우는지 확인 부탁드립니다.
