### PR TITLE
fix: 학교 인증 후 지원하기 복귀 처리

### DIFF
--- a/apps/web/src/app/my/school-email/_ui/SchoolEmailVerificationContent/index.tsx
+++ b/apps/web/src/app/my/school-email/_ui/SchoolEmailVerificationContent/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { useGetMyInfo, usePostConfirmSchoolEmail, usePostSchoolEmail } from "@/apis/MyPage";
 import BlockBtn from "@/components/button/BlockBtn";
@@ -25,6 +25,7 @@ const formatTime = (seconds: number) => {
 
 const SchoolEmailVerificationContent = () => {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { data: myInfo } = useGetMyInfo();
   const postSchoolEmailMutation = usePostSchoolEmail();
   const postConfirmSchoolEmailMutation = usePostConfirmSchoolEmail();
@@ -42,6 +43,7 @@ const SchoolEmailVerificationContent = () => {
   const isCodeInputValid = code.length === CODE_LENGTH;
   const isTimerExpired = remainingSeconds <= 0;
   const progressValue = step === "email" ? 0 : step === "code" ? 50 : 100;
+  const shouldReturnToApply = searchParams?.get("returnTo") === "applicationApply";
 
   useEffect(() => {
     if (step !== "code" || remainingSeconds <= 0) return;
@@ -132,7 +134,9 @@ const SchoolEmailVerificationContent = () => {
 
         <div className="fixed bottom-14 left-0 right-0 w-full bg-white">
           <div className="mx-auto mb-[37px] w-full max-w-app px-5">
-            <BlockBtn onClick={() => router.replace("/")}>홈으로</BlockBtn>
+            <BlockBtn onClick={() => router.replace(shouldReturnToApply ? "/university/application/apply" : "/")}>
+              {shouldReturnToApply ? "지원하기로 돌아가기" : "홈으로"}
+            </BlockBtn>
           </div>
         </div>
       </div>

--- a/apps/web/src/app/my/school-email/page.tsx
+++ b/apps/web/src/app/my/school-email/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 
 import TopDetailNavigation from "@/components/layout/TopDetailNavigation";
+import CloudSpinnerPage from "@/components/ui/CloudSpinnerPage";
 import { NO_INDEX_ROBOTS } from "@/utils/seo";
 
 import SchoolEmailVerificationContent from "./_ui/SchoolEmailVerificationContent";
@@ -14,7 +16,9 @@ const SchoolEmailVerificationPage = () => {
   return (
     <>
       <TopDetailNavigation title="학교 인증하기" />
-      <SchoolEmailVerificationContent />
+      <Suspense fallback={<CloudSpinnerPage />}>
+        <SchoolEmailVerificationContent />
+      </Suspense>
     </>
   );
 };

--- a/apps/web/src/app/university/application/apply/ApplyPageContent.tsx
+++ b/apps/web/src/app/university/application/apply/ApplyPageContent.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { usePostSubmitApplication } from "@/apis/applications";
 import { useGetMyGpaScore, useGetMyLanguageTestScore } from "@/apis/Scores";
 import { useUniversitySearch } from "@/apis/universities";
@@ -23,6 +23,8 @@ const APPLY_PROGRESS_TOTAL_STEPS = 5;
 const ApplyPageContent = () => {
   const router = useRouter();
   const homeUniversityId = useAuthStore((state) => state.homeUniversityId);
+  const isAuthInitialized = useAuthStore((state) => state.isInitialized);
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const [step, setStep] = useState<number>(1);
   const maxChoiceCount = getHomeUniversityById(homeUniversityId)?.maxChoiceCount ?? DEFAULT_MAX_CHOICE_COUNT;
   const universitySearchOptions = useMemo(
@@ -45,6 +47,14 @@ const ApplyPageContent = () => {
   const [curLanguageTestScore, setCurLanguageTestScore] = useState<number | null>(null);
   const [curGpaScore, setCurGpaScore] = useState<number | null>(null);
   const [curUniversityList, setCurUniversityList] = useState<number[]>([]);
+
+  useEffect(() => {
+    if (!isAuthInitialized || !isAuthenticated || homeUniversityId !== null) {
+      return;
+    }
+
+    router.replace("/my/school-email?returnTo=applicationApply");
+  }, [homeUniversityId, isAuthInitialized, isAuthenticated, router]);
 
   // 다음 스텝으로 넘어가기
   const goNextStep = () => setStep((prev) => prev + 1);
@@ -88,6 +98,10 @@ const ApplyPageContent = () => {
   const isDataExist = gpaScoreList.length === 0 || languageTestScoreList.length === 0;
   const hasSelectedUniversity = curUniversityList.some((universityId) => universityId > 0);
   const progressStep = step === 3 && hasSelectedUniversity ? APPLY_PROGRESS_TOTAL_STEPS : step + 1;
+
+  if (isAuthInitialized && isAuthenticated && homeUniversityId === null) {
+    return null;
+  }
 
   return (
     <>


### PR DESCRIPTION
## 관련 이슈
학교 미인증자 지원 시 학교 인증으로 redirect

## 작업 내용
- 지원하기 페이지 진입 시 로그인된 사용자에게 학교 정보(`homeUniversityId`)가 없으면 학교 인증 페이지로 이동하도록 처리했습니다.
- 학교 인증 페이지에 `returnTo=applicationApply` 의도 기반 파라미터를 추가해, 인증 완료 후 지원하기 페이지로 복귀할 수 있도록 했습니다.
- `useSearchParams` 사용에 맞춰 학교 인증 페이지 콘텐츠를 `Suspense`로 감쌌습니다.