### PR TITLE
feat: 대학 목록 가상화 적용

### DIFF
--- a/apps/university-web/src/components/university/UniversityCards/index.tsx
+++ b/apps/university-web/src/components/university/UniversityCards/index.tsx
@@ -1,9 +1,17 @@
 "use client";
 
+import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import clsx from "clsx";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { ListUniversity } from "@/types/university";
 import UniversityCard from "../../ui/UniverSityCard";
+
+const UNIVERSITY_CARD_HEIGHT = 91;
+const UNIVERSITY_CARD_BOTTOM_PADDING = 10;
+const UNIVERSITY_CARD_GAP = 10;
+const ESTIMATED_UNIVERSITY_CARD_ROW_HEIGHT = UNIVERSITY_CARD_HEIGHT + UNIVERSITY_CARD_BOTTOM_PADDING;
+const INITIAL_VIEWPORT_HEIGHT = 900;
 
 type UniversityCardsProps = {
   colleges: ListUniversity[];
@@ -14,13 +22,81 @@ type UniversityCardsProps = {
 };
 
 const UniversityCards = ({ colleges, style, className, showCapacity = true, linkPrefix }: UniversityCardsProps) => {
+  const listRef = useRef<HTMLDivElement>(null);
+  const [scrollMargin, setScrollMargin] = useState(0);
+
+  const measureScrollMargin = useCallback(() => {
+    if (!listRef.current) {
+      return;
+    }
+
+    setScrollMargin(listRef.current.getBoundingClientRect().top + window.scrollY);
+  }, []);
+
+  useEffect(() => {
+    measureScrollMargin();
+
+    const animationFrameId = window.requestAnimationFrame(measureScrollMargin);
+    window.addEventListener("resize", measureScrollMargin);
+
+    return () => {
+      window.cancelAnimationFrame(animationFrameId);
+      window.removeEventListener("resize", measureScrollMargin);
+    };
+  }, [measureScrollMargin]);
+
+  const getItemKey = useCallback((index: number) => colleges[index]?.id ?? index, [colleges]);
+
+  const virtualizer = useWindowVirtualizer({
+    count: colleges.length,
+    estimateSize: () => ESTIMATED_UNIVERSITY_CARD_ROW_HEIGHT,
+    gap: UNIVERSITY_CARD_GAP,
+    getItemKey,
+    overscan: 6,
+    scrollMargin,
+    initialRect: {
+      width: 0,
+      height: INITIAL_VIEWPORT_HEIGHT,
+    },
+    useFlushSync: false,
+  });
+
+  const virtualItems = virtualizer.getVirtualItems();
+
   return (
-    <div className={clsx("flex flex-col gap-2.5", className)} style={style}>
-      {colleges.map((college) => (
-        <div key={college.id} className="pb-2.5">
-          <UniversityCard university={college} showCapacity={showCapacity} linkPrefix={linkPrefix} />
-        </div>
-      ))}
+    <div
+      ref={listRef}
+      className={clsx("relative w-full", className)}
+      role="list"
+      style={{
+        ...style,
+        height: `${virtualizer.getTotalSize()}px`,
+      }}
+    >
+      {virtualItems.map((virtualItem) => {
+        const college = colleges[virtualItem.index];
+
+        if (!college) {
+          return null;
+        }
+
+        return (
+          <div
+            key={virtualItem.key}
+            ref={virtualizer.measureElement}
+            className="absolute left-0 top-0 w-full pb-2.5"
+            data-index={virtualItem.index}
+            role="listitem"
+            aria-posinset={virtualItem.index + 1}
+            aria-setsize={colleges.length}
+            style={{
+              transform: `translateY(${virtualItem.start - virtualizer.options.scrollMargin}px)`,
+            }}
+          >
+            <UniversityCard university={college} showCapacity={showCapacity} linkPrefix={linkPrefix} />
+          </div>
+        );
+      })}
     </div>
   );
 };


### PR DESCRIPTION
## 관련 이슈

- Closes #580

## 작업 내용

- `apps/university-web`의 대학 목록 카드 렌더링을 TanStack Virtual 기반 window virtualizer로 변경했습니다.
- 기존 문서 전체 스크롤 UX를 유지하기 위해 내부 스크롤 컨테이너를 만들지 않고 `useWindowVirtualizer`를 사용했습니다.
- 목록 위 검색/필터/카운트 영역을 고려해 `scrollMargin`을 측정하고, virtual row 위치 계산에 반영했습니다.
- `getItemKey`에 대학 id를 사용해 필터/검색 후에도 row key가 안정적으로 유지되도록 했습니다.
- virtual row에 `role="listitem"`, `aria-posinset`, `aria-setsize`를 부여해 가상화 이후에도 리스트 문맥을 보강했습니다.

## 성능 검증 요약

### PageSpeed Insights 실제 측정

- 측정 URL: `https://www.solid-connection.com/university/kyunghee`
- 환경: PageSpeed Insights 모바일
- 기준: PR 코멘트에 첨부한 before/after 스크린샷

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Performance score | 70 | 89 | +19 pt |
| First Contentful Paint | 1.1 s | 1.8 s | +0.7 s |
| Largest Contentful Paint | 4.7 s | 2.2 s | -2.5 s |
| Total Blocking Time | 400 ms | 150 ms | -250 ms |
| Cumulative Layout Shift | 0 | 0 | 유지 |
| Speed Index | 4.6 s | 7.0 s | +2.4 s |

주요 개선 지점은 LCP와 TBT입니다. 긴 대학 목록에서 초기 렌더링해야 하는 카드, 이미지, DOM 수가 줄면서 메인 스레드 점유와 큰 콘텐츠 렌더링 시간이 함께 개선됐습니다. FCP와 Speed Index는 PageSpeed 기준으로 악화되어 보이지만, 전체 성능 점수는 70에서 89로 개선됐습니다.

### 로컬 상세 측정

- 비교: `HEAD^`(가상화 전) vs `HEAD`(가상화 적용)
- URL: `http://localhost:{3101,3102}/university/inha`
- 빌드: `UNIVERSITY_TERM_ID=1 NEXT_PUBLIC_UNIVERSITY_TERM_ID=1 pnpm --filter @solid-connect/university-web run build` 후 `next start`

| Metric | Before | After | Change |
|---|---:|---:|---:|
| DOM elements | 2,604 | 346 | -86.7% |
| 초기 카드 링크 | 136 | 13 | -90.4% |
| Image requests | 19 | 6 | -68.4% |
| Image transfer | 399 KiB | 58 KiB | -85.5% |
| HTML document | 23 KiB | 16 KiB | -30.4% |
| Script transfer | 623 KiB | 627 KiB | +4 KiB |
| Long task total (throttled) | 584 ms | 389 ms | -33.4% |

TanStack Virtual 추가로 JS가 약간 늘었지만, 전송량 기준 증가는 약 4KiB 수준입니다. 반면 이미지 요청/전송량, DOM 수, 초기 카드 렌더링 수는 크게 줄었습니다.

### FCP/LCP 해석

Lighthouse 기본 `simulate` 값에서는 FCP/Speed Index가 악화된 것처럼 보였지만, 실제 trace 기반 `provided` 모드와 Chrome PerformanceObserver 직접 측정에서는 FCP/LCP가 악화되지 않았습니다.

| 측정 방식 | Metric | Before | After |
|---|---|---:|---:|
| Lighthouse provided | FCP | 187 ms | 146 ms |
| Lighthouse provided | LCP | 187 ms | 146 ms |
| 직접 브라우저 측정 | FCP | 156 ms | 136 ms |
| 직접 브라우저 측정 | LCP | 160 ms | 144 ms |
| 실제 throttling 적용 | FCP | 844 ms | 836 ms |
| 실제 throttling 적용 | LCP | 844 ms | 836 ms |

Lighthouse simulate에서 13초대 LCP가 나온 원인은 리스트 이미지가 아니라, 약 2MB인 `PretendardVariable.woff2`가 preload되어 모바일 throttling 모델에서 크게 잡힌 영향으로 확인했습니다. 폰트를 차단하면 simulate LCP도 13초대에서 1.5~2.4초대로 내려갑니다.

## 결론

- 이번 PR은 대학 목록의 긴 리스트 렌더링 병목을 줄이는 데 효과가 있습니다.
- 실제 PageSpeed 모바일 기준 성능 점수는 70 → 89로 개선됐고, LCP/TBT가 크게 줄었습니다.
- DOM, 이미지 요청 수, 이미지 전송량, long task도 모두 감소했습니다.
- FCP/Speed Index는 일부 측정에서 악화되어 보여 후속 개선 여지가 있습니다. 이 부분은 가상화보다 폰트 preload/서브셋/above-the-fold 렌더링 전략이 더 직접적인 후보입니다.

## 특이 사항

- API, SSG 정책, 검색 파라미터 계약은 변경하지 않았습니다.
- `apps/web` 홈 화면의 대학 preview 리스트는 이번 범위가 아니어서 수정하지 않았습니다.
- 로컬 Node 버전이 v23.10.0이라 `node: 22.x` engine 경고가 출력됩니다.
- 브라우저 검증 중 `UNIVERSITY_TERM_ID=1 NEXT_PUBLIC_UNIVERSITY_TERM_ID=1`은 stage dev API 학기 확인용으로만 사용했습니다.

## 검증

- `pnpm --filter @solid-connect/university-web run ci:check` 통과
- `pnpm --filter @solid-connect/university-web run build` 통과
- pre-commit, pre-push CI parity checks 통과
- 브라우저 확인
  - `http://localhost:3001/university/inha`
  - 초기: 총 151개 학교 중 DOM `listitem` 11개 렌더 확인
  - 깊은 스크롤: 렌더 구간이 42~60번째로 갱신되고 DOM `listitem` 19개 렌더 확인
  - 권역 필터: 유럽권 총 82개 중 DOM `listitem` 11개 렌더 확인
  - 검색 결과 0개 상태: empty state 유지 및 DOM `listitem` 0개 확인
  - 가로 overflow 없음 확인

## 리뷰 요구사항 (선택)

- window virtualizer의 `scrollMargin` 측정과 row transform 계산이 기존 페이지 스크롤 UX와 잘 맞는지 봐주세요.
- 카드 간격이 기존 `UniversityCards`의 spacing과 충분히 동일하게 유지되는지 봐주세요.