### PR TITLE
fix: 대학 앱바 메인 웹 이동 경로 보정

### DIFF
--- a/apps/university-web/src/components/layout/GlobalLayout/ui/BottomNavigation/index.tsx
+++ b/apps/university-web/src/components/layout/GlobalLayout/ui/BottomNavigation/index.tsx
@@ -20,6 +20,15 @@ const ICON_COMPONENTS = {
 } as const;
 
 const UNIVERSITY_ZONE_ROUTE_PREFIX = "/university";
+const mainWebOrigin = process.env.NEXT_PUBLIC_WEB_URL?.replace(/\/$/, "");
+
+const getMainWebHref = (route: string) => {
+  if (!mainWebOrigin) {
+    return route;
+  }
+
+  return `${mainWebOrigin}${route === "/" ? "" : route}`;
+};
 
 const BottomNavigation = () => {
   const pathname = usePathname();
@@ -57,7 +66,7 @@ const BottomNavigation = () => {
           return (
             <a
               key={text}
-              href={route}
+              href={getMainWebHref(route)}
               aria-current={isActive ? "page" : undefined}
               aria-label={`${text} 페이지로 이동`}
               className={className}


### PR DESCRIPTION
## 작업 내용
- university-web 하단 앱바에서 학교 외 메뉴(`/`, `/community`, `/mentor`, `/my`)를 `NEXT_PUBLIC_WEB_URL` 기준 absolute URL로 이동하도록 수정했습니다.
- university zone 내부 메뉴(`/university`)는 기존처럼 Next Link로 유지했습니다.
- `stage.university...`에서 홈 앱바를 눌렀을 때 `stage.university.../`가 아니라 메인 web 도메인으로 이동하도록 보정합니다.

## 배경
- PR #543 머지 후 university-web이 별도 origin에서 직접 접근될 수 있는데, 기존 상대 경로 href가 현재 university origin 기준으로 해석되어 메인 web이 아닌 university-web 내부로 이동했습니다.

## 검증
- `pnpm --filter @solid-connect/university-web run ci:check`
- `NEXT_PUBLIC_WEB_URL=https://www.stage.solid-connection.com pnpm --filter @solid-connect/university-web run build`
- push hook의 university-web ci/build 통과

## 참고
- Vercel Preview/Stage의 `NEXT_PUBLIC_WEB_URL`은 메인 web stage origin으로 설정되어 있어야 합니다.
- Production의 `NEXT_PUBLIC_WEB_URL`은 `https://www.solid-connection.com`입니다.