### PR TITLE
feat: 커뮤니티 사용자 차단 분리

### DIFF
--- a/apps/web/src/app/community/[boardCode]/CommunityPageContent.tsx
+++ b/apps/web/src/app/community/[boardCode]/CommunityPageContent.tsx
@@ -21,6 +21,7 @@ const CommunityPageContent = ({ boardCode }: CommunityPageContentProps) => {
   const [category, setCategory] = useState<string | null>(COMMUNITY_INITIAL_CATEGORY);
   const reportedPostIds = useReportedPostsStore((state) => state.reportedPostIds);
   const blockedUserIds = useReportedPostsStore((state) => state.blockedUserIds);
+  const blockedPostIds = useReportedPostsStore((state) => state.blockedPostIds);
 
   const { data: posts = [], isPending } = useGetPostList({
     boardCode,
@@ -28,15 +29,16 @@ const CommunityPageContent = ({ boardCode }: CommunityPageContentProps) => {
   });
 
   const visiblePosts = useMemo(() => {
-    if (reportedPostIds.length === 0 && blockedUserIds.length === 0) {
+    if (reportedPostIds.length === 0 && blockedUserIds.length === 0 && blockedPostIds.length === 0) {
       return posts;
     }
 
     const reportedIdSet = new Set(reportedPostIds);
     const blockedUserIdSet = new Set(blockedUserIds);
+    const blockedPostIdSet = new Set(blockedPostIds);
 
     return posts.filter((post) => {
-      if (reportedIdSet.has(post.id)) {
+      if (reportedIdSet.has(post.id) || blockedPostIdSet.has(post.id)) {
         return false;
       }
 
@@ -48,7 +50,7 @@ const CommunityPageContent = ({ boardCode }: CommunityPageContentProps) => {
 
       return true;
     });
-  }, [posts, reportedPostIds, blockedUserIds]);
+  }, [posts, reportedPostIds, blockedUserIds, blockedPostIds]);
 
   const handleBoardChange = (newBoard: string) => {
     router.push(`/community/${newBoard}`);

--- a/apps/web/src/app/community/[boardCode]/CommunityPageContent.tsx
+++ b/apps/web/src/app/community/[boardCode]/CommunityPageContent.tsx
@@ -7,17 +7,10 @@ import { COMMUNITY_INITIAL_CATEGORY } from "@/apis/community/postListQuery";
 import ButtonTab from "@/components/ui/ButtonTab";
 import { COMMUNITY_BOARDS, COMMUNITY_CATEGORIES } from "@/constants/community";
 import useReportedPostsStore from "@/lib/zustand/useReportedPostsStore";
-import type { ListPost } from "@/types/community";
 import { CommunityPostListSkeleton } from "./CommunityPageSkeleton";
 import CommunityRegionSelector from "./CommunityRegionSelector";
 import PostCards from "./PostCards";
 import PostWriteButton from "./PostWriteButton";
-
-type ListPostWithAuthor = ListPost & {
-  postFindSiteUserResponse?: {
-    id: number;
-  };
-};
 
 interface CommunityPageContentProps {
   boardCode: string;
@@ -47,7 +40,7 @@ const CommunityPageContent = ({ boardCode }: CommunityPageContentProps) => {
         return false;
       }
 
-      const authorId = (post as ListPostWithAuthor).postFindSiteUserResponse?.id;
+      const authorId = post.postFindSiteUserResponse?.id;
 
       if (typeof authorId === "number" && blockedUserIdSet.has(authorId)) {
         return false;

--- a/apps/web/src/app/community/[boardCode]/[postId]/CommentSection.tsx
+++ b/apps/web/src/app/community/[boardCode]/[postId]/CommentSection.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import clsx from "clsx";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useDeleteComment } from "@/apis/community";
+import useBlockCommunityUser from "@/app/community/_hooks/useBlockCommunityUser";
 import Dropdown from "@/components/ui/Dropdown";
 import Image from "@/components/ui/FallbackImage";
 import { DEFAULT_PROFILE_IMAGE } from "@/constants/profile";
+import useReportedPostsStore from "@/lib/zustand/useReportedPostsStore";
 import { IconMoreVertFilled, IconSubComment } from "@/public/svgs";
 import type { Comment as CommentType, CommunityUser } from "@/types/community";
 import { normalizeImageUrlToUploadCdn } from "@/utils/cdnUrl";
@@ -21,8 +23,19 @@ type CommentSectionProps = {
 const CommentSection = ({ comments, postId, refresh }: CommentSectionProps) => {
   const [curSelectedComment, setCurSelectedComment] = useState<number | null>(null);
   const [activeDropdown, setActiveDropdown] = useState<number | null>(null);
+  const blockedUserIds = useReportedPostsStore((state) => state.blockedUserIds);
 
   const deleteCommentMutation = useDeleteComment();
+
+  const visibleComments = useMemo(() => {
+    if (blockedUserIds.length === 0) {
+      return comments;
+    }
+
+    const blockedUserIdSet = new Set(blockedUserIds);
+
+    return comments.filter((comment) => !blockedUserIdSet.has(comment.postFindSiteUserResponse.id));
+  }, [comments, blockedUserIds]);
 
   const deleteComment = (commentId: number) => {
     if (!window.confirm("정말 삭제하시겠습니까?")) return;
@@ -31,7 +44,7 @@ const CommentSection = ({ comments, postId, refresh }: CommentSectionProps) => {
 
   return (
     <div className="min-h-[50vh] pb-[49px]">
-      {comments?.map((comment) => (
+      {visibleComments?.map((comment) => (
         <Comment
           key={comment.id}
           comment={comment}
@@ -114,11 +127,15 @@ const Comment = ({
               nickname: isDeleted ? "알 수 없음" : comment.postFindSiteUserResponse.nickname,
             }}
           />
-          {comment.isOwner && (
+          {!isDeleted && (
             <CommentDropdown
               commentId={comment.id}
+              isOwner={comment.isOwner}
+              authorId={comment.postFindSiteUserResponse.id}
+              authorNickname={comment.postFindSiteUserResponse.nickname}
               activeDropdown={activeDropdown}
               toggleDropdown={toggleDropdown}
+              setActiveDropdown={setActiveDropdown}
               deleteComment={deleteComment}
             />
           )}
@@ -151,32 +168,52 @@ const CommentProfile = ({ user }: { user: CommunityUser }) => {
 
 const CommentDropdown = ({
   commentId,
+  isOwner,
+  authorId,
+  authorNickname,
   activeDropdown,
   toggleDropdown,
+  setActiveDropdown,
   deleteComment,
 }: {
   commentId: number;
+  isOwner: boolean;
+  authorId: number;
+  authorNickname: string;
   activeDropdown: number | null;
   toggleDropdown: (commentId: number) => void;
+  setActiveDropdown: (commentId: number | null) => void;
   deleteComment: (commentId: number) => void;
 }) => {
+  const { handleBlockUser } = useBlockCommunityUser({
+    onBlocked: () => setActiveDropdown(null),
+  });
+
+  const options = isOwner
+    ? [
+        {
+          label: "삭제하기",
+          action: () => {
+            deleteComment(commentId);
+          },
+        },
+      ]
+    : [
+        {
+          label: "차단하기",
+          action: () => {
+            setActiveDropdown(null);
+            void handleBlockUser({ userId: authorId, nickname: authorNickname });
+          },
+        },
+      ];
+
   return (
-    <div className="relative">
+    <div className="relative" onClick={(event) => event.stopPropagation()}>
       <button className="cursor-pointer" onClick={() => toggleDropdown(commentId)} aria-label="더보기">
         <IconMoreVertFilled />
       </button>
-      {activeDropdown === commentId && (
-        <Dropdown
-          options={[
-            {
-              label: "삭제하기",
-              action: () => {
-                deleteComment(commentId);
-              },
-            },
-          ]}
-        />
-      )}
+      {activeDropdown === commentId && <Dropdown options={options} />}
     </div>
   );
 };

--- a/apps/web/src/app/community/[boardCode]/[postId]/KebabMenu.tsx
+++ b/apps/web/src/app/community/[boardCode]/[postId]/KebabMenu.tsx
@@ -99,7 +99,7 @@ const KebabMenu = ({ postId, boardCode, isOwner = false, authorId }: KebabMenuPr
                 <button
                   onClick={() => {
                     setIsDropdownOpen(false);
-                    void handleBlockUser({ userId: authorId });
+                    void handleBlockUser({ userId: authorId, postId });
                   }}
                   disabled={isBlocking}
                   className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-gray-700 typo-regular-2 hover:bg-k-50 disabled:cursor-not-allowed disabled:opacity-50"

--- a/apps/web/src/app/community/[boardCode]/[postId]/KebabMenu.tsx
+++ b/apps/web/src/app/community/[boardCode]/[postId]/KebabMenu.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { Ban } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { type RefObject, useEffect, useRef, useState } from "react";
 import { useDeletePost } from "@/apis/community";
+import useBlockCommunityUser from "@/app/community/_hooks/useBlockCommunityUser";
 import ReportPanel from "@/components/ui/ReportPanel";
 import { showIconToast } from "@/lib/toast/showIconToast";
 import { IconSetting } from "@/public/svgs/mentor";
@@ -52,6 +54,9 @@ const KebabMenu = ({ postId, boardCode, isOwner = false, authorId }: KebabMenuPr
   const dropdownRef = useRef<HTMLDivElement>(null);
   const { mutate: deletePost } = useDeletePost();
   const router = useRouter();
+  const { handleBlockUser, isBlocking } = useBlockCommunityUser({
+    onBlocked: () => router.replace(`/community/${boardCode}`),
+  });
 
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
@@ -87,8 +92,25 @@ const KebabMenu = ({ postId, boardCode, isOwner = false, authorId }: KebabMenuPr
         <div className="absolute right-0 top-full z-10 mt-2 w-40 origin-top-right rounded-lg border border-gray-100 bg-white shadow-lg">
           <ul className="p-1">
             <li>
-              <ReportPanel idx={postId} blockUserId={authorId} />
+              <ReportPanel idx={postId} />
             </li>
+            {!isOwner && authorId && (
+              <li key={"차단하기"}>
+                <button
+                  onClick={() => {
+                    setIsDropdownOpen(false);
+                    void handleBlockUser({ userId: authorId });
+                  }}
+                  disabled={isBlocking}
+                  className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-gray-700 typo-regular-2 hover:bg-k-50 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <span className="flex-shrink-0">
+                    <Ban className="h-[18px] w-[18px] text-sub-d-500" />
+                  </span>
+                  <span>{"차단하기"}</span>
+                </button>
+              </li>
+            )}
             <li key={"URL 복사"}>
               <button
                 onClick={handleCopyUrl}

--- a/apps/web/src/app/community/[boardCode]/[postId]/PostPageContent.tsx
+++ b/apps/web/src/app/community/[boardCode]/[postId]/PostPageContent.tsx
@@ -19,16 +19,17 @@ const PostPageContent = ({ boardCode, postId }: PostPageContentProps) => {
   const router = useRouter();
   const reportedPostIds = useReportedPostsStore((state) => state.reportedPostIds);
   const blockedUserIds = useReportedPostsStore((state) => state.blockedUserIds);
-  const isReportedPost = reportedPostIds.includes(postId);
+  const blockedPostIds = useReportedPostsStore((state) => state.blockedPostIds);
+  const isHiddenPost = reportedPostIds.includes(postId) || blockedPostIds.includes(postId);
 
   const { data: post, isLoading, isError, refetch } = useGetPostDetail(postId);
   const isBlockedUserPost = post ? blockedUserIds.includes(post.postFindSiteUserResponse.id) : false;
 
   useEffect(() => {
-    if (isReportedPost) {
+    if (isHiddenPost) {
       router.replace(`/community/${boardCode}`);
     }
-  }, [boardCode, isReportedPost, router]);
+  }, [boardCode, isHiddenPost, router]);
 
   useEffect(() => {
     if (isBlockedUserPost) {
@@ -36,7 +37,7 @@ const PostPageContent = ({ boardCode, postId }: PostPageContentProps) => {
     }
   }, [boardCode, isBlockedUserPost, router]);
 
-  if (isReportedPost || isBlockedUserPost) {
+  if (isHiddenPost || isBlockedUserPost) {
     return null;
   }
 

--- a/apps/web/src/app/community/_hooks/useBlockCommunityUser.ts
+++ b/apps/web/src/app/community/_hooks/useBlockCommunityUser.ts
@@ -13,6 +13,7 @@ type BlockCommunityUserOptions = {
 
 type BlockCommunityUserParams = {
   userId?: number;
+  postId?: number;
   nickname?: string;
 };
 
@@ -22,8 +23,9 @@ const useBlockCommunityUser = ({ onBlocked }: BlockCommunityUserOptions = {}) =>
   const { mutateAsync: blockUser, isPending } = postBlockUser();
   const blockedUserIds = useReportedPostsStore((state) => state.blockedUserIds);
   const addBlockedUser = useReportedPostsStore((state) => state.addBlockedUser);
+  const addBlockedPost = useReportedPostsStore((state) => state.addBlockedPost);
 
-  const handleBlockUser = async ({ userId, nickname }: BlockCommunityUserParams) => {
+  const handleBlockUser = async ({ userId, postId, nickname }: BlockCommunityUserParams) => {
     if (!userId) {
       return;
     }
@@ -48,6 +50,9 @@ const useBlockCommunityUser = ({ onBlocked }: BlockCommunityUserOptions = {}) =>
     }
 
     addBlockedUser(userId);
+    if (postId) {
+      addBlockedPost(postId);
+    }
     onBlocked?.();
 
     try {

--- a/apps/web/src/app/community/_hooks/useBlockCommunityUser.ts
+++ b/apps/web/src/app/community/_hooks/useBlockCommunityUser.ts
@@ -55,10 +55,11 @@ const useBlockCommunityUser = ({ onBlocked }: BlockCommunityUserOptions = {}) =>
         blockedId: userId,
         data: {},
       });
-      showIconToast("logo", "사용자를 차단했습니다.");
     } catch {
-      showIconToast("logo", "차단 정보를 로컬에 저장했습니다.");
+      // 서버 차단 동기화 실패와 관계없이 현재 화면에서는 차단 상태를 즉시 반영합니다.
     }
+
+    showIconToast("logo", "사용자를 차단했습니다.");
   };
 
   return {

--- a/apps/web/src/app/community/_hooks/useBlockCommunityUser.ts
+++ b/apps/web/src/app/community/_hooks/useBlockCommunityUser.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { Ban } from "lucide-react";
+import type { ComponentType, SVGProps } from "react";
+import { postBlockUser } from "@/apis/users";
+import { showIconToast } from "@/lib/toast/showIconToast";
+import { customConfirm } from "@/lib/zustand/useConfirmModalStore";
+import useReportedPostsStore from "@/lib/zustand/useReportedPostsStore";
+
+type BlockCommunityUserOptions = {
+  onBlocked?: () => void;
+};
+
+type BlockCommunityUserParams = {
+  userId?: number;
+  nickname?: string;
+};
+
+const IconBlock = Ban as ComponentType<SVGProps<SVGSVGElement>>;
+
+const useBlockCommunityUser = ({ onBlocked }: BlockCommunityUserOptions = {}) => {
+  const { mutateAsync: blockUser, isPending } = postBlockUser();
+  const blockedUserIds = useReportedPostsStore((state) => state.blockedUserIds);
+  const addBlockedUser = useReportedPostsStore((state) => state.addBlockedUser);
+
+  const handleBlockUser = async ({ userId, nickname }: BlockCommunityUserParams) => {
+    if (!userId) {
+      return;
+    }
+
+    if (blockedUserIds.includes(userId)) {
+      showIconToast("logo", "이미 차단한 사용자입니다.");
+      onBlocked?.();
+      return;
+    }
+
+    const userLabel = nickname ? `${nickname}님` : "이 사용자";
+    const ok = await customConfirm({
+      title: "사용자 차단",
+      content: `${userLabel}의 게시글과 댓글이 보이지 않도록 차단할까요?`,
+      approveMessage: "차단하기",
+      rejectMessage: "취소",
+      icon: IconBlock,
+    });
+
+    if (!ok) {
+      return;
+    }
+
+    addBlockedUser(userId);
+    onBlocked?.();
+
+    try {
+      await blockUser({
+        blockedId: userId,
+        data: {},
+      });
+      showIconToast("logo", "사용자를 차단했습니다.");
+    } catch {
+      showIconToast("logo", "차단 정보를 로컬에 저장했습니다.");
+    }
+  };
+
+  return {
+    handleBlockUser,
+    isBlocking: isPending,
+  };
+};
+
+export default useBlockCommunityUser;

--- a/apps/web/src/components/ui/ReportPanel/_hooks/useSelectReportHandler.ts
+++ b/apps/web/src/components/ui/ReportPanel/_hooks/useSelectReportHandler.ts
@@ -1,7 +1,6 @@
 import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
 import { usePostReports } from "@/apis/reports";
-import { postBlockUser } from "@/apis/users";
 import { reportReasons } from "@/constants/report";
 import { customConfirm } from "@/lib/zustand/useConfirmModalStore";
 import useReportedPostsStore from "@/lib/zustand/useReportedPostsStore";
@@ -13,19 +12,9 @@ interface UseSelectReportHandlerReturn {
   handleReasonSelect: (reason: ReportType) => Promise<void>;
 }
 
-interface UseSelectReportHandlerOptions {
-  blockUserId?: number;
-}
-
-const useSelectReportHandler = (
-  chatId: number,
-  { blockUserId }: UseSelectReportHandlerOptions = {},
-): UseSelectReportHandlerReturn => {
+const useSelectReportHandler = (chatId: number): UseSelectReportHandlerReturn => {
   const [selectedReason, setSelectedReason] = useState<ReportType | null>(null);
   const { mutateAsync: postReports } = usePostReports();
-  const { mutateAsync: blockUser } = postBlockUser();
-  const addBlockedUser = useReportedPostsStore((state) => state.addBlockedUser);
-  const removeBlockedUser = useReportedPostsStore((state) => state.removeBlockedUser);
   const addReportedPost = useReportedPostsStore((state) => state.addReportedPost);
   const pathname = usePathname();
   const router = useRouter();
@@ -49,20 +38,6 @@ const useSelectReportHandler = (
 
         if (pathname.startsWith("/community/")) {
           addReportedPost(chatId);
-
-          if (blockUserId) {
-            addBlockedUser(blockUserId);
-
-            try {
-              await blockUser({
-                blockedId: blockUserId,
-                data: {},
-              });
-            } catch {
-              removeBlockedUser(blockUserId);
-              return;
-            }
-          }
         }
 
         router.back();

--- a/apps/web/src/components/ui/ReportPanel/index.tsx
+++ b/apps/web/src/components/ui/ReportPanel/index.tsx
@@ -11,12 +11,11 @@ import useSelectReportHandler from "./_hooks/useSelectReportHandler";
 
 interface ReportPanelProps {
   idx: number;
-  blockUserId?: number;
 }
 
-const ReportPanel = ({ idx, blockUserId }: ReportPanelProps) => {
+const ReportPanel = ({ idx }: ReportPanelProps) => {
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
-  const { selectedReason, handleReasonSelect } = useSelectReportHandler(idx, { blockUserId });
+  const { selectedReason, handleReasonSelect } = useSelectReportHandler(idx);
 
   return (
     <>

--- a/apps/web/src/lib/zustand/useReportedPostsStore.ts
+++ b/apps/web/src/lib/zustand/useReportedPostsStore.ts
@@ -4,8 +4,10 @@ import { persist } from "zustand/middleware";
 interface ReportedPostsState {
   reportedPostIds: number[];
   blockedUserIds: number[];
+  blockedPostIds: number[];
   addReportedPost: (postId: number) => void;
   addBlockedUser: (userId: number) => void;
+  addBlockedPost: (postId: number) => void;
   removeBlockedUser: (userId: number) => void;
 }
 
@@ -14,6 +16,7 @@ const useReportedPostsStore = create<ReportedPostsState>()(
     (set) => ({
       reportedPostIds: [],
       blockedUserIds: [],
+      blockedPostIds: [],
       addReportedPost: (postId) => {
         set((state) => {
           if (state.reportedPostIds.includes(postId)) {
@@ -36,6 +39,17 @@ const useReportedPostsStore = create<ReportedPostsState>()(
           };
         });
       },
+      addBlockedPost: (postId) => {
+        set((state) => {
+          if (state.blockedPostIds.includes(postId)) {
+            return state;
+          }
+
+          return {
+            blockedPostIds: [...state.blockedPostIds, postId],
+          };
+        });
+      },
       removeBlockedUser: (userId) => {
         set((state) => ({
           blockedUserIds: state.blockedUserIds.filter((id) => id !== userId),
@@ -47,6 +61,7 @@ const useReportedPostsStore = create<ReportedPostsState>()(
       partialize: (state) => ({
         reportedPostIds: state.reportedPostIds,
         blockedUserIds: state.blockedUserIds,
+        blockedPostIds: state.blockedPostIds,
       }),
     },
   ),

--- a/apps/web/src/types/community.ts
+++ b/apps/web/src/types/community.ts
@@ -54,6 +54,7 @@ export interface ListPost {
   postCategory: string;
   url: string | null;
   postThumbnailUrl: string | null;
+  postFindSiteUserResponse?: CommunityUser;
 }
 
 export interface PostCreateRequest {


### PR DESCRIPTION
## 관련 이슈

- 없음

## 작업 내용

- 커뮤니티 신고 흐름에서 사용자 차단을 분리했습니다.
- 게시글 상세 더보기 메뉴에 별도 `차단하기` 액션을 추가했습니다.
- 댓글 더보기 메뉴에서 본인이 아닌 댓글 작성자를 `차단하기` 할 수 있도록 추가했습니다.
- 차단한 사용자의 게시글/댓글을 커뮤니티 화면에서 숨기도록 했습니다.
- 차단된 작성자의 게시글 상세에 접근하면 기존 목록으로 이동하도록 기존 상세 가드와 연결했습니다.

## 특이 사항

- 백엔드 댓글 차단 API가 별도로 추가되기 전까지도 프론트에서는 사용자 차단 상태를 기준으로 해당 사용자의 댓글을 숨깁니다.
- 현재 구현은 기존 사용자 차단 API(`/users/block/{blockedId}`)를 호출합니다.
- 검증 시 Node 버전 경고가 발생했습니다. 프로젝트 요구 버전은 `22.x`, 현재 로컬은 `23.10.0`입니다.

## 리뷰 요구사항 (선택)

- 신고만 했을 때 사용자가 자동 차단되지 않는지 확인 부탁드립니다.
- 게시글/댓글에서 각각 `차단하기` 후 해당 작성자의 콘텐츠가 즉시 보이지 않는지 확인 부탁드립니다.
- 댓글 차단 백엔드 API가 별도로 생길 경우 현재 훅의 API 호출부를 교체할 수 있을지 확인 부탁드립니다.

## 검증

- `pnpm --filter @solid-connect/web run lint:check`
- `pnpm --filter @solid-connect/web run typecheck:ci`
