### PR TITLE
refactor: 호스트 대학교 이미지 업로드 multipart/form-data 방식으로 전환

### DIFF
--- a/apps/admin/src/components/features/univ-apply-infos/tabs/HostUniversityTab.test.tsx
+++ b/apps/admin/src/components/features/univ-apply-infos/tabs/HostUniversityTab.test.tsx
@@ -40,53 +40,77 @@ describe("HostUniversityTab image uploads", () => {
 			totalElements: 0,
 			totalPages: 0,
 		});
+		vi.stubGlobal("URL", {
+			createObjectURL: vi.fn(() => "blob:mock-url"),
+			revokeObjectURL: vi.fn(),
+		});
 	});
 
 	afterEach(() => {
 		cleanup();
 		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
 		toastError.mockReset();
 		toastSuccess.mockReset();
 	});
 
-	it("uploads a selected logo with formatName and writes the returned URL", async () => {
-		const upload = vi
-			.spyOn(adminApi, "uploadAdminUniversityLogo")
-			.mockResolvedValue({ fileUrl: "admin/logo/test.webp" });
-		await openCreateModal();
-		fireEvent.change(screen.getByLabelText("표시명 *"), { target: { value: "university_of_test" } });
-		const file = new File(["logo"], "logo.png", { type: "image/png" });
-		fireEvent.change(screen.getByLabelText("로고 이미지 파일"), { target: { files: [file] } });
-
-		await waitFor(() => expect(upload).toHaveBeenCalledWith(file, "university_of_test"));
-		await waitFor(() =>
-			expect((screen.getByLabelText("로고 이미지 URL *") as HTMLInputElement).value).toBe("admin/logo/test.webp"),
-		);
-		expect(screen.getByRole("img", { name: "로고 미리보기" }).getAttribute("src")).toBe(
-			"https://cdn.upload.solid-connection.com/admin/logo/test.webp",
-		);
-	});
-
-	it("does not upload when formatName is blank", async () => {
-		const upload = vi.spyOn(adminApi, "uploadAdminUniversityLogo");
+	it("shows logo preview immediately after file selection without calling the API", async () => {
 		await openCreateModal();
 		const file = new File(["logo"], "logo.png", { type: "image/png" });
 		fireEvent.change(screen.getByLabelText("로고 이미지 파일"), { target: { files: [file] } });
 
-		expect(upload).not.toHaveBeenCalled();
-		expect(toastError).toHaveBeenCalledWith("표시명을 먼저 입력해 주세요.");
+		await waitFor(() => expect(screen.getByRole("img", { name: "로고 미리보기" })).toBeTruthy());
+		expect(toastError).not.toHaveBeenCalled();
 	});
 
-	it("preserves the current background URL when upload fails", async () => {
-		vi.spyOn(adminApi, "uploadAdminUniversityBackground").mockRejectedValue(new Error("업로드 실패"));
+	it("shows background preview immediately after file selection without calling the API", async () => {
 		await openCreateModal();
-		fireEvent.change(screen.getByLabelText("표시명 *"), { target: { value: "university_of_test" } });
-		const urlInput = screen.getByLabelText("배경 이미지 URL *") as HTMLInputElement;
-		fireEvent.change(urlInput, { target: { value: "existing/background.webp" } });
-		const file = new File(["background"], "background.png", { type: "image/png" });
+		const file = new File(["bg"], "background.png", { type: "image/png" });
 		fireEvent.change(screen.getByLabelText("배경 이미지 파일"), { target: { files: [file] } });
 
-		await waitFor(() => expect(toastError).toHaveBeenCalledWith("업로드 실패"));
-		expect(urlInput.value).toBe("existing/background.webp");
+		await waitFor(() => expect(screen.getByRole("img", { name: "배경 미리보기" })).toBeTruthy());
+		expect(toastError).not.toHaveBeenCalled();
+	});
+
+	it("shows an error toast and does not submit when files are not selected on create", async () => {
+		const create = vi.spyOn(adminApi, "createHostUniversity").mockResolvedValue({} as never);
+		await openCreateModal();
+
+		fireEvent.change(screen.getByLabelText("한글명 *"), { target: { value: "테스트 대학교" } });
+		fireEvent.change(screen.getByLabelText("영문명 *"), { target: { value: "Test University" } });
+		fireEvent.change(screen.getByLabelText("표시명 *"), { target: { value: "Test U" } });
+		fireEvent.change(screen.getByLabelText("국가코드 *"), { target: { value: "JP" } });
+		fireEvent.change(screen.getByLabelText("권역코드 *"), { target: { value: "ASIA" } });
+
+		fireEvent.click(screen.getByRole("button", { name: "생성" }));
+
+		await waitFor(() => expect(toastError).toHaveBeenCalledWith("로고 및 배경 이미지를 모두 선택해 주세요."));
+		expect(create).not.toHaveBeenCalled();
+	});
+
+	it("calls createHostUniversity with form data and selected files on submit", async () => {
+		const create = vi.spyOn(adminApi, "createHostUniversity").mockResolvedValue({} as never);
+		await openCreateModal();
+
+		fireEvent.change(screen.getByLabelText("한글명 *"), { target: { value: "테스트 대학교" } });
+		fireEvent.change(screen.getByLabelText("영문명 *"), { target: { value: "Test University" } });
+		fireEvent.change(screen.getByLabelText("표시명 *"), { target: { value: "Test U" } });
+		fireEvent.change(screen.getByLabelText("국가코드 *"), { target: { value: "JP" } });
+		fireEvent.change(screen.getByLabelText("권역코드 *"), { target: { value: "ASIA" } });
+
+		const logoFile = new File(["logo"], "logo.png", { type: "image/png" });
+		const backgroundFile = new File(["bg"], "bg.png", { type: "image/png" });
+		fireEvent.change(screen.getByLabelText("로고 이미지 파일"), { target: { files: [logoFile] } });
+		fireEvent.change(screen.getByLabelText("배경 이미지 파일"), { target: { files: [backgroundFile] } });
+
+		fireEvent.click(screen.getByRole("button", { name: "생성" }));
+
+		await waitFor(() =>
+			expect(create).toHaveBeenCalledWith(
+				expect.objectContaining({ koreanName: "테스트 대학교", countryCode: "JP" }),
+				logoFile,
+				backgroundFile,
+			),
+		);
 	});
 });

--- a/apps/admin/src/components/features/univ-apply-infos/tabs/HostUniversityTab.tsx
+++ b/apps/admin/src/components/features/univ-apply-infos/tabs/HostUniversityTab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { keepPreviousData, useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ImageIcon, Loader2, Upload } from "lucide-react";
+import { ImageIcon, Upload } from "lucide-react";
 import { type FormEvent, useId, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -19,23 +19,18 @@ import { normalizeImageUrlToUploadCdn } from "@/lib/utils/cdnUrl";
 
 type ModalState = { open: false } | { open: true; mode: "create" } | { open: true; mode: "edit"; id: number };
 
-const REQUIRED_FIELDS = [
-	"koreanName",
-	"englishName",
-	"formatName",
-	"logoImageUrl",
-	"backgroundImageUrl",
-	"countryCode",
-	"regionCode",
-] as const;
+interface HostUniversityFormState extends HostUniversityPayload {
+	logoImageUrl: string;
+	backgroundImageUrl: string;
+}
+
+const REQUIRED_FIELDS = ["koreanName", "englishName", "formatName", "countryCode", "regionCode"] as const;
 const OPTIONAL_FIELDS = ["homepageUrl", "englishCourseUrl", "accommodationUrl"] as const;
 
-const FIELD_LABELS: Record<keyof HostUniversityPayload, string> = {
+const FIELD_LABELS: Record<string, string> = {
 	koreanName: "한글명",
 	englishName: "영문명",
 	formatName: "표시명",
-	logoImageUrl: "로고 이미지 URL",
-	backgroundImageUrl: "배경 이미지 URL",
 	countryCode: "국가코드",
 	regionCode: "권역코드",
 	homepageUrl: "홈페이지 URL",
@@ -44,7 +39,7 @@ const FIELD_LABELS: Record<keyof HostUniversityPayload, string> = {
 	detailsForLocal: "상세 설명",
 };
 
-const EMPTY_FORM: HostUniversityPayload = {
+const EMPTY_FORM: HostUniversityFormState = {
 	koreanName: "",
 	englishName: "",
 	formatName: "",
@@ -58,7 +53,7 @@ const EMPTY_FORM: HostUniversityPayload = {
 	detailsForLocal: "",
 };
 
-function detailToForm(detail: HostUniversityDetailResponse): HostUniversityPayload {
+function detailToForm(detail: HostUniversityDetailResponse): HostUniversityFormState {
 	return {
 		koreanName: detail.koreanName,
 		englishName: detail.englishName,
@@ -74,9 +69,13 @@ function detailToForm(detail: HostUniversityDetailResponse): HostUniversityPaylo
 	};
 }
 
-function toPayload(form: HostUniversityPayload): HostUniversityPayload {
+function toPayload(form: HostUniversityFormState): HostUniversityPayload {
 	return {
-		...form,
+		koreanName: form.koreanName,
+		englishName: form.englishName,
+		formatName: form.formatName,
+		countryCode: form.countryCode,
+		regionCode: form.regionCode,
 		homepageUrl: form.homepageUrl || undefined,
 		englishCourseUrl: form.englishCourseUrl || undefined,
 		accommodationUrl: form.accommodationUrl || undefined,
@@ -94,11 +93,15 @@ export function HostUniversityTab() {
 	const [searchParams, setSearchParams] = useState({ keyword: "", countryCode: "", regionCode: "", page: 0 });
 
 	const [modal, setModal] = useState<ModalState>({ open: false });
-	const [form, setForm] = useState<HostUniversityPayload>(EMPTY_FORM);
+	const [form, setForm] = useState<HostUniversityFormState>(EMPTY_FORM);
+	const [logoFile, setLogoFile] = useState<File | null>(null);
+	const [backgroundFile, setBackgroundFile] = useState<File | null>(null);
 	const pendingEditIdRef = useRef<number | null>(null);
 
 	const closeModal = () => {
 		pendingEditIdRef.current = null;
+		setLogoFile(null);
+		setBackgroundFile(null);
 		setModal({ open: false });
 	};
 
@@ -111,7 +114,8 @@ export function HostUniversityTab() {
 	const invalidate = () => queryClient.invalidateQueries({ queryKey: ["admin", "host-universities"] });
 
 	const createMutation = useMutation({
-		mutationFn: (data: HostUniversityPayload) => adminApi.createHostUniversity(data),
+		mutationFn: ({ data, logo, background }: { data: HostUniversityPayload; logo: File; background: File }) =>
+			adminApi.createHostUniversity(data, logo, background),
 		onSuccess: async () => {
 			await invalidate();
 			closeModal();
@@ -124,7 +128,17 @@ export function HostUniversityTab() {
 	});
 
 	const updateMutation = useMutation({
-		mutationFn: ({ id, data }: { id: number; data: HostUniversityPayload }) => adminApi.updateHostUniversity(id, data),
+		mutationFn: ({
+			id,
+			data,
+			logo,
+			background,
+		}: {
+			id: number;
+			data: HostUniversityPayload;
+			logo?: File | null;
+			background?: File | null;
+		}) => adminApi.updateHostUniversity(id, data, logo, background),
 		onSuccess: async () => {
 			await invalidate();
 			closeModal();
@@ -148,32 +162,6 @@ export function HostUniversityTab() {
 		},
 	});
 
-	const logoUploadMutation = useMutation({
-		mutationFn: ({ file, englishName }: { file: File; englishName: string }) =>
-			adminApi.uploadAdminUniversityLogo(file, englishName),
-		onSuccess: ({ fileUrl }) => {
-			setForm((prev) => ({ ...prev, logoImageUrl: fileUrl }));
-			toast.success("로고 이미지를 업로드했습니다.");
-		},
-		onError: (e: unknown) => {
-			const msg = e instanceof Error ? e.message : "로고 이미지 업로드에 실패했습니다.";
-			toast.error(msg);
-		},
-	});
-
-	const backgroundUploadMutation = useMutation({
-		mutationFn: ({ file, englishName }: { file: File; englishName: string }) =>
-			adminApi.uploadAdminUniversityBackground(file, englishName),
-		onSuccess: ({ fileUrl }) => {
-			setForm((prev) => ({ ...prev, backgroundImageUrl: fileUrl }));
-			toast.success("배경 이미지를 업로드했습니다.");
-		},
-		onError: (e: unknown) => {
-			const msg = e instanceof Error ? e.message : "배경 이미지 업로드에 실패했습니다.";
-			toast.error(msg);
-		},
-	});
-
 	const handleSearch = (e: FormEvent) => {
 		e.preventDefault();
 		setSearchParams({ keyword, countryCode, regionCode, page: 0 });
@@ -182,11 +170,15 @@ export function HostUniversityTab() {
 	const handleOpenCreate = () => {
 		pendingEditIdRef.current = null;
 		setForm(EMPTY_FORM);
+		setLogoFile(null);
+		setBackgroundFile(null);
 		setModal({ open: true, mode: "create" });
 	};
 
 	const handleOpenEdit = (univ: HostUniversityResponse) => {
 		pendingEditIdRef.current = univ.id;
+		setLogoFile(null);
+		setBackgroundFile(null);
 		const cached = detailMap.get(univ.id);
 		if (cached) {
 			setForm(detailToForm(cached));
@@ -210,33 +202,33 @@ export function HostUniversityTab() {
 		deleteMutation.mutate(id);
 	};
 
-	const uploadImage = (kind: "logo" | "background", file: File | undefined) => {
+	const handleLogoChange = (file: File | undefined) => {
 		if (!file) return;
-		if (!form.formatName.trim()) {
-			toast.error("표시명을 먼저 입력해 주세요.");
-			return;
-		}
+		setLogoFile(file);
+		setForm((prev) => ({ ...prev, logoImageUrl: URL.createObjectURL(file) }));
+	};
 
-		const variables = { file, englishName: form.formatName };
-		if (kind === "logo") {
-			logoUploadMutation.mutate(variables);
-		} else {
-			backgroundUploadMutation.mutate(variables);
-		}
+	const handleBackgroundChange = (file: File | undefined) => {
+		if (!file) return;
+		setBackgroundFile(file);
+		setForm((prev) => ({ ...prev, backgroundImageUrl: URL.createObjectURL(file) }));
 	};
 
 	const handleSubmit = (e: FormEvent) => {
 		e.preventDefault();
 		const payload = toPayload(form);
 		if (modal.open && modal.mode === "edit") {
-			updateMutation.mutate({ id: modal.id, data: payload });
+			updateMutation.mutate({ id: modal.id, data: payload, logo: logoFile, background: backgroundFile });
 		} else {
-			createMutation.mutate(payload);
+			if (!logoFile || !backgroundFile) {
+				toast.error("로고 및 배경 이미지를 모두 선택해 주세요.");
+				return;
+			}
+			createMutation.mutate({ data: payload, logo: logoFile, background: backgroundFile });
 		}
 	};
 
 	const isMutating = createMutation.isPending || updateMutation.isPending || deleteMutation.isPending;
-	const isUploading = logoUploadMutation.isPending || backgroundUploadMutation.isPending;
 	const universities = query.data?.content ?? [];
 	const totalPages = query.data?.totalPages ?? 0;
 	const currentPage = searchParams.page;
@@ -439,100 +431,89 @@ export function HostUniversityTab() {
 										onChange={(e) => setForm((prev) => ({ ...prev, [field]: e.target.value }))}
 										required
 									/>
-									{field === "logoImageUrl" && (
-										<div className="flex items-center gap-3 rounded-lg border border-k-100 bg-k-50 p-3">
-											{form.logoImageUrl ? (
-												<img
-													src={normalizeImageUrlToUploadCdn(form.logoImageUrl)}
-													alt="로고 미리보기"
-													className="h-14 w-14 shrink-0 rounded-md border border-k-100 bg-white object-contain p-1"
-												/>
-											) : (
-												<div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-md border border-dashed border-k-200 bg-white">
-													<ImageIcon className="h-5 w-5 text-k-300" />
-												</div>
-											)}
-											<label
-												className={cn(
-													"flex cursor-pointer items-center gap-2 rounded-lg border px-3 py-2 typo-regular-4 transition-colors",
-													logoUploadMutation.isPending
-														? "cursor-not-allowed border-k-200 text-k-400 opacity-60"
-														: "border-k-200 text-k-600 hover:border-primary hover:bg-primary/5 hover:text-primary",
-												)}
-											>
-												{logoUploadMutation.isPending ? (
-													<>
-														<Loader2 className="h-4 w-4 animate-spin" />
-														업로드 중...
-													</>
-												) : (
-													<>
-														<Upload className="h-4 w-4" />
-														파일 선택
-													</>
-												)}
-												<input
-													type="file"
-													accept="image/*"
-													aria-label="로고 이미지 파일"
-													className="sr-only"
-													disabled={logoUploadMutation.isPending}
-													onChange={(e) => {
-														uploadImage("logo", e.target.files?.[0]);
-														e.target.value = "";
-													}}
-												/>
-											</label>
-										</div>
-									)}
-									{field === "backgroundImageUrl" && (
-										<div className="flex items-center gap-3 rounded-lg border border-k-100 bg-k-50 p-3">
-											{form.backgroundImageUrl ? (
-												<img
-													src={normalizeImageUrlToUploadCdn(form.backgroundImageUrl)}
-													alt="배경 미리보기"
-													className="h-14 w-28 shrink-0 rounded-md border border-k-100 bg-white object-cover"
-												/>
-											) : (
-												<div className="flex h-14 w-28 shrink-0 items-center justify-center rounded-md border border-dashed border-k-200 bg-white">
-													<ImageIcon className="h-5 w-5 text-k-300" />
-												</div>
-											)}
-											<label
-												className={cn(
-													"flex cursor-pointer items-center gap-2 rounded-lg border px-3 py-2 typo-regular-4 transition-colors",
-													backgroundUploadMutation.isPending
-														? "cursor-not-allowed border-k-200 text-k-400 opacity-60"
-														: "border-k-200 text-k-600 hover:border-primary hover:bg-primary/5 hover:text-primary",
-												)}
-											>
-												{backgroundUploadMutation.isPending ? (
-													<>
-														<Loader2 className="h-4 w-4 animate-spin" />
-														업로드 중...
-													</>
-												) : (
-													<>
-														<Upload className="h-4 w-4" />
-														파일 선택
-													</>
-												)}
-												<input
-													type="file"
-													accept="image/*"
-													aria-label="배경 이미지 파일"
-													className="sr-only"
-													disabled={backgroundUploadMutation.isPending}
-													onChange={(e) => {
-														uploadImage("background", e.target.files?.[0]);
-														e.target.value = "";
-													}}
-												/>
-											</label>
-										</div>
-									)}
 								</div>
 							))}
+
+							<div className="space-y-1">
+								<p className="typo-sb-11 text-k-700">로고 이미지{modal.mode === "create" ? " *" : ""}</p>
+								<div className="flex items-center gap-3 rounded-lg border border-k-100 bg-k-50 p-3">
+									{form.logoImageUrl ? (
+										<img
+											src={
+												form.logoImageUrl.startsWith("blob:")
+													? form.logoImageUrl
+													: normalizeImageUrlToUploadCdn(form.logoImageUrl)
+											}
+											alt="로고 미리보기"
+											className="h-14 w-14 shrink-0 rounded-md border border-k-100 bg-white object-contain p-1"
+										/>
+									) : (
+										<div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-md border border-dashed border-k-200 bg-white">
+											<ImageIcon className="h-5 w-5 text-k-300" />
+										</div>
+									)}
+									<label
+										className={cn(
+											"flex cursor-pointer items-center gap-2 rounded-lg border px-3 py-2 typo-regular-4 transition-colors",
+											"border-k-200 text-k-600 hover:border-primary hover:bg-primary/5 hover:text-primary",
+										)}
+									>
+										<Upload className="h-4 w-4" />
+										{logoFile ? logoFile.name : "파일 선택"}
+										<input
+											type="file"
+											accept="image/*"
+											aria-label="로고 이미지 파일"
+											className="sr-only"
+											onChange={(e) => {
+												handleLogoChange(e.target.files?.[0]);
+												e.target.value = "";
+											}}
+										/>
+									</label>
+								</div>
+							</div>
+
+							<div className="space-y-1">
+								<p className="typo-sb-11 text-k-700">배경 이미지{modal.mode === "create" ? " *" : ""}</p>
+								<div className="flex items-center gap-3 rounded-lg border border-k-100 bg-k-50 p-3">
+									{form.backgroundImageUrl ? (
+										<img
+											src={
+												form.backgroundImageUrl.startsWith("blob:")
+													? form.backgroundImageUrl
+													: normalizeImageUrlToUploadCdn(form.backgroundImageUrl)
+											}
+											alt="배경 미리보기"
+											className="h-14 w-28 shrink-0 rounded-md border border-k-100 bg-white object-cover"
+										/>
+									) : (
+										<div className="flex h-14 w-28 shrink-0 items-center justify-center rounded-md border border-dashed border-k-200 bg-white">
+											<ImageIcon className="h-5 w-5 text-k-300" />
+										</div>
+									)}
+									<label
+										className={cn(
+											"flex cursor-pointer items-center gap-2 rounded-lg border px-3 py-2 typo-regular-4 transition-colors",
+											"border-k-200 text-k-600 hover:border-primary hover:bg-primary/5 hover:text-primary",
+										)}
+									>
+										<Upload className="h-4 w-4" />
+										{backgroundFile ? backgroundFile.name : "파일 선택"}
+										<input
+											type="file"
+											accept="image/*"
+											aria-label="배경 이미지 파일"
+											className="sr-only"
+											onChange={(e) => {
+												handleBackgroundChange(e.target.files?.[0]);
+												e.target.value = "";
+											}}
+										/>
+									</label>
+								</div>
+							</div>
+
 							{OPTIONAL_FIELDS.map((field) => (
 								<div key={field} className="space-y-1">
 									<label htmlFor={`field-${field}`} className="typo-sb-11 text-k-700">
@@ -560,7 +541,7 @@ export function HostUniversityTab() {
 								<Button type="button" variant="secondary" onClick={closeModal}>
 									취소
 								</Button>
-								<Button type="submit" disabled={createMutation.isPending || updateMutation.isPending || isUploading}>
+								<Button type="submit" disabled={createMutation.isPending || updateMutation.isPending}>
 									{modal.mode === "create" ? "생성" : "저장"}
 								</Button>
 							</div>

--- a/apps/admin/src/components/features/univ-apply-infos/tabs/HostUniversityTab.tsx
+++ b/apps/admin/src/components/features/univ-apply-infos/tabs/HostUniversityTab.tsx
@@ -2,7 +2,7 @@
 
 import { keepPreviousData, useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ImageIcon, Upload } from "lucide-react";
-import { type FormEvent, useId, useRef, useState } from "react";
+import { type FormEvent, useEffect, useId, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -96,7 +96,29 @@ export function HostUniversityTab() {
 	const [form, setForm] = useState<HostUniversityFormState>(EMPTY_FORM);
 	const [logoFile, setLogoFile] = useState<File | null>(null);
 	const [backgroundFile, setBackgroundFile] = useState<File | null>(null);
+	const [logoPreviewUrl, setLogoPreviewUrl] = useState("");
+	const [backgroundPreviewUrl, setBackgroundPreviewUrl] = useState("");
 	const pendingEditIdRef = useRef<number | null>(null);
+
+	useEffect(() => {
+		if (!logoFile) {
+			setLogoPreviewUrl("");
+			return;
+		}
+		const url = URL.createObjectURL(logoFile);
+		setLogoPreviewUrl(url);
+		return () => URL.revokeObjectURL(url);
+	}, [logoFile]);
+
+	useEffect(() => {
+		if (!backgroundFile) {
+			setBackgroundPreviewUrl("");
+			return;
+		}
+		const url = URL.createObjectURL(backgroundFile);
+		setBackgroundPreviewUrl(url);
+		return () => URL.revokeObjectURL(url);
+	}, [backgroundFile]);
 
 	const closeModal = () => {
 		pendingEditIdRef.current = null;
@@ -205,13 +227,11 @@ export function HostUniversityTab() {
 	const handleLogoChange = (file: File | undefined) => {
 		if (!file) return;
 		setLogoFile(file);
-		setForm((prev) => ({ ...prev, logoImageUrl: URL.createObjectURL(file) }));
 	};
 
 	const handleBackgroundChange = (file: File | undefined) => {
 		if (!file) return;
 		setBackgroundFile(file);
-		setForm((prev) => ({ ...prev, backgroundImageUrl: URL.createObjectURL(file) }));
 	};
 
 	const handleSubmit = (e: FormEvent) => {
@@ -437,13 +457,9 @@ export function HostUniversityTab() {
 							<div className="space-y-1">
 								<p className="typo-sb-11 text-k-700">로고 이미지{modal.mode === "create" ? " *" : ""}</p>
 								<div className="flex items-center gap-3 rounded-lg border border-k-100 bg-k-50 p-3">
-									{form.logoImageUrl ? (
+									{logoPreviewUrl || form.logoImageUrl ? (
 										<img
-											src={
-												form.logoImageUrl.startsWith("blob:")
-													? form.logoImageUrl
-													: normalizeImageUrlToUploadCdn(form.logoImageUrl)
-											}
+											src={logoPreviewUrl || normalizeImageUrlToUploadCdn(form.logoImageUrl)}
 											alt="로고 미리보기"
 											className="h-14 w-14 shrink-0 rounded-md border border-k-100 bg-white object-contain p-1"
 										/>
@@ -477,13 +493,9 @@ export function HostUniversityTab() {
 							<div className="space-y-1">
 								<p className="typo-sb-11 text-k-700">배경 이미지{modal.mode === "create" ? " *" : ""}</p>
 								<div className="flex items-center gap-3 rounded-lg border border-k-100 bg-k-50 p-3">
-									{form.backgroundImageUrl ? (
+									{backgroundPreviewUrl || form.backgroundImageUrl ? (
 										<img
-											src={
-												form.backgroundImageUrl.startsWith("blob:")
-													? form.backgroundImageUrl
-													: normalizeImageUrlToUploadCdn(form.backgroundImageUrl)
-											}
+											src={backgroundPreviewUrl || normalizeImageUrlToUploadCdn(form.backgroundImageUrl)}
 											alt="배경 미리보기"
 											className="h-14 w-28 shrink-0 rounded-md border border-k-100 bg-white object-cover"
 										/>

--- a/apps/admin/src/lib/api/admin.test.ts
+++ b/apps/admin/src/lib/api/admin.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { post } = vi.hoisted(() => ({ post: vi.fn() }));
+const { post, put } = vi.hoisted(() => ({ post: vi.fn(), put: vi.fn() }));
 
 vi.mock("@/lib/api/client", () => ({
 	axiosInstance: {
 		get: vi.fn(),
 		post,
-		put: vi.fn(),
+		put,
 		patch: vi.fn(),
 		delete: vi.fn(),
 	},
@@ -14,29 +14,67 @@ vi.mock("@/lib/api/client", () => ({
 
 import { adminApi } from "./admin";
 
-describe("admin university image uploads", () => {
+describe("admin host university multipart API", () => {
 	beforeEach(() => {
 		post.mockReset();
+		put.mockReset();
 	});
 
-	it.each([
-		["logo", "/file/admin/university/logo"],
-		["background", "/file/admin/university/background"],
-	] as const)("uploads the %s with formatName under the existing englishName wire key", async (kind, endpoint) => {
-		post.mockResolvedValue({ data: { fileUrl: `admin/${kind}/image.webp` } });
-		const file = new File(["image"], `${kind}.png`, { type: "image/png" });
+	it("createHostUniversity sends multipart/form-data with request JSON blob and files", async () => {
+		post.mockResolvedValue({ data: { id: 1, koreanName: "테스트 대학교" } });
+		const logoFile = new File(["logo"], "logo.png", { type: "image/png" });
+		const backgroundFile = new File(["bg"], "bg.png", { type: "image/png" });
+		const request = {
+			koreanName: "테스트 대학교",
+			englishName: "Test Univ",
+			formatName: "Test U",
+			countryCode: "JP",
+			regionCode: "ASIA",
+		};
 
-		const result =
-			kind === "logo"
-				? await adminApi.uploadAdminUniversityLogo(file, "university_of_test")
-				: await adminApi.uploadAdminUniversityBackground(file, "university_of_test");
+		await adminApi.createHostUniversity(request, logoFile, backgroundFile);
 
-		expect(post).toHaveBeenCalledWith(endpoint, expect.any(FormData), {
-			headers: { "Content-Type": "multipart/form-data" },
-		});
+		expect(post).toHaveBeenCalledWith("/admin/host-universities", expect.any(FormData));
 		const formData = post.mock.calls[0]?.[1] as FormData;
-		expect(formData.get("file")).toBe(file);
-		expect(formData.get("englishName")).toBe("university_of_test");
-		expect(result).toEqual({ fileUrl: `admin/${kind}/image.webp` });
+		expect(formData.get("logoFile")).toBe(logoFile);
+		expect(formData.get("backgroundFile")).toBe(backgroundFile);
+		const requestBlob = formData.get("request") as Blob;
+		expect(requestBlob.type).toBe("application/json");
+	});
+
+	it("updateHostUniversity sends multipart/form-data with optional files", async () => {
+		put.mockResolvedValue({ data: { id: 1 } });
+		const logoFile = new File(["logo"], "logo.png", { type: "image/png" });
+		const request = {
+			koreanName: "변경된 대학교",
+			englishName: "Changed Univ",
+			formatName: "Changed U",
+			countryCode: "KR",
+			regionCode: "ASIA",
+		};
+
+		await adminApi.updateHostUniversity(1, request, logoFile, null);
+
+		expect(put).toHaveBeenCalledWith("/admin/host-universities/1", expect.any(FormData));
+		const formData = put.mock.calls[0]?.[1] as FormData;
+		expect(formData.get("logoFile")).toBe(logoFile);
+		expect(formData.get("backgroundFile")).toBeNull();
+	});
+
+	it("updateHostUniversity omits both file parts when no files are provided", async () => {
+		put.mockResolvedValue({ data: { id: 1 } });
+		const request = {
+			koreanName: "대학교",
+			englishName: "University",
+			formatName: "U",
+			countryCode: "JP",
+			regionCode: "ASIA",
+		};
+
+		await adminApi.updateHostUniversity(1, request);
+
+		const formData = put.mock.calls[0]?.[1] as FormData;
+		expect(formData.get("logoFile")).toBeNull();
+		expect(formData.get("backgroundFile")).toBeNull();
 	});
 });

--- a/apps/admin/src/lib/api/admin.ts
+++ b/apps/admin/src/lib/api/admin.ts
@@ -122,18 +122,12 @@ export interface HostUniversityPayload {
 	koreanName: string;
 	englishName: string;
 	formatName: string;
-	logoImageUrl: string;
-	backgroundImageUrl: string;
 	countryCode: string;
 	regionCode: string;
 	homepageUrl?: string;
 	englishCourseUrl?: string;
 	accommodationUrl?: string;
 	detailsForLocal?: string;
-}
-
-export interface AdminUniversityImageUploadResponse {
-	fileUrl: string;
 }
 
 export interface UnivApplyInfoLanguageRequirement {
@@ -339,36 +333,33 @@ export const adminApi = {
 	getHostUniversity: (id: number) =>
 		axiosInstance.get<HostUniversityDetailResponse>(`/admin/host-universities/${id}`).then((res) => res.data),
 
-	createHostUniversity: (data: HostUniversityPayload) =>
-		axiosInstance.post<HostUniversityDetailResponse>("/admin/host-universities", data).then((res) => res.data),
+	createHostUniversity: (data: HostUniversityPayload, logoFile: File, backgroundFile: File) => {
+		const formData = new FormData();
+		formData.append("request", new Blob([JSON.stringify(data)], { type: "application/json" }));
+		formData.append("logoFile", logoFile);
+		formData.append("backgroundFile", backgroundFile);
+		return axiosInstance
+			.post<HostUniversityDetailResponse>("/admin/host-universities", formData)
+			.then((res) => res.data);
+	},
 
-	updateHostUniversity: (id: number, data: HostUniversityPayload) =>
-		axiosInstance.put<HostUniversityDetailResponse>(`/admin/host-universities/${id}`, data).then((res) => res.data),
+	updateHostUniversity: (
+		id: number,
+		data: HostUniversityPayload,
+		logoFile?: File | null,
+		backgroundFile?: File | null,
+	) => {
+		const formData = new FormData();
+		formData.append("request", new Blob([JSON.stringify(data)], { type: "application/json" }));
+		if (logoFile) formData.append("logoFile", logoFile);
+		if (backgroundFile) formData.append("backgroundFile", backgroundFile);
+		return axiosInstance
+			.put<HostUniversityDetailResponse>(`/admin/host-universities/${id}`, formData)
+			.then((res) => res.data);
+	},
 
 	deleteHostUniversity: (id: number) =>
 		axiosInstance.delete<void>(`/admin/host-universities/${id}`).then((res) => res.data),
-
-	uploadAdminUniversityLogo: (file: File, englishName: string) => {
-		const formData = new FormData();
-		formData.append("file", file);
-		formData.append("englishName", englishName);
-		return axiosInstance
-			.post<AdminUniversityImageUploadResponse>("/file/admin/university/logo", formData, {
-				headers: { "Content-Type": "multipart/form-data" },
-			})
-			.then((res) => res.data);
-	},
-
-	uploadAdminUniversityBackground: (file: File, englishName: string) => {
-		const formData = new FormData();
-		formData.append("file", file);
-		formData.append("englishName", englishName);
-		return axiosInstance
-			.post<AdminUniversityImageUploadResponse>("/file/admin/university/background", formData, {
-				headers: { "Content-Type": "multipart/form-data" },
-			})
-			.then((res) => res.data);
-	},
 
 	createUnivApplyInfo: (data: UnivApplyInfoCreatePayload) =>
 		axiosInstance.post<UnivApplyInfoManageResponse>("/admin/univ-apply-infos", data).then((res) => res.data),


### PR DESCRIPTION
## Summary

- 기존: 파일 선택 시 `/file/admin/university/logo`, `/file/admin/university/background` 엔드포인트로 즉시 업로드 후 URL을 form state에 저장
- 변경: 파일 선택 시 로컬 state에 보관 → 폼 submit 시 `multipart/form-data`로 request JSON + 파일을 함께 전송
- 백엔드 리팩토링(#782)에서 삭제된 파일 업로드 전용 엔드포인트 대신 대학 생성/수정 API에 통합된 새 방식 적용

### 주요 변경사항

- `admin.ts`: `HostUniversityPayload`에서 `logoImageUrl`, `backgroundImageUrl` 제거; `createHostUniversity`, `updateHostUniversity` 함수가 `multipart/form-data` 방식으로 변경; 구 업로드 전용 함수(`uploadAdminUniversityLogo`, `uploadAdminUniversityBackground`) 제거
- `HostUniversityTab.tsx`: 이미지 파일을 로컬 state로 보관 후 submit 시 전달; 파일 선택 시 `URL.createObjectURL()`로 즉시 미리보기 표시; create 모드에서 파일 미선택 시 에러 toast 표시
- 테스트 업데이트: 새로운 동작(즉시 업로드 없음, submit 시 파일 전달) 기준으로 재작성

## Test plan

- [ ] 호스트 대학교 생성: 파일 선택 시 미리보기 확인, submit 시 정상 생성 확인
- [ ] 호스트 대학교 수정: 기존 이미지 미리보기 표시, 신규 파일 선택 시 교체 확인
- [ ] create 모드에서 이미지 미선택 후 submit 시 에러 toast 표시 확인
- [ ] 단위 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)