### PR TITLE
fix: 커뮤니티 기본 썸네일 숨김

### DIFF
--- a/apps/web/src/app/community/[boardCode]/PostCards.tsx
+++ b/apps/web/src/app/community/[boardCode]/PostCards.tsx
@@ -6,7 +6,6 @@ import { useRef } from "react";
 import Image from "@/components/ui/FallbackImage";
 import { IconPostLikeOutline } from "@/public/svgs";
 import { IconCommunication } from "@/public/svgs/community";
-import { IconSolidConnentionLogo } from "@/public/svgs/mentor";
 import type { ListPost } from "@/types/community";
 import { normalizeImageUrlToUploadCdn } from "@/utils/cdnUrl";
 import { convertISODateToDate } from "@/utils/datetimeUtils";
@@ -71,47 +70,77 @@ const PostCards = ({ posts, boardCode }: PostCardsProps) => {
 
 export default PostCards;
 
-export const PostCard = ({ post, priorityImage = false }: { post: ListPost; priorityImage?: boolean }) => (
-  <div className="flex justify-between border-b border-b-gray-c-100 px-5 py-4">
-    <div className="flex flex-col">
-      <div className="flex items-center truncate font-serif text-gray-250">
-        <span className="typo-bold-5">{post.postCategory || ""}</span>
-        <span className="ml-2.5 typo-regular-4">{convertISODateToDate(post.createdAt) || "1970. 1. 1."}</span>
-      </div>
-      <span className="mt-2 font-serif text-black typo-sb-7">{post.title || ""}</span>
-      <div className="mt-1 h-11 overflow-hidden text-ellipsis break-all font-serif text-gray-250 typo-medium-2">
-        {post.content || "내용 없음"}
-      </div>
-      <div className="mt-1 flex items-center gap-2.5">
-        <div className="flex items-center gap-1">
-          <IconPostLikeOutline />
-          <span className="overflow-hidden font-serif text-gray-500 typo-regular-4">{post.likeCount || 0}</span>
-        </div>
-        <div className="flex items-center gap-1">
-          <IconCommunication />
-          <span className="overflow-hidden font-serif text-gray-500 typo-regular-4">{post.commentCount || 0}</span>
-        </div>
-      </div>
-    </div>
+const DEFAULT_THUMBNAIL_PATHS = new Set([
+  "/article-thumb.png",
+  "/site-thumbnail.png",
+  "/images/article-thumb.png",
+  "/images/site-thumbnail.png",
+]);
 
-    <div className="ml-4 mt-3 h-20 w-20 shrink-0 select-none">
-      <div className="bg-gray-c-50 relative h-full w-full overflow-hidden rounded border border-k-100">
-        {post.postThumbnailUrl ? (
-          <Image
-            className="object-cover"
-            src={normalizeImageUrlToUploadCdn(post.postThumbnailUrl)}
-            fill
-            sizes="80px"
-            alt="게시글 사진"
-            fallbackSrc="/images/article-thumb.png"
-            loading={priorityImage ? "eager" : undefined}
-          />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center">
-            <IconSolidConnentionLogo />
+const getThumbnailPathname = (thumbnailSrc: string) => {
+  try {
+    return new URL(thumbnailSrc, "https://solid-connection.local").pathname;
+  } catch {
+    return thumbnailSrc;
+  }
+};
+
+const getPostThumbnailSrc = (postThumbnailUrl: string | null) => {
+  const thumbnailSrc = normalizeImageUrlToUploadCdn(postThumbnailUrl);
+  const thumbnailPathname = getThumbnailPathname(thumbnailSrc);
+
+  if (
+    !thumbnailSrc ||
+    DEFAULT_THUMBNAIL_PATHS.has(thumbnailPathname) ||
+    thumbnailPathname.startsWith("/svgs/placeholders/")
+  ) {
+    return null;
+  }
+
+  return thumbnailSrc;
+};
+
+export const PostCard = ({ post, priorityImage = false }: { post: ListPost; priorityImage?: boolean }) => {
+  const thumbnailSrc = getPostThumbnailSrc(post.postThumbnailUrl);
+
+  return (
+    <div className="flex justify-between border-b border-b-gray-c-100 px-5 py-4">
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="flex items-center truncate font-serif text-gray-250">
+          <span className="typo-bold-5">{post.postCategory || ""}</span>
+          <span className="ml-2.5 typo-regular-4">{convertISODateToDate(post.createdAt) || "1970. 1. 1."}</span>
+        </div>
+        <span className="mt-2 font-serif text-black typo-sb-7">{post.title || ""}</span>
+        <div className="mt-1 h-11 overflow-hidden text-ellipsis break-all font-serif text-gray-250 typo-medium-2">
+          {post.content || "내용 없음"}
+        </div>
+        <div className="mt-1 flex items-center gap-2.5">
+          <div className="flex items-center gap-1">
+            <IconPostLikeOutline />
+            <span className="overflow-hidden font-serif text-gray-500 typo-regular-4">{post.likeCount || 0}</span>
           </div>
-        )}
+          <div className="flex items-center gap-1">
+            <IconCommunication />
+            <span className="overflow-hidden font-serif text-gray-500 typo-regular-4">{post.commentCount || 0}</span>
+          </div>
+        </div>
       </div>
+
+      {thumbnailSrc ? (
+        <div className="ml-4 mt-3 h-20 w-20 shrink-0 select-none">
+          <div className="bg-gray-c-50 relative h-full w-full overflow-hidden rounded border border-k-100">
+            <Image
+              className="object-cover"
+              src={thumbnailSrc}
+              fill
+              sizes="80px"
+              alt="게시글 사진"
+              fallbackSrc="/images/article-thumb.png"
+              loading={priorityImage ? "eager" : undefined}
+            />
+          </div>
+        </div>
+      ) : null}
     </div>
-  </div>
-);
+  );
+};


### PR DESCRIPTION
## 관련 이슈

- resolves: #이슈 번호

## 작업 내용

- 커뮤니티 리스트에서 게시글에 실제 첨부 이미지가 있을 때만 오른쪽 썸네일을 표시하도록 수정했습니다.
- 사진이 없는 게시글은 솔커 로고/기본 이미지 placeholder 썸네일 영역을 렌더링하지 않습니다.
- 서버가 기본 썸네일 경로(`/images/article-thumb.png`, `/images/site-thumbnail.png`, placeholder svg 등)를 내려주는 경우도 실제 게시글 이미지가 아닌 것으로 보고 숨기도록 방어했습니다.
- 썸네일 영역이 사라지는 경우 본문 영역이 자연스럽게 남은 너비를 사용하도록 `min-w-0 flex-1`을 적용했습니다.

## 특이 사항

- 실제 첨부 이미지 URL이 있는 게시글의 썸네일 렌더링과 fallback 동작은 유지했습니다.
- 로컬 Node 버전이 repo 권장 `22.x`와 달라 `Unsupported engine` 경고가 출력되지만 검증은 통과했습니다.

## 리뷰 요구사항 (선택)

- 기본 썸네일 URL을 숨기는 조건이 서버 응답 형태와 맞는지 확인 부탁드립니다.
- 사진 없는 게시글에서 오른쪽 여백/썸네일 박스가 사라지는 UI가 의도와 맞는지 봐주세요.

## 검증

- `pnpm --filter @solid-connect/web lint:check`
- `pnpm --filter @solid-connect/web typecheck:ci`
- pre-commit CI parity checks 통과
- pre-push CI parity checks 및 `@solid-connect/web build` 통과
