### PR TITLE
fix: 모집 인원 미정 표시 처리

### DIFF
--- a/apps/university-web/src/apis/universities/api.ts
+++ b/apps/university-web/src/apis/universities/api.ts
@@ -31,7 +31,7 @@ export interface RecommendedUniversitiesResponseRecommendedUniversitiesItem {
   country: string;
   logoImageUrl: string;
   backgroundImageUrl: string;
-  studentCapacity: number;
+  studentCapacity: number | null;
   languageRequirements: RecommendedUniversitiesResponseRecommendedUniversitiesItemLanguageRequirementsItem[];
 }
 
@@ -52,7 +52,7 @@ export interface WishListResponseItem {
   country: string;
   logoImageUrl: string;
   backgroundImageUrl: string;
-  studentCapacity: number;
+  studentCapacity: number | null;
   languageRequirements: WishListResponseItemLanguageRequirementsItem[];
 }
 
@@ -91,7 +91,7 @@ export interface UniversityDetailResponse {
   logoImageUrl: string;
   backgroundImageUrl: string;
   detailsForLocal: string;
-  studentCapacity: number;
+  studentCapacity: number | null;
   tuitionFeeType: string;
   semesterAvailableForDispatch: string;
   languageRequirements: UniversityDetailResponseLanguageRequirementsItem[];
@@ -116,7 +116,7 @@ export interface SearchTextResponseUnivApplyInfoPreviewsItem {
   country: string;
   logoImageUrl: string;
   backgroundImageUrl: string;
-  studentCapacity: number;
+  studentCapacity: number | null;
   languageRequirements: SearchTextResponseUnivApplyInfoPreviewsItemLanguageRequirementsItem[];
   homeUniversityName?: HomeUniversityName;
 }
@@ -138,7 +138,7 @@ export interface SearchFilterResponseUnivApplyInfoPreviewsItem {
   country: string;
   logoImageUrl: string;
   backgroundImageUrl: string;
-  studentCapacity: number;
+  studentCapacity: number | null;
   languageRequirements: SearchFilterResponseUnivApplyInfoPreviewsItemLanguageRequirementsItem[];
 }
 

--- a/apps/university-web/src/app/university/[homeUniversity]/[id]/_ui/UniversityDetail/index.tsx
+++ b/apps/university-web/src/app/university/[homeUniversity]/[id]/_ui/UniversityDetail/index.tsx
@@ -14,6 +14,11 @@ interface UniversityDetailProps {
 }
 
 const UniversityDetail = ({ university, koreanName }: UniversityDetailProps) => {
+  const capacityLabel =
+    university.studentCapacity === null || university.studentCapacity === undefined
+      ? "모집 인원 미정"
+      : `모집 ${university.studentCapacity}명`;
+
   return (
     <div className="relative">
       <div className="absolute top-4 flex w-full justify-between gap-3 px-5">
@@ -39,7 +44,7 @@ const UniversityDetail = ({ university, koreanName }: UniversityDetailProps) => 
         <div className="mb-7 mt-10 flex justify-center divide-x">
           <span className="px-[30px] text-k-900 typo-sb-9">{}0회 파견</span>
           <span className="px-[30px] text-k-900 typo-sb-9">{university.country}</span>
-          <span className="px-[30px] text-k-900 typo-sb-9">모집 {university.studentCapacity}명</span>
+          <span className="px-[30px] text-k-900 typo-sb-9">{capacityLabel}</span>
         </div>
         <LanguageSection
           detailsForLanguage={university.detailsForLanguage}

--- a/apps/university-web/src/app/university/[homeUniversity]/[id]/page.tsx
+++ b/apps/university-web/src/app/university/[homeUniversity]/[id]/page.tsx
@@ -96,7 +96,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const imageUrl = resolveMetadataImageUrl(universityData.backgroundImageUrl);
 
   const countryExchangeKeyword = `${universityData.country} 교환학생`;
-  const description = `${convertedKoreanName}(${universityData.englishName}) ${countryExchangeKeyword} 프로그램. 모집인원 ${universityData.studentCapacity}명. ${homeUniversityInfo?.shortName || ""} 학생을 위한 교환학생 정보.`;
+  const capacityDescription =
+    universityData.studentCapacity === null || universityData.studentCapacity === undefined
+      ? "모집인원 미정"
+      : `모집인원 ${universityData.studentCapacity}명`;
+  const description = `${convertedKoreanName}(${universityData.englishName}) ${countryExchangeKeyword} 프로그램. ${capacityDescription}. ${homeUniversityInfo?.shortName || ""} 학생을 위한 교환학생 정보.`;
   const title = `${convertedKoreanName} - ${countryExchangeKeyword} 정보 | 솔리드커넥션`;
 
   return {

--- a/apps/university-web/src/components/ui/UniverSityCard/index.tsx
+++ b/apps/university-web/src/components/ui/UniverSityCard/index.tsx
@@ -14,6 +14,10 @@ type UniversityCardProps = {
 
 const UniversityCard = ({ university, showCapacity = true, linkPrefix = "/university" }: UniversityCardProps) => {
   const convertedKoreanName = university.koreanName;
+  const capacityLabel =
+    university.studentCapacity === null || university.studentCapacity === undefined
+      ? "모집 인원 미정"
+      : `모집 ${university.studentCapacity}명`;
 
   const mappedHomeUniversitySlug = getHomeUniversitySlugByName(university.homeUniversityName);
   const hasExplicitPrefix = linkPrefix !== "/university";
@@ -51,7 +55,7 @@ const UniversityCard = ({ university, showCapacity = true, linkPrefix = "/univer
                 <span className="text-k-500 typo-medium-4">
                   {university.country} | {university.region}
                 </span>
-                {showCapacity && <span className="text-primary typo-sb-11">모집 {university.studentCapacity}명</span>}
+                {showCapacity && <span className="text-primary typo-sb-11">{capacityLabel}</span>}
               </div>
               <div className="flex gap-4">
                 {university.languageRequirements.slice(0, 3).map((requirement) => {

--- a/apps/university-web/src/types/university.ts
+++ b/apps/university-web/src/types/university.ts
@@ -57,7 +57,7 @@ export interface University {
   backgroundImageUrl: string;
   detailsForLocal: string; // 지역 정보
 
-  studentCapacity: number;
+  studentCapacity: number | null;
   tuitionFeeType: string; // 등록금 납부 유형
   semesterAvailableForDispatch: string; // 파견 가능 학기
 
@@ -85,7 +85,7 @@ export interface ListUniversity {
   country: string;
   logoImageUrl: string;
   backgroundImageUrl: string;
-  studentCapacity: number;
+  studentCapacity: number | null;
   languageRequirements: LanguageRequirement[];
 }
 

--- a/apps/web/src/apis/universities/api.ts
+++ b/apps/web/src/apis/universities/api.ts
@@ -31,7 +31,7 @@ export interface RecommendedUniversitiesResponseRecommendedUniversitiesItem {
   country: string;
   logoImageUrl: string;
   backgroundImageUrl: string;
-  studentCapacity: number;
+  studentCapacity: number | null;
   languageRequirements: RecommendedUniversitiesResponseRecommendedUniversitiesItemLanguageRequirementsItem[];
 }
 
@@ -52,7 +52,7 @@ export interface WishListResponseItem {
   country: string;
   logoImageUrl: string;
   backgroundImageUrl: string;
-  studentCapacity: number;
+  studentCapacity: number | null;
   languageRequirements: WishListResponseItemLanguageRequirementsItem[];
 }
 
@@ -91,7 +91,7 @@ export interface UniversityDetailResponse {
   logoImageUrl: string;
   backgroundImageUrl: string;
   detailsForLocal: string;
-  studentCapacity: number;
+  studentCapacity: number | null;
   tuitionFeeType: string;
   semesterAvailableForDispatch: string;
   languageRequirements: UniversityDetailResponseLanguageRequirementsItem[];
@@ -116,7 +116,7 @@ export interface SearchTextResponseUnivApplyInfoPreviewsItem {
   country: string;
   logoImageUrl: string;
   backgroundImageUrl: string;
-  studentCapacity: number;
+  studentCapacity: number | null;
   languageRequirements: SearchTextResponseUnivApplyInfoPreviewsItemLanguageRequirementsItem[];
   homeUniversityName?: HomeUniversityName;
 }
@@ -138,7 +138,7 @@ export interface SearchFilterResponseUnivApplyInfoPreviewsItem {
   country: string;
   logoImageUrl: string;
   backgroundImageUrl: string;
-  studentCapacity: number;
+  studentCapacity: number | null;
   languageRequirements: SearchFilterResponseUnivApplyInfoPreviewsItemLanguageRequirementsItem[];
 }
 

--- a/apps/web/src/app/my/favorite/_ui/FavoriteContent/_hooks/useSortedUniversities.ts
+++ b/apps/web/src/app/my/favorite/_ui/FavoriteContent/_hooks/useSortedUniversities.ts
@@ -28,7 +28,9 @@ const useSortedUniversities = (): UseSortedUniversitiesReturn => {
     switch (sequence) {
       // '모집인원 순'일 경우 studentCapacity를 기준으로 내림차순 정렬
       case filterType.NUMBER_OF_RECRUIT:
-        return newWishUniversity.sort((a: University, b: University) => b.studentCapacity - a.studentCapacity);
+        return newWishUniversity.sort(
+          (a: University, b: University) => (b.studentCapacity ?? -1) - (a.studentCapacity ?? -1),
+        );
       default:
         return wishUniversity; // 원본 순서(최신순) 그대로 반환
     }

--- a/apps/web/src/components/ui/UniverSityCard/index.tsx
+++ b/apps/web/src/components/ui/UniverSityCard/index.tsx
@@ -14,6 +14,10 @@ type UniversityCardProps = {
 
 const UniversityCard = ({ university, showCapacity = true, linkPrefix = "/university" }: UniversityCardProps) => {
   const convertedKoreanName = university.koreanName;
+  const capacityLabel =
+    university.studentCapacity === null || university.studentCapacity === undefined
+      ? "모집 인원 미정"
+      : `모집 ${university.studentCapacity}명`;
 
   const mappedHomeUniversitySlug = getHomeUniversitySlugByName(university.homeUniversityName);
   const hasExplicitPrefix = linkPrefix !== "/university";
@@ -55,7 +59,7 @@ const UniversityCard = ({ university, showCapacity = true, linkPrefix = "/univer
                 <span className="text-k-500 typo-medium-4">
                   {university.country} | {university.region}
                 </span>
-                {showCapacity && <span className="text-primary typo-sb-11">모집 {university.studentCapacity}명</span>}
+                {showCapacity && <span className="text-primary typo-sb-11">{capacityLabel}</span>}
               </div>
               <div className="flex gap-4">
                 {university.languageRequirements.slice(0, 3).map((requirement) => {

--- a/apps/web/src/types/university.ts
+++ b/apps/web/src/types/university.ts
@@ -57,7 +57,7 @@ export interface University {
   backgroundImageUrl: string;
   detailsForLocal: string; // 지역 정보
 
-  studentCapacity: number;
+  studentCapacity: number | null;
   tuitionFeeType: string; // 등록금 납부 유형
   semesterAvailableForDispatch: string; // 파견 가능 학기
 
@@ -85,7 +85,7 @@ export interface ListUniversity {
   country: string;
   logoImageUrl: string;
   backgroundImageUrl: string;
-  studentCapacity: number;
+  studentCapacity: number | null;
   languageRequirements: LanguageRequirement[];
 }
 


### PR DESCRIPTION
## 관련 이슈

- 서버에서 지원 가능 대학의 `studentCapacity`가 nullable하게 응답될 수 있도록 변경되었습니다.
- 기존 프론트 타입은 `studentCapacity`를 항상 `number`로 가정하고 있어, 모집 인원이 없는 경우 UI에서 부정확하게 표시될 수 있었습니다.
- 경희대 2027-1 지원 가능 대학 데이터 중 모집 인원이 아직 미정인 학교가 있어, 프론트에서도 nullable 응답을 처리해야 합니다.

## 작업 내용

- 대학 목록/상세 응답 타입의 `studentCapacity`를 `number | null`로 변경했습니다.
- 모집 인원이 없는 경우 `모집 인원 미정`으로 표시되도록 처리했습니다.
- 모집 인원 기준 정렬 시 `null` 값은 뒤로 정렬되도록 처리했습니다.