### PR TITLE
fix: 커뮤니티 상세 기본 프로필 이미지 통일

### DIFF
--- a/apps/web/src/app/community/[boardCode]/[postId]/CommentSection.tsx
+++ b/apps/web/src/app/community/[boardCode]/[postId]/CommentSection.tsx
@@ -5,12 +5,10 @@ import { useMemo, useState } from "react";
 import { useDeleteComment } from "@/apis/community";
 import useBlockCommunityUser from "@/app/community/_hooks/useBlockCommunityUser";
 import Dropdown from "@/components/ui/Dropdown";
-import Image from "@/components/ui/FallbackImage";
-import { DEFAULT_PROFILE_IMAGE } from "@/constants/profile";
+import ProfileWithBadge from "@/components/ui/ProfileWithBadge";
 import useReportedPostsStore from "@/lib/zustand/useReportedPostsStore";
 import { IconMoreVertFilled, IconSubComment } from "@/public/svgs";
 import type { Comment as CommentType, CommunityUser } from "@/types/community";
-import { normalizeImageUrlToUploadCdn } from "@/utils/cdnUrl";
 import { convertISODateToDateTime } from "@/utils/datetimeUtils";
 import CommentInput from "./CommentInput";
 
@@ -152,15 +150,7 @@ const Comment = ({
 const CommentProfile = ({ user }: { user: CommunityUser }) => {
   return (
     <div className="flex items-center gap-2">
-      <div className="h-[25px] w-[25px] rounded-full bg-bg-600">
-        <Image
-          className="h-full w-full rounded-full"
-          src={user?.profileImageUrl ? normalizeImageUrlToUploadCdn(user?.profileImageUrl) : DEFAULT_PROFILE_IMAGE}
-          width={40}
-          height={40}
-          alt="alt"
-        />
-      </div>
+      <ProfileWithBadge profileImageUrl={user?.profileImageUrl} width={25} height={25} />
       <div className="overflow-hidden text-black typo-medium-2">{user?.nickname}</div>
     </div>
   );

--- a/apps/web/src/app/community/[boardCode]/[postId]/Content.tsx
+++ b/apps/web/src/app/community/[boardCode]/[postId]/Content.tsx
@@ -3,8 +3,8 @@ import { useEffect, useState } from "react";
 import { useDeleteLike, usePostLike } from "@/apis/community";
 import Image from "@/components/ui/FallbackImage";
 import LinkifyText from "@/components/ui/LinkifyText";
+import ProfileWithBadge from "@/components/ui/ProfileWithBadge";
 import { COMMUNITY_MAX_UPLOAD_IMAGES } from "@/constants/community";
-import { DEFAULT_PROFILE_IMAGE } from "@/constants/profile";
 import { showIconToast } from "@/lib/toast/showIconToast";
 import { IconCloseFilled, IconPostLikeFilled, IconPostLikeOutline } from "@/public/svgs";
 import { IconCommunication } from "@/public/svgs/community";
@@ -115,19 +115,7 @@ const Content = ({ post, postId }: ContentProps) => {
 
       <div className="flex h-16 items-center justify-between border-y border-gray-c-100 px-5 py-3">
         <div className="flex gap-2.5">
-          <div className="h-10 w-10 rounded-full bg-bg-600">
-            <Image
-              className="h-full w-full rounded-full object-cover"
-              src={
-                post.postFindSiteUserResponse.profileImageUrl
-                  ? normalizeImageUrlToUploadCdn(post.postFindSiteUserResponse.profileImageUrl)
-                  : DEFAULT_PROFILE_IMAGE
-              }
-              width={40}
-              height={40}
-              alt=""
-            />
-          </div>
+          <ProfileWithBadge profileImageUrl={post.postFindSiteUserResponse.profileImageUrl} width={40} height={40} />
           <div className="flex flex-col">
             <div className="overflow-hidden text-ellipsis font-serif text-black typo-medium-2">
               {post.postFindSiteUserResponse.nickname || ""}


### PR DESCRIPTION
## 관련 이슈

- 없음

## 작업 내용

- 커뮤니티 상세 게시글 작성자 프로필을 공용 `ProfileWithBadge`로 렌더링하도록 변경했습니다.
- 커뮤니티 상세 댓글 작성자 프로필도 동일한 공용 컴포넌트를 사용하도록 맞췄습니다.
- 기본 프로필 이미지와 이미지 로드 실패 fallback 처리가 앱 공통 프로필 UI와 동일하게 동작하도록 정리했습니다.

## 특이 사항

- 현재 작업 브랜치의 다른 수정은 포함하지 않고, 커뮤니티 상세 프로필 이미지 관련 2개 파일만 별도 브랜치에 담았습니다.
- 로컬 검증 중 Node 엔진 경고가 표시되었습니다. 현재 로컬은 Node v23.10.0이고, 프로젝트 요구 버전은 Node 22.x입니다.

## 리뷰 요구사항 (선택)

- 커뮤니티 상세 게시글 작성자/댓글 작성자의 기본 프로필 이미지가 다른 화면과 동일하게 보이는지 확인 부탁드립니다.
