### PR TITLE
refactor: 지원 대학 국가 코드 검증 개선

### DIFF
--- a/apps/admin/src/components/features/univ-apply-infos/UnivApplyInfosPageContent.tsx
+++ b/apps/admin/src/components/features/univ-apply-infos/UnivApplyInfosPageContent.tsx
@@ -1,13 +1,18 @@
 "use client";
 
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { type FormEvent, useId, useState } from "react";
+import { type FormEvent, useId, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { AdminLayout } from "@/components/layout/AdminLayout";
 import { Button } from "@/components/ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Textarea } from "@/components/ui/textarea";
-import { adminApi, type UnivApplyInfoImportResponse } from "@/lib/api/admin";
+import {
+	type AdminCollection,
+	adminApi,
+	type CountryResponse,
+	type UnivApplyInfoImportResponse,
+} from "@/lib/api/admin";
 import { preprocessMarkdownCountryCodes } from "./countryCodeAliases";
 import { findFieldByHeader, UNIV_APPLY_INFO_FIELDS } from "./univApplyInfoFields";
 import { canConfirmUnivApplyInfoImport } from "./univApplyInfoImportGuard";
@@ -37,6 +42,20 @@ function buildAutoMappings(headers: string[], languageTestTypes: string[]): Reco
 	return mappings;
 }
 
+const toOptionalString = (value: string | number | null | undefined) => {
+	if (value === null || value === undefined) return undefined;
+	const normalized = String(value).trim();
+	return normalized.length > 0 ? normalized : undefined;
+};
+
+const normalizeCollection = <T,>(data: AdminCollection<T> | undefined) => {
+	if (!data) return [];
+	if (Array.isArray(data)) return data;
+	return data.content ?? data.data ?? data.items ?? data.result ?? [];
+};
+
+const getCountryCode = (country: CountryResponse) => toOptionalString(country.code);
+
 export function UnivApplyInfosPageContent() {
 	const homeUniversitySelectId = useId();
 	const termSelectId = useId();
@@ -57,6 +76,11 @@ export function UnivApplyInfosPageContent() {
 	const termsQuery = useQuery({
 		queryKey: ["admin", "terms"],
 		queryFn: adminApi.getTerms,
+	});
+
+	const countriesQuery = useQuery({
+		queryKey: ["admin", "countries"],
+		queryFn: adminApi.getCountries,
 	});
 
 	const fieldsQuery = useQuery({
@@ -135,6 +159,15 @@ export function UnivApplyInfosPageContent() {
 	const universities = homeUniversitiesQuery.data ?? [];
 	const terms = termsQuery.data ?? [];
 	const fields = fieldsQuery.data;
+	const validCountryCodes = useMemo(
+		() =>
+			new Set(
+				normalizeCollection(countriesQuery.data)
+					.map(getCountryCode)
+					.filter((code): code is string => Boolean(code)),
+			),
+		[countriesQuery.data],
+	);
 
 	const mappedFieldSet = new Set(Object.values(columnMappings).filter(Boolean));
 	const previewColumns: { field: string; label: string; required: boolean; mapped: boolean }[] = [
@@ -158,7 +191,7 @@ export function UnivApplyInfosPageContent() {
 			.map((f) => ({ field: f, label: f, required: false, mapped: true })),
 	];
 	const previewRows = showPreviewModal ? buildPreviewRows(markdown.trim(), columnMappings) : [];
-	const clientCellErrors = validatePreviewRows(previewRows);
+	const clientCellErrors = validatePreviewRows(previewRows, { validCountryCodes });
 	// key format: "rowNumber:field:fieldName" — rowNumber is always the first segment
 	const clientErrorRowNumbers = new Set([...clientCellErrors.keys()].map((k) => Number(k.split(":")[0])));
 	const failedCellMessages = clientCellErrors;

--- a/apps/admin/src/components/features/univ-apply-infos/UnivApplyInfosPageContent.tsx
+++ b/apps/admin/src/components/features/univ-apply-infos/UnivApplyInfosPageContent.tsx
@@ -191,7 +191,9 @@ export function UnivApplyInfosPageContent() {
 			.map((f) => ({ field: f, label: f, required: false, mapped: true })),
 	];
 	const previewRows = showPreviewModal ? buildPreviewRows(markdown.trim(), columnMappings) : [];
-	const clientCellErrors = validatePreviewRows(previewRows, { validCountryCodes });
+	const clientCellErrors = validatePreviewRows(previewRows, {
+		validCountryCodes: countriesQuery.isSuccess ? validCountryCodes : undefined,
+	});
 	// key format: "rowNumber:field:fieldName" — rowNumber is always the first segment
 	const clientErrorRowNumbers = new Set([...clientCellErrors.keys()].map((k) => Number(k.split(":")[0])));
 	const failedCellMessages = clientCellErrors;

--- a/apps/admin/src/components/features/univ-apply-infos/univApplyInfoValidation.test.ts
+++ b/apps/admin/src/components/features/univ-apply-infos/univApplyInfoValidation.test.ts
@@ -104,4 +104,25 @@ describe("validatePreviewRows", () => {
 		expect(errors.get("1:field:universityCountryCode")).toContain("유효하지 않은 국가 코드");
 		expect(errors.get("1:field:studentCapacity")).toContain("정수");
 	});
+
+	it("rejects country codes that are absent from the server country list", () => {
+		const rows = [
+			makeRow({
+				universityKoreanName: {
+					header: "대학명 (국문)",
+					field: "universityKoreanName",
+					value: "괌 대학",
+				},
+				universityCountryCode: {
+					header: "국가",
+					field: "universityCountryCode",
+					value: "ZZ",
+				},
+			}),
+		];
+
+		const errors = validatePreviewRows(rows, { validCountryCodes: new Set(["US", "JP"]) });
+
+		expect(errors.get("1:field:universityCountryCode")).toContain("서버에 등록되지 않은 국가 코드");
+	});
 });

--- a/apps/admin/src/components/features/univ-apply-infos/univApplyInfoValidation.ts
+++ b/apps/admin/src/components/features/univ-apply-infos/univApplyInfoValidation.ts
@@ -21,6 +21,10 @@ type FieldRule =
 	| { type: "enum"; values: readonly string[]; label: string }
 	| { type: "format"; check: (v: string) => boolean; message: string };
 
+interface ValidatePreviewRowsOptions {
+	validCountryCodes?: ReadonlySet<string>;
+}
+
 const FIELD_RULES: Record<string, FieldRule[]> = {
 	universityKoreanName: [
 		{ type: "required", message: "대학명은 필수입니다" },
@@ -97,7 +101,7 @@ function validateCell(value: string, rules: FieldRule[]): string | undefined {
 	return undefined;
 }
 
-export function validatePreviewRows(rows: PreviewRow[]): Map<string, string> {
+export function validatePreviewRows(rows: PreviewRow[], options: ValidatePreviewRowsOptions = {}): Map<string, string> {
 	const errors = new Map<string, string>();
 
 	for (const row of rows) {
@@ -115,6 +119,15 @@ export function validatePreviewRows(rows: PreviewRow[]): Map<string, string> {
 			const message = validateCell(cell.value, rules);
 			if (message) {
 				errors.set(`${row.rowNumber}:field:${field}`, message);
+				continue;
+			}
+			if (
+				field === "universityCountryCode" &&
+				cell.value.trim() &&
+				options.validCountryCodes &&
+				!options.validCountryCodes.has(cell.value.trim())
+			) {
+				errors.set(`${row.rowNumber}:field:${field}`, "서버에 등록되지 않은 국가 코드입니다");
 			}
 		}
 	}


### PR DESCRIPTION
## 변경 사항

- 어드민 지원 대학 추가 미리보기에서 국가 코드 검증 기준을 서버의 국가 목록 응답으로 변경했습니다.
- `/admin/countries` 응답을 정규화해 등록된 국가 코드 Set을 만들고, `universityCountryCode` 값이 목록에 없으면 미리보기 단계에서 오류로 표시합니다.
- 형식은 맞지만 서버에 등록되지 않은 국가 코드가 거부되는 테스트를 추가했습니다.

## 배경

기존 프론트 검증은 국가 코드가 대문자 2글자인지만 확인해 `ZZ`처럼 실제 서버 마스터 데이터에 없는 코드도 통과할 수 있었습니다. 국가/권역 마스터 데이터를 서버에서 받을 수 있으므로, import 전 preview 검증도 서버 데이터 기준으로 맞췄습니다.

## 검증

- `pnpm --filter @solid-connect/admin test`
- `pnpm --filter @solid-connect/admin lint:check`
- `pnpm --filter @solid-connect/admin typecheck`
- push hook: `@solid-connect/admin ci:check`, `@solid-connect/admin build`

## 참고

- 로컬 Node 버전은 `v24.14.0`이라 저장소 요구사항인 `22.x`와 다르다는 pnpm 경고가 출력됐지만, 위 검증 명령은 모두 통과했습니다.