### PR TITLE
fix: 어드민 액세스 토큰 저장 키 분리

### DIFF
--- a/apps/admin/src/components/features/auth/AdminLoginPage.tsx
+++ b/apps/admin/src/components/features/auth/AdminLoginPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMutation } from "@tanstack/react-query";
-import { type FormEvent, useId, useState } from "react";
+import { type ChangeEvent, type FormEvent, useId, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -26,6 +26,8 @@ export function AdminLoginPage({ onLoginSuccess }: AdminLoginPageProps) {
 	});
 
 	const isLoading = signInMutation.isPending;
+	const handleEmailChange = (e: ChangeEvent<HTMLInputElement>) => setEmail(e.target.value);
+	const handlePasswordChange = (e: ChangeEvent<HTMLInputElement>) => setPassword(e.target.value);
 
 	const handleSubmit = async (e: FormEvent) => {
 		e.preventDefault();
@@ -72,7 +74,7 @@ export function AdminLoginPage({ onLoginSuccess }: AdminLoginPageProps) {
 								type="email"
 								placeholder="admin@example.com"
 								value={email}
-								onChange={(e) => setEmail(e.target.value)}
+								onChange={handleEmailChange}
 								disabled={isLoading}
 								required
 								className="h-11 border-k-100 bg-bg-50 typo-regular-3 text-k-800 placeholder:text-k-400"
@@ -86,7 +88,7 @@ export function AdminLoginPage({ onLoginSuccess }: AdminLoginPageProps) {
 								id={passwordInputId}
 								type="password"
 								value={password}
-								onChange={(e) => setPassword(e.target.value)}
+								onChange={handlePasswordChange}
 								disabled={isLoading}
 								required
 								className="h-11 border-k-100 bg-bg-50 typo-regular-3 text-k-800"

--- a/apps/admin/src/lib/utils/localStorage.ts
+++ b/apps/admin/src/lib/utils/localStorage.ts
@@ -1,6 +1,17 @@
+const ADMIN_ACCESS_TOKEN_KEY = "adminAccessToken";
+const LEGACY_ACCESS_TOKEN_KEY = "accessToken";
+
+const removeLegacyToken = (key: string) => {
+	try {
+		localStorage.removeItem(key);
+	} catch (err) {
+		console.error(`Could not remove legacy token: ${key}`, err);
+	}
+};
+
 export const loadAccessToken = () => {
 	try {
-		return localStorage.getItem("accessToken");
+		return localStorage.getItem(ADMIN_ACCESS_TOKEN_KEY);
 	} catch (err) {
 		console.error("Could not load access token", err);
 		return null;
@@ -9,7 +20,8 @@ export const loadAccessToken = () => {
 
 export const saveAccessToken = (token: string) => {
 	try {
-		localStorage.setItem("accessToken", token);
+		localStorage.setItem(ADMIN_ACCESS_TOKEN_KEY, token);
+		removeLegacyToken(LEGACY_ACCESS_TOKEN_KEY);
 	} catch (err) {
 		console.error("Could not save access token", err);
 	}
@@ -17,7 +29,8 @@ export const saveAccessToken = (token: string) => {
 
 export const removeAccessToken = () => {
 	try {
-		localStorage.removeItem("accessToken");
+		localStorage.removeItem(ADMIN_ACCESS_TOKEN_KEY);
+		removeLegacyToken(LEGACY_ACCESS_TOKEN_KEY);
 	} catch (err) {
 		console.error("Could not remove access token", err);
 	}


### PR DESCRIPTION
## 작업 내용

- 어드민 localStorage access token 저장 키를 `accessToken`에서 `adminAccessToken`으로 분리했습니다.
- 어드민 토큰 저장/조회/삭제 시 기존 범용 `accessToken` 키를 정리해 웹/어드민 토큰 충돌 잔재를 줄였습니다.
- `refreshToken`은 서버가 HttpOnly cookie `refreshToken`으로 내려주는 상태라 프론트에서 prefix 처리하지 않고 기존 cookie 기반 재발급 흐름을 유지했습니다.
- 로그인 입력 핸들러 타입을 명시해 수정 파일의 implicit any를 정리했습니다.

## 검증

- `pnpm --filter @solid-connect/admin run lint:check` 통과
- `pnpm --filter @solid-connect/admin run typecheck:ci` 실패
  - 기존 admin 타입 오류로 실패합니다: `BrunoApiPageContent.tsx`, `ChatSocketPageContent.tsx`, `RegionsCountriesPageContent.tsx`의 implicit any
  - 기존 모듈 해석 오류로 실패합니다: `@solid-connect/ui/*`, `vinext`, `vite.config.ts` resolve 설정
  - 이번 변경 파일인 `AdminLoginPage.tsx`, `localStorage.ts` 관련 신규 타입 오류는 없습니다.

## 참고

- 서버 refreshToken cookie 키가 분리되기 전까지 refreshToken 충돌은 프론트에서 완전히 해결할 수 없습니다.
- 이번 PR은 프론트에서 제어 가능한 accessToken localStorage 충돌만 우선 방어합니다.
- 로컬 Node가 `v23.10.0`이라 프로젝트 요구 버전 `22.x` 경고가 발생했습니다.
