### PR TITLE
fix: 인기 파견학교 상세 링크 보정

### DIFF
--- a/apps/university-web/src/apis/universities/api.ts
+++ b/apps/university-web/src/apis/universities/api.ts
@@ -1,5 +1,12 @@
+import { DEFAULT_UNIVERSITY_TERM_ID } from "@/constants/university";
 import type { HomeUniversityName } from "@/types/university";
 import { axiosInstance, publicAxiosInstance } from "@/utils/axiosInstance";
+
+const getClientUniversityTermId = () => {
+  const termId = Number(process.env.NEXT_PUBLIC_UNIVERSITY_TERM_ID);
+
+  return Number.isInteger(termId) && termId > 0 ? termId : DEFAULT_UNIVERSITY_TERM_ID;
+};
 
 export interface RecommendedUniversitiesResponseRecommendedUniversitiesItem {
   id: number;
@@ -175,16 +182,29 @@ export const universitiesApi = {
     return res.data;
   },
 
-  getSearchText: async (params?: { value?: string }): Promise<SearchTextResponse> => {
+  getSearchText: async (params?: {
+    value?: string;
+    termId?: number;
+    homeUniversityId?: number;
+  }): Promise<SearchTextResponse> => {
     const res = await publicAxiosInstance.get<SearchTextResponse>(`/univ-apply-infos/search/text`, {
-      params: { value: params?.value ?? "" },
+      params: {
+        value: params?.value ?? "",
+        termId: params?.termId ?? getClientUniversityTermId(),
+        homeUniversityId: params?.homeUniversityId,
+      },
     });
     return res.data;
   },
 
   getSearchFilter: async (params?: { params?: Record<string, unknown> }): Promise<SearchFilterResponse> => {
+    const requestParams = {
+      ...params?.params,
+      termId: params?.params?.termId ?? getClientUniversityTermId(),
+    };
+
     const res = await publicAxiosInstance.get<SearchFilterResponse>(`/univ-apply-infos/search/filter`, {
-      params: params?.params,
+      params: requestParams,
     });
     return res.data;
   },

--- a/apps/university-web/src/apis/universities/api.ts
+++ b/apps/university-web/src/apis/universities/api.ts
@@ -5,6 +5,7 @@ export interface RecommendedUniversitiesResponseRecommendedUniversitiesItem {
   id: number;
   term: string;
   koreanName: string;
+  homeUniversityName?: HomeUniversityName;
   region: string;
   country: string;
   logoImageUrl: string;

--- a/apps/university-web/src/apis/universities/api.ts
+++ b/apps/university-web/src/apis/universities/api.ts
@@ -8,6 +8,20 @@ const getClientUniversityTermId = () => {
   return Number.isInteger(termId) && termId > 0 ? termId : DEFAULT_UNIVERSITY_TERM_ID;
 };
 
+const normalizePositiveInt = (value: unknown) => {
+  const numberValue = typeof value === "string" && value.trim() !== "" ? Number(value) : value;
+
+  return typeof numberValue === "number" && Number.isInteger(numberValue) && numberValue > 0 ? numberValue : undefined;
+};
+
+const getScopedTermId = (termId: unknown, useDefaultTermId?: boolean) => {
+  if (termId === undefined) {
+    return useDefaultTermId ? getClientUniversityTermId() : undefined;
+  }
+
+  return normalizePositiveInt(termId) ?? getClientUniversityTermId();
+};
+
 export interface RecommendedUniversitiesResponseRecommendedUniversitiesItem {
   id: number;
   term: string;
@@ -185,22 +199,27 @@ export const universitiesApi = {
   getSearchText: async (params?: {
     value?: string;
     termId?: number;
+    useDefaultTermId?: boolean;
     homeUniversityId?: number;
   }): Promise<SearchTextResponse> => {
+    const requestParams = {
+      value: params?.value ?? "",
+      termId: getScopedTermId(params?.termId, params?.useDefaultTermId),
+      homeUniversityId: normalizePositiveInt(params?.homeUniversityId),
+    };
+
     const res = await publicAxiosInstance.get<SearchTextResponse>(`/univ-apply-infos/search/text`, {
-      params: {
-        value: params?.value ?? "",
-        termId: params?.termId ?? getClientUniversityTermId(),
-        homeUniversityId: params?.homeUniversityId,
-      },
+      params: requestParams,
     });
     return res.data;
   },
 
   getSearchFilter: async (params?: { params?: Record<string, unknown> }): Promise<SearchFilterResponse> => {
+    const { termId, homeUniversityId, useDefaultTermId, ...restParams } = params?.params ?? {};
     const requestParams = {
-      ...params?.params,
-      termId: params?.params?.termId ?? getClientUniversityTermId(),
+      ...restParams,
+      termId: getScopedTermId(termId, useDefaultTermId === true),
+      homeUniversityId: normalizePositiveInt(homeUniversityId),
     };
 
     const res = await publicAxiosInstance.get<SearchFilterResponse>(`/univ-apply-infos/search/filter`, {

--- a/apps/university-web/src/apis/universities/getSearchFilter.ts
+++ b/apps/university-web/src/apis/universities/getSearchFilter.ts
@@ -12,6 +12,7 @@ export interface UniversitySearchFilterParams {
   countryCode?: CountryCode[];
   termId?: number;
   homeUniversityId?: number;
+  useDefaultTermId?: boolean;
 }
 
 // API 응답에 homeUniversityName이 포함된 타입
@@ -45,6 +46,9 @@ const useGetUniversitySearchByFilter = (
     }
     if (filters.homeUniversityId !== undefined) {
       params.homeUniversityId = filters.homeUniversityId;
+    }
+    if (filters.useDefaultTermId) {
+      params.useDefaultTermId = true;
     }
     return params;
   };

--- a/apps/university-web/src/apis/universities/getSearchFilter.ts
+++ b/apps/university-web/src/apis/universities/getSearchFilter.ts
@@ -10,6 +10,8 @@ export interface UniversitySearchFilterParams {
   languageTestType?: LanguageTestType;
   testScore?: number;
   countryCode?: CountryCode[];
+  termId?: number;
+  homeUniversityId?: number;
 }
 
 // API 응답에 homeUniversityName이 포함된 타입
@@ -37,6 +39,12 @@ const useGetUniversitySearchByFilter = (
     }
     if (filters.countryCode && filters.countryCode.length > 0) {
       params.countryCode = filters.countryCode;
+    }
+    if (filters.termId !== undefined) {
+      params.termId = filters.termId;
+    }
+    if (filters.homeUniversityId !== undefined) {
+      params.homeUniversityId = filters.homeUniversityId;
     }
     return params;
   };

--- a/apps/university-web/src/apis/universities/getSearchText.ts
+++ b/apps/university-web/src/apis/universities/getSearchText.ts
@@ -12,13 +12,23 @@ interface ListUniversityWithHome extends ListUniversity {
   homeUniversityName?: HomeUniversityName;
 }
 
+export interface UniversitySearchOptions {
+  termId?: number;
+  homeUniversityId?: number;
+  useDefaultTermId?: boolean;
+}
+
 /**
  * @description 대학 검색을 위한 useQuery 커스텀 훅
  * 모든 대학 데이터를 한 번만 가져와 캐싱하고, 검색어에 따라 클라이언트에서 필터링합니다.
  * @param searchValue - 검색어
  * @param homeUniversityName - 홈 대학교 이름 (선택적 필터)
  */
-const useUniversitySearch = (searchValue: string, homeUniversityName?: HomeUniversityName) => {
+const useUniversitySearch = (
+  searchValue: string,
+  homeUniversityName?: HomeUniversityName,
+  options: UniversitySearchOptions = {},
+) => {
   // 1. 모든 대학 데이터를 한 번만 가져와 'Infinity' 캐시로 저장합니다.
   const {
     data: allUniversities,
@@ -26,8 +36,8 @@ const useUniversitySearch = (searchValue: string, homeUniversityName?: HomeUnive
     isError,
     error,
   } = useQuery<SearchTextResponse, AxiosError, ListUniversityWithHome[]>({
-    queryKey: [QueryKeys.universities.searchText],
-    queryFn: () => universitiesApi.getSearchText({ value: "" }),
+    queryKey: [QueryKeys.universities.searchText, options],
+    queryFn: () => universitiesApi.getSearchText({ value: "", ...options }),
     staleTime: Infinity,
     gcTime: Infinity,
     select: (data) => data.univApplyInfoPreviews as unknown as ListUniversityWithHome[],

--- a/apps/university-web/src/apis/universities/server/getSearchUniversitiesByFilter.ts
+++ b/apps/university-web/src/apis/universities/server/getSearchUniversitiesByFilter.ts
@@ -25,6 +25,22 @@ const getUniversityTermId = () => {
   return Number.isInteger(termId) && termId > 0 ? termId : DEFAULT_UNIVERSITY_TERM_ID;
 };
 
+const normalizePositiveInt = (value: unknown) => {
+  const numberValue = typeof value === "string" && value.trim() !== "" ? Number(value) : value;
+
+  return typeof numberValue === "number" && Number.isInteger(numberValue) && numberValue > 0 ? numberValue : undefined;
+};
+
+const assertPositiveInt = (name: string, value: unknown) => {
+  const positiveInt = normalizePositiveInt(value);
+
+  if (positiveInt === undefined) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+
+  return positiveInt;
+};
+
 export const getSearchUniversitiesByFilter = async (
   filters: UniversitySearchFilterParams,
 ): Promise<ListUniversity[]> => {
@@ -41,10 +57,10 @@ export const getSearchUniversitiesByFilter = async (
     filters.countryCode.forEach((code) => params.append("countryCode", code));
   }
   if (filters.termId !== undefined) {
-    params.append("termId", String(filters.termId));
+    params.append("termId", String(assertPositiveInt("termId", filters.termId)));
   }
   if (filters.homeUniversityId !== undefined) {
-    params.append("homeUniversityId", String(filters.homeUniversityId));
+    params.append("homeUniversityId", String(assertPositiveInt("homeUniversityId", filters.homeUniversityId)));
   }
 
   // 필터 값이 하나도 없으면 빈 배열을 반환합니다.
@@ -61,13 +77,14 @@ export const getSearchUniversitiesByFilter = async (
 export const getSearchUniversitiesAllRegions = async (
   params: Pick<UniversitySearchFilterParams, "termId" | "homeUniversityId"> = {},
 ): Promise<ListUniversity[]> => {
+  const termId = params.termId === undefined ? getUniversityTermId() : assertPositiveInt("termId", params.termId);
   const searchParams = new URLSearchParams({
     value: "",
-    termId: String(params.termId ?? getUniversityTermId()),
+    termId: String(termId),
   });
 
   if (params.homeUniversityId !== undefined) {
-    searchParams.set("homeUniversityId", String(params.homeUniversityId));
+    searchParams.set("homeUniversityId", String(assertPositiveInt("homeUniversityId", params.homeUniversityId)));
   }
 
   const endpoint = `/univ-apply-infos/search/text?${searchParams.toString()}`;

--- a/apps/university-web/src/apis/universities/server/getSearchUniversitiesByFilter.ts
+++ b/apps/university-web/src/apis/universities/server/getSearchUniversitiesByFilter.ts
@@ -1,4 +1,5 @@
 import { URLSearchParams } from "node:url";
+import { DEFAULT_UNIVERSITY_TERM_ID } from "@/constants/university";
 import type { CountryCode, LanguageTestType, ListUniversity } from "@/types/university";
 import serverFetch from "@/utils/serverFetchUtil";
 import { assertUniversitySsgResponse } from "./assertUniversitySsgResponse";
@@ -14,7 +15,15 @@ export interface UniversitySearchFilterParams {
   languageTestType?: LanguageTestType;
   testScore?: number;
   countryCode?: CountryCode[];
+  termId?: number;
+  homeUniversityId?: number;
 }
+
+const getUniversityTermId = () => {
+  const termId = Number(process.env.UNIVERSITY_TERM_ID ?? process.env.NEXT_PUBLIC_UNIVERSITY_TERM_ID);
+
+  return Number.isInteger(termId) && termId > 0 ? termId : DEFAULT_UNIVERSITY_TERM_ID;
+};
 
 export const getSearchUniversitiesByFilter = async (
   filters: UniversitySearchFilterParams,
@@ -31,6 +40,12 @@ export const getSearchUniversitiesByFilter = async (
   if (filters.countryCode) {
     filters.countryCode.forEach((code) => params.append("countryCode", code));
   }
+  if (filters.termId !== undefined) {
+    params.append("termId", String(filters.termId));
+  }
+  if (filters.homeUniversityId !== undefined) {
+    params.append("homeUniversityId", String(filters.homeUniversityId));
+  }
 
   // 필터 값이 하나도 없으면 빈 배열을 반환합니다.
   if (params.size === 0) {
@@ -43,8 +58,19 @@ export const getSearchUniversitiesByFilter = async (
     .univApplyInfoPreviews;
 };
 
-export const getSearchUniversitiesAllRegions = async (): Promise<ListUniversity[]> => {
-  const endpoint = `/univ-apply-infos/search/text?value=`;
+export const getSearchUniversitiesAllRegions = async (
+  params: Pick<UniversitySearchFilterParams, "termId" | "homeUniversityId"> = {},
+): Promise<ListUniversity[]> => {
+  const searchParams = new URLSearchParams({
+    value: "",
+    termId: String(params.termId ?? getUniversityTermId()),
+  });
+
+  if (params.homeUniversityId !== undefined) {
+    searchParams.set("homeUniversityId", String(params.homeUniversityId));
+  }
+
+  const endpoint = `/univ-apply-infos/search/text?${searchParams.toString()}`;
   const response = await serverFetch<UniversitySearchResponse>(endpoint);
   return assertUniversitySsgResponse(response, "search all universities").univApplyInfoPreviews;
 };

--- a/apps/university-web/src/apis/universities/server/getSearchUniversitiesByText.ts
+++ b/apps/university-web/src/apis/universities/server/getSearchUniversitiesByText.ts
@@ -1,3 +1,5 @@
+import { URLSearchParams } from "node:url";
+import { DEFAULT_UNIVERSITY_TERM_ID } from "@/constants/university";
 import { type AllRegionsUniversityList, type ListUniversity, RegionEnumExtend } from "@/types/university";
 import serverFetch from "@/utils/serverFetchUtil";
 import { assertUniversitySsgResponse } from "./assertUniversitySsgResponse";
@@ -7,22 +9,51 @@ interface UniversitySearchResponse {
   univApplyInfoPreviews: ListUniversity[];
 }
 
-export const getUniversitiesByText = async (value: string): Promise<ListUniversity[]> => {
+export interface UniversitySearchTextParams {
+  termId?: number;
+  homeUniversityId?: number;
+}
+
+const getUniversityTermId = () => {
+  const termId = Number(process.env.UNIVERSITY_TERM_ID ?? process.env.NEXT_PUBLIC_UNIVERSITY_TERM_ID);
+
+  return Number.isInteger(termId) && termId > 0 ? termId : DEFAULT_UNIVERSITY_TERM_ID;
+};
+
+const createSearchTextEndpoint = (value: string, params: UniversitySearchTextParams = {}) => {
+  const searchParams = new URLSearchParams({
+    value,
+    termId: String(params.termId ?? getUniversityTermId()),
+  });
+
+  if (params.homeUniversityId !== undefined) {
+    searchParams.set("homeUniversityId", String(params.homeUniversityId));
+  }
+
+  return `/univ-apply-infos/search/text?${searchParams.toString()}`;
+};
+
+export const getUniversitiesByText = async (
+  value: string,
+  params?: UniversitySearchTextParams,
+): Promise<ListUniversity[]> => {
   if (value === null || value === undefined) {
     return [];
   }
-  const endpoint = `/univ-apply-infos/search/text?value=${encodeURIComponent(value)}`;
+  const endpoint = createSearchTextEndpoint(value, params);
   const response = await serverFetch<UniversitySearchResponse>(endpoint);
   return assertUniversitySsgResponse(response, `search universities by text "${value}"`).univApplyInfoPreviews;
 };
 
-export const getAllUniversities = async (): Promise<ListUniversity[]> => {
-  return getUniversitiesByText("");
+export const getAllUniversities = async (params?: UniversitySearchTextParams): Promise<ListUniversity[]> => {
+  return getUniversitiesByText("", params);
 };
 
-export const getCategorizedUniversities = async (): Promise<AllRegionsUniversityList> => {
+export const getCategorizedUniversities = async (
+  params?: UniversitySearchTextParams,
+): Promise<AllRegionsUniversityList> => {
   // 1. 단 한 번의 API 호출로 모든 대학 데이터를 가져옵니다.
-  const allUniversities = await getAllUniversities();
+  const allUniversities = await getAllUniversities(params);
 
   const categorizedList: AllRegionsUniversityList = {
     [RegionEnumExtend.ALL]: allUniversities,

--- a/apps/university-web/src/apis/universities/server/getSearchUniversitiesByText.ts
+++ b/apps/university-web/src/apis/universities/server/getSearchUniversitiesByText.ts
@@ -20,14 +20,31 @@ const getUniversityTermId = () => {
   return Number.isInteger(termId) && termId > 0 ? termId : DEFAULT_UNIVERSITY_TERM_ID;
 };
 
+const normalizePositiveInt = (value: unknown) => {
+  const numberValue = typeof value === "string" && value.trim() !== "" ? Number(value) : value;
+
+  return typeof numberValue === "number" && Number.isInteger(numberValue) && numberValue > 0 ? numberValue : undefined;
+};
+
+const assertPositiveInt = (name: string, value: unknown) => {
+  const positiveInt = normalizePositiveInt(value);
+
+  if (positiveInt === undefined) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+
+  return positiveInt;
+};
+
 const createSearchTextEndpoint = (value: string, params: UniversitySearchTextParams = {}) => {
+  const termId = params.termId === undefined ? getUniversityTermId() : assertPositiveInt("termId", params.termId);
   const searchParams = new URLSearchParams({
     value,
-    termId: String(params.termId ?? getUniversityTermId()),
+    termId: String(termId),
   });
 
   if (params.homeUniversityId !== undefined) {
-    searchParams.set("homeUniversityId", String(params.homeUniversityId));
+    searchParams.set("homeUniversityId", String(assertPositiveInt("homeUniversityId", params.homeUniversityId)));
   }
 
   return `/univ-apply-infos/search/text?${searchParams.toString()}`;

--- a/apps/university-web/src/app/university/[homeUniversity]/[id]/page.tsx
+++ b/apps/university-web/src/app/university/[homeUniversity]/[id]/page.tsx
@@ -17,25 +17,27 @@ export const dynamicParams = false;
 
 // 모든 homeUniversity + id 조합에 대해 정적 경로 생성
 export async function generateStaticParams() {
-  const params: { homeUniversity: string; id: string }[] = [];
+  const scopedUniversitiesBySlug = await Promise.all(
+    HOME_UNIVERSITY_SLUGS.map(async (slug) => {
+      const homeUniversityInfo = getHomeUniversityBySlug(slug);
+      if (!homeUniversityInfo) {
+        return { slug, universities: [] };
+      }
 
-  for (const slug of HOME_UNIVERSITY_SLUGS) {
-    const homeUniversityInfo = getHomeUniversityBySlug(slug);
-    if (!homeUniversityInfo) continue;
-
-    const universities = await getAllUniversities({
-      homeUniversityId: homeUniversityInfo.homeUniversityId,
-    });
-
-    for (const university of universities) {
-      params.push({
-        homeUniversity: slug,
-        id: String(university.id),
+      const universities = await getAllUniversities({
+        homeUniversityId: homeUniversityInfo.homeUniversityId,
       });
-    }
-  }
 
-  return params;
+      return { slug, universities };
+    }),
+  );
+
+  return scopedUniversitiesBySlug.flatMap(({ slug, universities }) =>
+    universities.map((university) => ({
+      homeUniversity: slug,
+      id: String(university.id),
+    })),
+  );
 }
 
 type PageProps = {

--- a/apps/university-web/src/app/university/[homeUniversity]/[id]/page.tsx
+++ b/apps/university-web/src/app/university/[homeUniversity]/[id]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 
 import { getAllUniversities, getUniversityDetailWithStatus } from "@/apis/universities/server";
 import TopDetailNavigation from "@/components/layout/TopDetailNavigation";
-import { getHomeUniversityBySlug, HOME_UNIVERSITY_SLUGS, isMatchedHomeUniversityName } from "@/constants/university";
+import { getHomeUniversityBySlug, HOME_UNIVERSITY_SLUGS } from "@/constants/university";
 import type { HomeUniversitySlug } from "@/types/university";
 import { normalizeImageUrlToUploadCdn } from "@/utils/cdnUrl";
 import { createUrl, NO_INDEX_ROBOTS } from "@/utils/seo";
@@ -17,21 +17,17 @@ export const dynamicParams = false;
 
 // 모든 homeUniversity + id 조합에 대해 정적 경로 생성
 export async function generateStaticParams() {
-  const universities = await getAllUniversities();
-
   const params: { homeUniversity: string; id: string }[] = [];
 
-  // 각 대학에 대해 모든 homeUniversity 슬러그와 조합
   for (const slug of HOME_UNIVERSITY_SLUGS) {
     const homeUniversityInfo = getHomeUniversityBySlug(slug);
     if (!homeUniversityInfo) continue;
 
-    // 해당 홈대학에 속하는 대학들만 필터링
-    const filteredUniversities = universities.filter((uni) =>
-      isMatchedHomeUniversityName(uni.homeUniversityName, homeUniversityInfo.name),
-    );
+    const universities = await getAllUniversities({
+      homeUniversityId: homeUniversityInfo.homeUniversityId,
+    });
 
-    for (const university of filteredUniversities) {
+    for (const university of universities) {
       params.push({
         homeUniversity: slug,
         id: String(university.id),

--- a/apps/university-web/src/app/university/[homeUniversity]/page.tsx
+++ b/apps/university-web/src/app/university/[homeUniversity]/page.tsx
@@ -53,7 +53,9 @@ const UniversityListPage = async ({ params }: PageProps) => {
     notFound();
   }
 
-  const allUniversities = await getSearchUniversitiesAllRegions();
+  const allUniversities = await getSearchUniversitiesAllRegions({
+    homeUniversityId: universityInfo.homeUniversityId,
+  });
 
   // homeUniversityName으로 프론트에서 필터링
   const filteredUniversities = allUniversities.filter((university) =>

--- a/apps/university-web/src/app/university/[homeUniversity]/page.tsx
+++ b/apps/university-web/src/app/university/[homeUniversity]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 
 import { getSearchUniversitiesAllRegions } from "@/apis/universities/server";
 import TopDetailNavigation from "@/components/layout/TopDetailNavigation";
-import { getHomeUniversityBySlug, HOME_UNIVERSITY_SLUGS, isMatchedHomeUniversityName } from "@/constants/university";
+import { getHomeUniversityBySlug, HOME_UNIVERSITY_SLUGS } from "@/constants/university";
 import type { HomeUniversitySlug } from "@/types/university";
 
 import UniversityListContent from "./_ui/UniversityListContent";
@@ -53,19 +53,14 @@ const UniversityListPage = async ({ params }: PageProps) => {
     notFound();
   }
 
-  const allUniversities = await getSearchUniversitiesAllRegions({
+  const universities = await getSearchUniversitiesAllRegions({
     homeUniversityId: universityInfo.homeUniversityId,
   });
-
-  // homeUniversityName으로 프론트에서 필터링
-  const filteredUniversities = allUniversities.filter((university) =>
-    isMatchedHomeUniversityName(university.homeUniversityName, universityInfo.name),
-  );
 
   return (
     <>
       <TopDetailNavigation title={`${universityInfo.shortName} 파견학교`} backHref="/university" />
-      <UniversityListContent universities={filteredUniversities} homeUniversitySlug={homeUniversitySlug} />
+      <UniversityListContent universities={universities} homeUniversitySlug={homeUniversitySlug} />
     </>
   );
 };

--- a/apps/university-web/src/constants/university.ts
+++ b/apps/university-web/src/constants/university.ts
@@ -33,6 +33,7 @@ export const HOME_UNIVERSITY_TO_SLUG_MAP: Record<HomeUniversity, HomeUniversityS
  * 홈 대학교 정보 (온보딩 카드에서 사용)
  */
 export interface HomeUniversityInfo {
+  homeUniversityId: number;
   name: HomeUniversity;
   slug: HomeUniversitySlug;
   shortName: string;
@@ -43,6 +44,7 @@ export interface HomeUniversityInfo {
 
 export const HOME_UNIVERSITY_LIST: HomeUniversityInfo[] = [
   {
+    homeUniversityId: 1,
     name: HomeUniversity.INHA,
     slug: "inha",
     shortName: "인하대",
@@ -51,6 +53,7 @@ export const HOME_UNIVERSITY_LIST: HomeUniversityInfo[] = [
     color: "#004C98",
   },
   {
+    homeUniversityId: 2,
     name: HomeUniversity.INCHEON,
     slug: "incheon",
     shortName: "인천대",
@@ -59,6 +62,7 @@ export const HOME_UNIVERSITY_LIST: HomeUniversityInfo[] = [
     color: "#003876",
   },
   {
+    homeUniversityId: 3,
     name: HomeUniversity.SUNGSHIN,
     slug: "sungshin",
     shortName: "성신여대",
@@ -67,6 +71,9 @@ export const HOME_UNIVERSITY_LIST: HomeUniversityInfo[] = [
     color: "#7B1FA2",
   },
 ];
+
+// 배포 환경에서 UNIVERSITY_TERM_ID를 주입하지 못했을 때 사용하는 현재 학기 fallback입니다.
+export const DEFAULT_UNIVERSITY_TERM_ID = 12;
 
 /**
  * 슬러그로 홈 대학교 정보 조회

--- a/apps/web/src/apis/universities/api.ts
+++ b/apps/web/src/apis/universities/api.ts
@@ -1,5 +1,12 @@
+import { DEFAULT_UNIVERSITY_TERM_ID } from "@/constants/university";
 import type { HomeUniversityName } from "@/types/university";
 import { axiosInstance, publicAxiosInstance } from "@/utils/axiosInstance";
+
+const getClientUniversityTermId = () => {
+  const termId = Number(process.env.NEXT_PUBLIC_UNIVERSITY_TERM_ID);
+
+  return Number.isInteger(termId) && termId > 0 ? termId : DEFAULT_UNIVERSITY_TERM_ID;
+};
 
 export interface RecommendedUniversitiesResponseRecommendedUniversitiesItem {
   id: number;
@@ -175,16 +182,29 @@ export const universitiesApi = {
     return res.data;
   },
 
-  getSearchText: async (params?: { value?: string }): Promise<SearchTextResponse> => {
+  getSearchText: async (params?: {
+    value?: string;
+    termId?: number;
+    homeUniversityId?: number;
+  }): Promise<SearchTextResponse> => {
     const res = await publicAxiosInstance.get<SearchTextResponse>(`/univ-apply-infos/search/text`, {
-      params: { value: params?.value ?? "" },
+      params: {
+        value: params?.value ?? "",
+        termId: params?.termId ?? getClientUniversityTermId(),
+        homeUniversityId: params?.homeUniversityId,
+      },
     });
     return res.data;
   },
 
   getSearchFilter: async (params?: { params?: Record<string, unknown> }): Promise<SearchFilterResponse> => {
+    const requestParams = {
+      ...params?.params,
+      termId: params?.params?.termId ?? getClientUniversityTermId(),
+    };
+
     const res = await publicAxiosInstance.get<SearchFilterResponse>(`/univ-apply-infos/search/filter`, {
-      params: params?.params,
+      params: requestParams,
     });
     return res.data;
   },

--- a/apps/web/src/apis/universities/api.ts
+++ b/apps/web/src/apis/universities/api.ts
@@ -5,6 +5,7 @@ export interface RecommendedUniversitiesResponseRecommendedUniversitiesItem {
   id: number;
   term: string;
   koreanName: string;
+  homeUniversityName?: HomeUniversityName;
   region: string;
   country: string;
   logoImageUrl: string;

--- a/apps/web/src/apis/universities/api.ts
+++ b/apps/web/src/apis/universities/api.ts
@@ -8,6 +8,20 @@ const getClientUniversityTermId = () => {
   return Number.isInteger(termId) && termId > 0 ? termId : DEFAULT_UNIVERSITY_TERM_ID;
 };
 
+const normalizePositiveInt = (value: unknown) => {
+  const numberValue = typeof value === "string" && value.trim() !== "" ? Number(value) : value;
+
+  return typeof numberValue === "number" && Number.isInteger(numberValue) && numberValue > 0 ? numberValue : undefined;
+};
+
+const getScopedTermId = (termId: unknown, useDefaultTermId?: boolean) => {
+  if (termId === undefined) {
+    return useDefaultTermId ? getClientUniversityTermId() : undefined;
+  }
+
+  return normalizePositiveInt(termId) ?? getClientUniversityTermId();
+};
+
 export interface RecommendedUniversitiesResponseRecommendedUniversitiesItem {
   id: number;
   term: string;
@@ -185,22 +199,27 @@ export const universitiesApi = {
   getSearchText: async (params?: {
     value?: string;
     termId?: number;
+    useDefaultTermId?: boolean;
     homeUniversityId?: number;
   }): Promise<SearchTextResponse> => {
+    const requestParams = {
+      value: params?.value ?? "",
+      termId: getScopedTermId(params?.termId, params?.useDefaultTermId),
+      homeUniversityId: normalizePositiveInt(params?.homeUniversityId),
+    };
+
     const res = await publicAxiosInstance.get<SearchTextResponse>(`/univ-apply-infos/search/text`, {
-      params: {
-        value: params?.value ?? "",
-        termId: params?.termId ?? getClientUniversityTermId(),
-        homeUniversityId: params?.homeUniversityId,
-      },
+      params: requestParams,
     });
     return res.data;
   },
 
   getSearchFilter: async (params?: { params?: Record<string, unknown> }): Promise<SearchFilterResponse> => {
+    const { termId, homeUniversityId, useDefaultTermId, ...restParams } = params?.params ?? {};
     const requestParams = {
-      ...params?.params,
-      termId: params?.params?.termId ?? getClientUniversityTermId(),
+      ...restParams,
+      termId: getScopedTermId(termId, useDefaultTermId === true),
+      homeUniversityId: normalizePositiveInt(homeUniversityId),
     };
 
     const res = await publicAxiosInstance.get<SearchFilterResponse>(`/univ-apply-infos/search/filter`, {

--- a/apps/web/src/apis/universities/getSearchFilter.ts
+++ b/apps/web/src/apis/universities/getSearchFilter.ts
@@ -12,6 +12,7 @@ export interface UniversitySearchFilterParams {
   countryCode?: CountryCode[];
   termId?: number;
   homeUniversityId?: number;
+  useDefaultTermId?: boolean;
 }
 
 // API 응답에 homeUniversityName이 포함된 타입
@@ -45,6 +46,9 @@ const useGetUniversitySearchByFilter = (
     }
     if (filters.homeUniversityId !== undefined) {
       params.homeUniversityId = filters.homeUniversityId;
+    }
+    if (filters.useDefaultTermId) {
+      params.useDefaultTermId = true;
     }
     return params;
   };

--- a/apps/web/src/apis/universities/getSearchFilter.ts
+++ b/apps/web/src/apis/universities/getSearchFilter.ts
@@ -10,6 +10,8 @@ export interface UniversitySearchFilterParams {
   languageTestType?: LanguageTestType;
   testScore?: number;
   countryCode?: CountryCode[];
+  termId?: number;
+  homeUniversityId?: number;
 }
 
 // API 응답에 homeUniversityName이 포함된 타입
@@ -37,6 +39,12 @@ const useGetUniversitySearchByFilter = (
     }
     if (filters.countryCode && filters.countryCode.length > 0) {
       params.countryCode = filters.countryCode;
+    }
+    if (filters.termId !== undefined) {
+      params.termId = filters.termId;
+    }
+    if (filters.homeUniversityId !== undefined) {
+      params.homeUniversityId = filters.homeUniversityId;
     }
     return params;
   };

--- a/apps/web/src/apis/universities/getSearchText.ts
+++ b/apps/web/src/apis/universities/getSearchText.ts
@@ -12,13 +12,23 @@ interface ListUniversityWithHome extends ListUniversity {
   homeUniversityName?: HomeUniversityName;
 }
 
+export interface UniversitySearchOptions {
+  termId?: number;
+  homeUniversityId?: number;
+  useDefaultTermId?: boolean;
+}
+
 /**
  * @description 대학 검색을 위한 useQuery 커스텀 훅
  * 모든 대학 데이터를 한 번만 가져와 캐싱하고, 검색어에 따라 클라이언트에서 필터링합니다.
  * @param searchValue - 검색어
  * @param homeUniversityName - 홈 대학교 이름 (선택적 필터)
  */
-const useUniversitySearch = (searchValue: string, homeUniversityName?: HomeUniversityName) => {
+const useUniversitySearch = (
+  searchValue: string,
+  homeUniversityName?: HomeUniversityName,
+  options: UniversitySearchOptions = {},
+) => {
   // 1. 모든 대학 데이터를 한 번만 가져와 'Infinity' 캐시로 저장합니다.
   const {
     data: allUniversities,
@@ -26,8 +36,8 @@ const useUniversitySearch = (searchValue: string, homeUniversityName?: HomeUnive
     isError,
     error,
   } = useQuery<SearchTextResponse, AxiosError, ListUniversityWithHome[]>({
-    queryKey: [QueryKeys.universities.searchText],
-    queryFn: () => universitiesApi.getSearchText({ value: "" }),
+    queryKey: [QueryKeys.universities.searchText, options],
+    queryFn: () => universitiesApi.getSearchText({ value: "", ...options }),
     staleTime: Infinity,
     gcTime: Infinity,
     select: (data) => data.univApplyInfoPreviews as unknown as ListUniversityWithHome[],

--- a/apps/web/src/apis/universities/server/getSearchUniversitiesByFilter.ts
+++ b/apps/web/src/apis/universities/server/getSearchUniversitiesByFilter.ts
@@ -24,6 +24,22 @@ const getUniversityTermId = () => {
   return Number.isInteger(termId) && termId > 0 ? termId : DEFAULT_UNIVERSITY_TERM_ID;
 };
 
+const normalizePositiveInt = (value: unknown) => {
+  const numberValue = typeof value === "string" && value.trim() !== "" ? Number(value) : value;
+
+  return typeof numberValue === "number" && Number.isInteger(numberValue) && numberValue > 0 ? numberValue : undefined;
+};
+
+const assertPositiveInt = (name: string, value: unknown) => {
+  const positiveInt = normalizePositiveInt(value);
+
+  if (positiveInt === undefined) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+
+  return positiveInt;
+};
+
 export const getSearchUniversitiesByFilter = async (
   filters: UniversitySearchFilterParams,
 ): Promise<ListUniversity[]> => {
@@ -40,10 +56,10 @@ export const getSearchUniversitiesByFilter = async (
     filters.countryCode.forEach((code) => params.append("countryCode", code));
   }
   if (filters.termId !== undefined) {
-    params.append("termId", String(filters.termId));
+    params.append("termId", String(assertPositiveInt("termId", filters.termId)));
   }
   if (filters.homeUniversityId !== undefined) {
-    params.append("homeUniversityId", String(filters.homeUniversityId));
+    params.append("homeUniversityId", String(assertPositiveInt("homeUniversityId", filters.homeUniversityId)));
   }
 
   // 필터 값이 하나도 없으면 빈 배열을 반환합니다.
@@ -64,13 +80,14 @@ export const getSearchUniversitiesByFilter = async (
 export const getSearchUniversitiesAllRegions = async (
   params: Pick<UniversitySearchFilterParams, "termId" | "homeUniversityId"> = {},
 ): Promise<ListUniversity[]> => {
+  const termId = params.termId === undefined ? getUniversityTermId() : assertPositiveInt("termId", params.termId);
   const searchParams = new URLSearchParams({
     value: "",
-    termId: String(params.termId ?? getUniversityTermId()),
+    termId: String(termId),
   });
 
   if (params.homeUniversityId !== undefined) {
-    searchParams.set("homeUniversityId", String(params.homeUniversityId));
+    searchParams.set("homeUniversityId", String(assertPositiveInt("homeUniversityId", params.homeUniversityId)));
   }
 
   const endpoint = `/univ-apply-infos/search/text?${searchParams.toString()}`;

--- a/apps/web/src/apis/universities/server/getSearchUniversitiesByFilter.ts
+++ b/apps/web/src/apis/universities/server/getSearchUniversitiesByFilter.ts
@@ -1,4 +1,5 @@
 import { URLSearchParams } from "node:url";
+import { DEFAULT_UNIVERSITY_TERM_ID } from "@/constants/university";
 import type { CountryCode, LanguageTestType, ListUniversity } from "@/types/university";
 import serverFetch from "@/utils/serverFetchUtil";
 
@@ -13,7 +14,15 @@ export interface UniversitySearchFilterParams {
   languageTestType?: LanguageTestType;
   testScore?: number;
   countryCode?: CountryCode[];
+  termId?: number;
+  homeUniversityId?: number;
 }
+
+const getUniversityTermId = () => {
+  const termId = Number(process.env.UNIVERSITY_TERM_ID ?? process.env.NEXT_PUBLIC_UNIVERSITY_TERM_ID);
+
+  return Number.isInteger(termId) && termId > 0 ? termId : DEFAULT_UNIVERSITY_TERM_ID;
+};
 
 export const getSearchUniversitiesByFilter = async (
   filters: UniversitySearchFilterParams,
@@ -29,6 +38,12 @@ export const getSearchUniversitiesByFilter = async (
   // countryCode는 여러 개일 수 있으므로 각각 append 해줍니다.
   if (filters.countryCode) {
     filters.countryCode.forEach((code) => params.append("countryCode", code));
+  }
+  if (filters.termId !== undefined) {
+    params.append("termId", String(filters.termId));
+  }
+  if (filters.homeUniversityId !== undefined) {
+    params.append("homeUniversityId", String(filters.homeUniversityId));
   }
 
   // 필터 값이 하나도 없으면 빈 배열을 반환합니다.
@@ -46,8 +61,19 @@ export const getSearchUniversitiesByFilter = async (
   return response.data.univApplyInfoPreviews;
 };
 
-export const getSearchUniversitiesAllRegions = async (): Promise<ListUniversity[]> => {
-  const endpoint = `/univ-apply-infos/search/text?value=`;
+export const getSearchUniversitiesAllRegions = async (
+  params: Pick<UniversitySearchFilterParams, "termId" | "homeUniversityId"> = {},
+): Promise<ListUniversity[]> => {
+  const searchParams = new URLSearchParams({
+    value: "",
+    termId: String(params.termId ?? getUniversityTermId()),
+  });
+
+  if (params.homeUniversityId !== undefined) {
+    searchParams.set("homeUniversityId", String(params.homeUniversityId));
+  }
+
+  const endpoint = `/univ-apply-infos/search/text?${searchParams.toString()}`;
   const response = await serverFetch<UniversitySearchResponse>(endpoint);
 
   if (!response.ok) {

--- a/apps/web/src/apis/universities/server/getSearchUniversitiesByText.ts
+++ b/apps/web/src/apis/universities/server/getSearchUniversitiesByText.ts
@@ -1,3 +1,5 @@
+import { URLSearchParams } from "node:url";
+import { DEFAULT_UNIVERSITY_TERM_ID } from "@/constants/university";
 import { type AllRegionsUniversityList, type ListUniversity, RegionEnumExtend } from "@/types/university";
 import serverFetch from "@/utils/serverFetchUtil";
 
@@ -6,11 +8,38 @@ interface UniversitySearchResponse {
   univApplyInfoPreviews: ListUniversity[];
 }
 
-export const getUniversitiesByText = async (value: string): Promise<ListUniversity[]> => {
+export interface UniversitySearchTextParams {
+  termId?: number;
+  homeUniversityId?: number;
+}
+
+const getUniversityTermId = () => {
+  const termId = Number(process.env.UNIVERSITY_TERM_ID ?? process.env.NEXT_PUBLIC_UNIVERSITY_TERM_ID);
+
+  return Number.isInteger(termId) && termId > 0 ? termId : DEFAULT_UNIVERSITY_TERM_ID;
+};
+
+const createSearchTextEndpoint = (value: string, params: UniversitySearchTextParams = {}) => {
+  const searchParams = new URLSearchParams({
+    value,
+    termId: String(params.termId ?? getUniversityTermId()),
+  });
+
+  if (params.homeUniversityId !== undefined) {
+    searchParams.set("homeUniversityId", String(params.homeUniversityId));
+  }
+
+  return `/univ-apply-infos/search/text?${searchParams.toString()}`;
+};
+
+export const getUniversitiesByText = async (
+  value: string,
+  params?: UniversitySearchTextParams,
+): Promise<ListUniversity[]> => {
   if (value === null || value === undefined) {
     return [];
   }
-  const endpoint = `/univ-apply-infos/search/text?value=${encodeURIComponent(value)}`;
+  const endpoint = createSearchTextEndpoint(value, params);
   const response = await serverFetch<UniversitySearchResponse>(endpoint);
 
   if (!response.ok) {
@@ -20,13 +49,15 @@ export const getUniversitiesByText = async (value: string): Promise<ListUniversi
   return response.data.univApplyInfoPreviews;
 };
 
-export const getAllUniversities = async (): Promise<ListUniversity[]> => {
-  return getUniversitiesByText("");
+export const getAllUniversities = async (params?: UniversitySearchTextParams): Promise<ListUniversity[]> => {
+  return getUniversitiesByText("", params);
 };
 
-export const getCategorizedUniversities = async (): Promise<AllRegionsUniversityList> => {
+export const getCategorizedUniversities = async (
+  params?: UniversitySearchTextParams,
+): Promise<AllRegionsUniversityList> => {
   // 1. 단 한 번의 API 호출로 모든 대학 데이터를 가져옵니다.
-  const allUniversities = await getAllUniversities();
+  const allUniversities = await getAllUniversities(params);
 
   const categorizedList: AllRegionsUniversityList = {
     [RegionEnumExtend.ALL]: allUniversities,

--- a/apps/web/src/apis/universities/server/getSearchUniversitiesByText.ts
+++ b/apps/web/src/apis/universities/server/getSearchUniversitiesByText.ts
@@ -19,14 +19,31 @@ const getUniversityTermId = () => {
   return Number.isInteger(termId) && termId > 0 ? termId : DEFAULT_UNIVERSITY_TERM_ID;
 };
 
+const normalizePositiveInt = (value: unknown) => {
+  const numberValue = typeof value === "string" && value.trim() !== "" ? Number(value) : value;
+
+  return typeof numberValue === "number" && Number.isInteger(numberValue) && numberValue > 0 ? numberValue : undefined;
+};
+
+const assertPositiveInt = (name: string, value: unknown) => {
+  const positiveInt = normalizePositiveInt(value);
+
+  if (positiveInt === undefined) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+
+  return positiveInt;
+};
+
 const createSearchTextEndpoint = (value: string, params: UniversitySearchTextParams = {}) => {
+  const termId = params.termId === undefined ? getUniversityTermId() : assertPositiveInt("termId", params.termId);
   const searchParams = new URLSearchParams({
     value,
-    termId: String(params.termId ?? getUniversityTermId()),
+    termId: String(termId),
   });
 
   if (params.homeUniversityId !== undefined) {
-    searchParams.set("homeUniversityId", String(params.homeUniversityId));
+    searchParams.set("homeUniversityId", String(assertPositiveInt("homeUniversityId", params.homeUniversityId)));
   }
 
   return `/univ-apply-infos/search/text?${searchParams.toString()}`;

--- a/apps/web/src/app/(home)/_ui/PopularUniversitySection/_ui/PopularUniversityCard.tsx
+++ b/apps/web/src/app/(home)/_ui/PopularUniversitySection/_ui/PopularUniversityCard.tsx
@@ -20,9 +20,12 @@ const PopularUniversityCard = ({
   quality = 60, // 기본값을 60으로 낮춤
 }: PopularUniversityCardProps) => {
   const homeUniversitySlug = getHomeUniversitySlugByName(university.homeUniversityName);
-  const universityDetailHref = homeUniversitySlug
-    ? `/university/${homeUniversitySlug}/${university.id}`
-    : "/university";
+
+  if (!homeUniversitySlug) {
+    return null;
+  }
+
+  const universityDetailHref = `/university/${homeUniversitySlug}/${university.id}`;
 
   return (
     <UniversityZoneLink key={university.id} href={universityDetailHref}>

--- a/apps/web/src/app/(home)/page.tsx
+++ b/apps/web/src/app/(home)/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { getHomeNewsList } from "@/apis/news/server/getNewsList";
 import { getCategorizedUniversities, getRecommendedUniversity } from "@/apis/universities/server";
+import { getHomeUniversitySlugByName } from "@/constants/university";
 import { type ListUniversity, RegionEnumExtend } from "@/types/university";
 import { createUrl } from "@/utils/seo";
 import FindLastYearScoreBar from "./_ui/FindLastYearScoreBar";
@@ -61,11 +62,40 @@ const resolveRecommendedUniversitiesHomeUniversityName = (
   const homeUniversityNameById = new Map(
     allUniversities.map((university) => [university.id, university.homeUniversityName]),
   );
+  const homeUniversityNamesByTermAndName = new Map<string, Set<ListUniversity["homeUniversityName"]>>();
+
+  allUniversities.forEach((university) => {
+    const key = `${university.term}:${university.koreanName}`;
+    const names = homeUniversityNamesByTermAndName.get(key) ?? new Set<ListUniversity["homeUniversityName"]>();
+
+    names.add(university.homeUniversityName);
+    homeUniversityNamesByTermAndName.set(key, names);
+  });
 
   return recommendedUniversities.map((university) => ({
     ...university,
-    homeUniversityName: university.homeUniversityName ?? homeUniversityNameById.get(university.id),
+    homeUniversityName:
+      university.homeUniversityName ??
+      homeUniversityNameById.get(university.id) ??
+      getUniqueHomeUniversityName(homeUniversityNamesByTermAndName, university),
   }));
+};
+
+const getUniqueHomeUniversityName = (
+  homeUniversityNamesByTermAndName: Map<string, Set<ListUniversity["homeUniversityName"]>>,
+  university: ListUniversity,
+) => {
+  const names = homeUniversityNamesByTermAndName.get(`${university.term}:${university.koreanName}`);
+
+  if (!names || names.size !== 1) {
+    return undefined;
+  }
+
+  return names.values().next().value;
+};
+
+const hasUniversityDetailRoute = (university: ListUniversity) => {
+  return getHomeUniversitySlugByName(university.homeUniversityName) !== undefined;
 };
 
 const HomePage = async () => {
@@ -78,7 +108,7 @@ const HomePage = async () => {
   const resolvedRecommendedUniversities = resolveRecommendedUniversitiesHomeUniversityName(
     recommendedUniversities,
     allUniversities,
-  );
+  ).filter(hasUniversityDetailRoute);
 
   return (
     <>

--- a/apps/web/src/app/university/application/apply/ApplyPageContent.tsx
+++ b/apps/web/src/app/university/application/apply/ApplyPageContent.tsx
@@ -20,7 +20,7 @@ const ApplyPageContent = () => {
   const router = useRouter();
   const [step, setStep] = useState<number>(1);
 
-  const { data: universityList = [] } = useUniversitySearch("");
+  const { data: universityList = [] } = useUniversitySearch("", undefined, { useDefaultTermId: true });
   const { data: gpaScoreList = [] } = useGetMyGpaScore();
   const { data: languageTestScoreList = [] } = useGetMyLanguageTestScore();
   const { mutate: postSubmitApplication } = usePostSubmitApplication({

--- a/apps/web/src/constants/university.ts
+++ b/apps/web/src/constants/university.ts
@@ -33,6 +33,7 @@ export const HOME_UNIVERSITY_TO_SLUG_MAP: Record<HomeUniversity, HomeUniversityS
  * 홈 대학교 정보 (온보딩 카드에서 사용)
  */
 export interface HomeUniversityInfo {
+  homeUniversityId: number;
   name: HomeUniversity;
   slug: HomeUniversitySlug;
   shortName: string;
@@ -43,6 +44,7 @@ export interface HomeUniversityInfo {
 
 export const HOME_UNIVERSITY_LIST: HomeUniversityInfo[] = [
   {
+    homeUniversityId: 1,
     name: HomeUniversity.INHA,
     slug: "inha",
     shortName: "인하대",
@@ -51,6 +53,7 @@ export const HOME_UNIVERSITY_LIST: HomeUniversityInfo[] = [
     color: "#004C98",
   },
   {
+    homeUniversityId: 2,
     name: HomeUniversity.INCHEON,
     slug: "incheon",
     shortName: "인천대",
@@ -59,6 +62,7 @@ export const HOME_UNIVERSITY_LIST: HomeUniversityInfo[] = [
     color: "#003876",
   },
   {
+    homeUniversityId: 3,
     name: HomeUniversity.SUNGSHIN,
     slug: "sungshin",
     shortName: "성신여대",
@@ -67,6 +71,9 @@ export const HOME_UNIVERSITY_LIST: HomeUniversityInfo[] = [
     color: "#7B1FA2",
   },
 ];
+
+// 배포 환경에서 UNIVERSITY_TERM_ID를 주입하지 못했을 때 사용하는 현재 학기 fallback입니다.
+export const DEFAULT_UNIVERSITY_TERM_ID = 12;
 
 /**
  * 슬러그로 홈 대학교 정보 조회


### PR DESCRIPTION
## 관련 이슈

- 없음

## 작업 내용

- 메인 페이지의 실시간 인기있는 파견학교 카드가 상세 라우트를 만들 수 없는 경우 `/university`로 fallback하지 않도록 수정했습니다.
- 추천 학교의 `homeUniversityName`을 추천 응답 자체, 전체 학교 목록의 id 매칭, 학기+학교명 단일 매칭 순서로 보강하도록 했습니다.
- 추천 응답 타입에 실제 API 응답 필드인 `homeUniversityName`을 반영했습니다.
- `/univ-apply-infos/search/text`, `/univ-apply-infos/search/filter` 호출에 `termId`, `homeUniversityId` 파라미터를 전달할 수 있도록 web/university-web 검색 API 계층을 보강했습니다.
- 대학별 목록/상세 SSG 생성 시 홈대학별 `homeUniversityId`를 붙여 `/university/{homeUniversity}/{id}` 조합을 해당 대학 데이터 기준으로 생성하도록 수정했습니다.
- 배포 환경에서 학기 env가 없을 때를 위해 `DEFAULT_UNIVERSITY_TERM_ID=12` fallback을 추가했습니다. 실제 운영 학기 변경 시 `UNIVERSITY_TERM_ID` 또는 `NEXT_PUBLIC_UNIVERSITY_TERM_ID`로 덮어쓸 수 있습니다.

## 특이 사항

- 현재 production API 기준 `termId=12`, `homeUniversityId=1` 조합에서 인하대 상세 SSG 경로가 생성되는 것을 build로 확인했습니다.
- 로컬 Node 버전이 repo 권장값인 22.x가 아닌 v23.10.0이라 엔진 경고가 출력됩니다.

## 검증

- `pnpm --filter @solid-connect/web run lint:check`
- `pnpm --filter @solid-connect/web run typecheck`
- `pnpm --filter @solid-connect/university-web run lint:check`
- `pnpm --filter @solid-connect/university-web run typecheck`
- `NODE_ENV=production UNIVERSITY_WEB_DOMAIN=https://university-web.ci.local pnpm --filter @solid-connect/web run build`
- `NODE_ENV=production pnpm --filter @solid-connect/university-web run build`
- commit hook의 web/university-web `ci:check`
- pre-push hook의 web/university-web `ci:check` 및 `build`
- 로컬 `http://localhost:3000/` HTML에서 인기 파견학교 카드 href 확인

## 리뷰 요구사항 (선택)

- staging/production 데이터에서도 인기 파견학교 카드가 `/university/{homeUniversity}/{id}`로만 이동하는지 확인 부탁드립니다.
- 운영 학기 전환 시 `UNIVERSITY_TERM_ID` 또는 `NEXT_PUBLIC_UNIVERSITY_TERM_ID` 값이 배포 환경에 맞게 주입되는지 확인 부탁드립니다.