### PR TITLE
fix: 대학존 링크 레이아웃 보정

### DIFF
--- a/apps/web/src/app/(home)/_ui/HomeActionLinks/index.tsx
+++ b/apps/web/src/app/(home)/_ui/HomeActionLinks/index.tsx
@@ -1,12 +1,16 @@
 import Link from "next/link";
 
+import UniversityZoneLink from "@/components/ui/UniversityZoneLink";
 import { IconIdCard, IconMagnifyingGlass, IconMuseum, IconPaper } from "@/public/svgs/home";
 
 const HomeActionLinks = () => {
   return (
     <div className="flex flex-col gap-2.5 px-5 py-3.5">
       <div className="flex gap-2">
-        <a className="flex flex-1 flex-col gap-2 rounded-lg bg-bg-accent-blue p-2.5" href="/university/search">
+        <UniversityZoneLink
+          className="flex flex-1 flex-col gap-2 rounded-lg bg-bg-accent-blue p-2.5"
+          href="/university/search"
+        >
           <div className="flex flex-col">
             <span className="text-secondary typo-bold-5">학교 검색하기</span>
             <span className="text-k-700 typo-medium-4">모든 학교 목록을 확인해보세요</span>
@@ -14,7 +18,7 @@ const HomeActionLinks = () => {
           <div className="flex justify-end">
             <IconMagnifyingGlass />
           </div>
-        </a>
+        </UniversityZoneLink>
         <Link className="flex flex-1 flex-col gap-2 rounded-lg bg-bg-accent-sky p-2.5" href="/university/score">
           <div className="flex flex-col">
             <span className="text-sub-a typo-bold-5">성적 입력하기</span>

--- a/apps/web/src/app/(home)/_ui/HomeUniversitySearchSection/index.tsx
+++ b/apps/web/src/app/(home)/_ui/HomeUniversitySearchSection/index.tsx
@@ -76,7 +76,7 @@ const HomeUniversitySearchSection = () => {
 
       <a
         href={searchHref}
-        className="mt-3 w-full rounded-lg bg-primary px-4 py-4 text-center text-k-0 transition-colors typo-sb-9 hover:bg-primary-600"
+        className="mt-3 block w-full rounded-lg bg-primary px-4 py-4 text-center text-k-0 transition-colors typo-sb-9 hover:bg-primary-600"
       >
         학교 검색하기
       </a>

--- a/apps/web/src/app/(home)/_ui/HomeUniversitySearchSection/index.tsx
+++ b/apps/web/src/app/(home)/_ui/HomeUniversitySearchSection/index.tsx
@@ -3,6 +3,7 @@
 import clsx from "clsx";
 
 import CustomDropdown from "@/components/search/CustomDropdown";
+import UniversityZoneLink from "@/components/ui/UniversityZoneLink";
 import { IconHatColor, IconHatGray, IconLocationColor, IconLocationGray } from "@/public/svgs/search";
 import useHomeUniversitySearch from "./_hooks/useHomeUniversitySearch";
 
@@ -74,12 +75,12 @@ const HomeUniversitySearchSection = () => {
         })}
       </div>
 
-      <a
+      <UniversityZoneLink
         href={searchHref}
-        className="mt-3 block w-full rounded-lg bg-primary px-4 py-4 text-center text-k-0 transition-colors typo-sb-9 hover:bg-primary-600"
+        className="mt-3 w-full rounded-lg bg-primary px-4 py-4 text-center text-k-0 transition-colors typo-sb-9 hover:bg-primary-600"
       >
         학교 검색하기
-      </a>
+      </UniversityZoneLink>
     </section>
   );
 };

--- a/apps/web/src/app/(home)/_ui/PopularUniversitySection/_ui/PopularUniversityCard.tsx
+++ b/apps/web/src/app/(home)/_ui/PopularUniversitySection/_ui/PopularUniversityCard.tsx
@@ -1,4 +1,5 @@
 import Image from "@/components/ui/FallbackImage";
+import UniversityZoneLink from "@/components/ui/UniversityZoneLink";
 import { getHomeUniversitySlugByName } from "@/constants/university";
 import type { ListUniversity } from "@/types/university";
 import { normalizeImageUrlToUploadCdn } from "@/utils/cdnUrl";
@@ -24,7 +25,7 @@ const PopularUniversityCard = ({
     : "/university";
 
   return (
-    <a key={university.id} href={universityDetailHref}>
+    <UniversityZoneLink key={university.id} href={universityDetailHref}>
       <div className="relative w-[153px]">
         <div className="relative h-[120px] w-[153px] overflow-hidden rounded-lg bg-k-700">
           <Image
@@ -55,7 +56,7 @@ const PopularUniversityCard = ({
           {university.koreanName}
         </div>
       </div>
-    </a>
+    </UniversityZoneLink>
   );
 };
 

--- a/apps/web/src/app/(home)/_ui/UniversityList/index.tsx
+++ b/apps/web/src/app/(home)/_ui/UniversityList/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import ButtonTab from "@/components/ui/ButtonTab";
+import UniversityZoneLink from "@/components/ui/UniversityZoneLink";
 import UniversityCards from "@/components/university/UniversityCards";
 import { IconDirectionRight } from "@/public/svgs/mentor";
 
@@ -19,12 +20,12 @@ const UniversityList = ({ allRegionsUniversityList }: UniversityListProps) => {
     <div className="flex flex-col gap-2">
       <div className="flex justify-between">
         <span className="text-k-700 typo-sb-5">전체 학교 리스트</span>
-        <a href={moreHref}>
+        <UniversityZoneLink href={moreHref}>
           <span className="flex items-center gap-1 text-k-500 typo-sb-9">
             더보기
             <IconDirectionRight className="h-4 w-4" />
           </span>
-        </a>
+        </UniversityZoneLink>
       </div>
       <ButtonTab
         choices={homeUniversityChoices}

--- a/apps/web/src/components/layout/GlobalLayout/ui/BottomNavigation/index.tsx
+++ b/apps/web/src/components/layout/GlobalLayout/ui/BottomNavigation/index.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
+import UniversityZoneLink from "@/components/ui/UniversityZoneLink";
 import { NAV_ITEMS } from "./constant/NAV_ITEMS";
 import isRouteActive from "./lib/isRouteActive";
 import DegreeHat from "./ui/DegreeHat";
@@ -55,7 +56,7 @@ const BottomNavigation = () => {
 
         if (route === UNIVERSITY_ZONE_ROUTE) {
           return (
-            <a
+            <UniversityZoneLink
               key={text}
               href={route}
               aria-current={isActive ? "page" : undefined}
@@ -63,7 +64,7 @@ const BottomNavigation = () => {
               className={className}
             >
               {content}
-            </a>
+            </UniversityZoneLink>
           );
         }
 

--- a/apps/web/src/components/ui/UniverSityCard/index.tsx
+++ b/apps/web/src/components/ui/UniverSityCard/index.tsx
@@ -1,5 +1,6 @@
 import Image from "@/components/ui/FallbackImage";
 import CheveronRightFilled from "@/components/ui/icon/ChevronRightFilled";
+import UniversityZoneLink from "@/components/ui/UniversityZoneLink";
 import { getHomeUniversitySlugByName } from "@/constants/university";
 import type { ListUniversity } from "@/types/university";
 import { normalizeImageUrlToUploadCdn } from "@/utils/cdnUrl";
@@ -23,7 +24,7 @@ const UniversityCard = ({ university, showCapacity = true, linkPrefix = "/univer
       : "/university";
 
   return (
-    <a
+    <UniversityZoneLink
       className="block w-full min-w-0 flex-1"
       href={universityDetailHref}
       aria-labelledby={`university-name-${university.id}`}
@@ -73,7 +74,7 @@ const UniversityCard = ({ university, showCapacity = true, linkPrefix = "/univer
           </div>
         </div>
       </div>
-    </a>
+    </UniversityZoneLink>
   );
 };
 

--- a/apps/web/src/components/ui/UniversityZoneLink.tsx
+++ b/apps/web/src/components/ui/UniversityZoneLink.tsx
@@ -1,0 +1,13 @@
+import type { ComponentPropsWithoutRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+type UniversityZoneLinkProps = ComponentPropsWithoutRef<"a"> & {
+  href: string;
+};
+
+const UniversityZoneLink = ({ className, ...props }: UniversityZoneLinkProps) => {
+  return <a className={cn("block", className)} {...props} />;
+};
+
+export default UniversityZoneLink;

--- a/scripts/check-university-zone-navigation.mjs
+++ b/scripts/check-university-zone-navigation.mjs
@@ -9,6 +9,7 @@ const webSrcDir = path.join(repoRoot, "apps/web/src");
 const checkedExtensions = new Set([".ts", ".tsx"]);
 
 const allowedMainWebUniversityRoutes = ["/university/score", "/university/application"];
+const universityCatalogLinkTag = "UniversityZoneLink";
 
 const jsxHrefPattern =
   /<([A-Za-z][\w.]*)\b[^>]*\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|\{\s*"([^"]*)"\s*\}|\{\s*'([^']*)'\s*\}|\{\s*`([^`]*)`\s*\})/g;
@@ -91,7 +92,7 @@ const collectViolations = (filePath) => {
     const [, tagName] = match;
     const route = pickMatchedRoute(match, 2);
 
-    if (tagName === "a" || route === null || !isUniversityCatalogRoute(route)) {
+    if (tagName === universityCatalogLinkTag || route === null || !isUniversityCatalogRoute(route)) {
       continue;
     }
 
@@ -100,7 +101,7 @@ const collectViolations = (filePath) => {
         filePath,
         source,
         index: match.index,
-        message: `Use <a href="${route}"> for university catalog navigation instead of <${tagName}>.`,
+        message: `Use <${universityCatalogLinkTag} href="${route}"> for university catalog navigation instead of <${tagName}>.`,
       }),
     );
   }
@@ -145,7 +146,7 @@ const collectViolations = (filePath) => {
 const violations = listSourceFiles(webSrcDir).flatMap(collectViolations);
 
 if (violations.length > 0) {
-  console.error("University catalog navigation must use plain <a> tags in apps/web.");
+  console.error(`University catalog navigation must use <${universityCatalogLinkTag}> in apps/web.`);
   console.error("Allowed main-web exceptions: /university/score, /university/application");
   console.error("");
   console.error(violations.join("\n"));


### PR DESCRIPTION
## 관련 이슈

- resolves: #이슈 번호

## 작업 내용

- 메인 페이지의 `학교 검색하기` CTA가 raw `<a>` 전환 이후 inline 요소처럼 동작해 `w-full`, `mt-*` 레이아웃이 깨지던 문제를 수정했습니다.
- `apps/web`의 대학 카탈로그 멀티존 이동 링크를 `UniversityZoneLink` 컴포넌트로 공통화했습니다.
  - 실제 렌더링은 `<a>`를 유지해 멀티존 간 full document navigation 요구를 지킵니다.
  - 기본 `block` 스타일을 적용해 CTA/카드형 링크에서 inline anchor 레이아웃 문제가 다시 생기지 않게 했습니다.
  - `className`에 `flex` 등을 넘기는 기존 카드/하단 내비게이션 사용처는 `tailwind-merge`로 기존 display 의도가 유지됩니다.
- 홈 액션 링크, 홈 대학 검색, 전체 학교 더보기, 인기 대학 카드, 대학 카드, 하단 내비게이션의 대학존 링크 사용처를 `UniversityZoneLink`로 교체했습니다.
- `lint:university-zone-navigation` 규칙을 갱신해 `/university` 카탈로그 이동에 `Link`나 raw `<a>` 대신 `UniversityZoneLink`를 사용하도록 검사합니다.

## 특이 사항

- 뉴스, 멘토 채널, 멘토 아티클처럼 외부 URL로 이동하는 raw `<a>`는 기존 의미가 맞아 그대로 유지했습니다.
- `/university/score`, `/university/application` 계열은 main web에 남아 있는 허용 예외라 기존 `Link` 사용을 유지합니다.
- 로컬 Node가 repo engine인 `22.x`와 달라 `Unsupported engine` 경고가 출력되지만 검증은 통과했습니다.

## 리뷰 요구사항 (선택)

- `UniversityZoneLink`가 멀티존 이동 요구를 유지하면서도 CTA/카드 레이아웃을 깨지 않게 적용됐는지 확인 부탁드립니다.
- `/university` 카탈로그 이동과 main web 잔존 라우트(`/university/score`, `/university/application`)의 구분이 의도와 맞는지 봐주세요.

## 검증

- `pnpm --filter @solid-connect/web ci:check`
- pre-commit CI parity checks 통과
- pre-push CI parity checks 통과
  - `@solid-connect/web` ci/build
  - `@solid-connect/university-web` ci/build
  - `@solid-connect/admin` ci/build
