### PR TITLE
fix: 파견학교 지도 초기 줌 조정

### DIFF
--- a/apps/university-web/src/app/university/[homeUniversity]/[id]/_ui/UniversityDetail/_ui/MapSection.tsx
+++ b/apps/university-web/src/app/university/[homeUniversity]/[id]/_ui/UniversityDetail/_ui/MapSection.tsx
@@ -4,6 +4,8 @@ interface MapSectionProps {
   universityEnglishName: string;
 }
 
+const SCHOOL_LOCATION_OVERVIEW_ZOOM = 5;
+
 const MapSection = ({ universityEnglishName }: MapSectionProps) => {
   return (
     <>
@@ -11,7 +13,13 @@ const MapSection = ({ universityEnglishName }: MapSectionProps) => {
       <div className="my-7">
         <div className="mb-3 text-k-900 typo-sb-7">파견학교 위치</div>
         <div>
-          <GoogleEmbedMap width="100%" height="300px" name={universityEnglishName} style={{ border: "0" }} />
+          <GoogleEmbedMap
+            width="100%"
+            height="300px"
+            name={universityEnglishName}
+            zoom={SCHOOL_LOCATION_OVERVIEW_ZOOM}
+            style={{ border: "0" }}
+          />
         </div>
       </div>
     </>


### PR DESCRIPTION
## 관련 이슈

- Closes #190

## 작업 내용

- 파견학교 상세 페이지의 Google Embed Map 초기 zoom을 `5`로 지정했습니다.
- 기존보다 덜 상세하게 보여서 캠퍼스 주변보다 국가/지역 기준의 위치감을 먼저 확인할 수 있도록 조정했습니다.

## 검증

- `pnpm --filter @solid-connect/university-web run lint:check`
- `pnpm --filter @solid-connect/university-web run typecheck`
- `NODE_ENV=production pnpm --filter @solid-connect/university-web run build`
- pre-push hook의 university-web `ci:check` 및 `build`
- university-web 정적 산출물에서 Google Maps iframe `zoom=5` 반영 확인

## 참고

- Google Maps zoom 값은 숫자가 클수록 더 상세하게 확대됩니다. 이번 변경은 사용자가 국가/지역 단위의 위치를 먼저 파악하도록 기존보다 낮은 zoom 값을 사용합니다.