### PR TITLE
fix(web): 마이페이지 비로그인 뒤로가기 노출 방지

### DIFF
--- a/apps/web/src/apis/MyPage/getProfile.ts
+++ b/apps/web/src/apis/MyPage/getProfile.ts
@@ -7,10 +7,15 @@ type UseGetMyInfoResult = Omit<UseQueryResult<MyInfoResponse, AxiosError>, "data
   data: MyInfoResponse | undefined;
 };
 
-const useGetMyInfo = (): UseGetMyInfoResult => {
+type UseGetMyInfoParams = {
+  enabled?: boolean;
+};
+
+const useGetMyInfo = ({ enabled = true }: UseGetMyInfoParams = {}): UseGetMyInfoResult => {
   const queryResult = useQuery<MyInfoResponse, AxiosError>({
     queryKey: [QueryKeys.MyPage.profile],
     queryFn: () => myPageApi.getProfile(),
+    enabled,
     // staleTime을 무한으로 설정하여 불필요한 자동 refetch를 방지합니다.
     staleTime: Infinity,
     gcTime: 1000 * 60 * 30, // 예: 30분

--- a/apps/web/src/app/my/_ui/MyProfileContent/index.tsx
+++ b/apps/web/src/app/my/_ui/MyProfileContent/index.tsx
@@ -30,7 +30,7 @@ const MyProfileContent = () => {
   const isInitialized = useAuthStore((state) => state.isInitialized);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const shouldFetchProfile = isInitialized && isAuthenticated;
-  const { data: profileData, isLoading, isFetching } = useGetMyInfo({ enabled: shouldFetchProfile });
+  const { data: profileData, isLoading, isFetching, isError, refetch } = useGetMyInfo({ enabled: shouldFetchProfile });
   const { mutate: deleteUserAccount } = useDeleteUserAccount();
   const { mutate: postLogout } = usePostLogout();
   const clientRole = useAuthStore((state) => state.clientRole);
@@ -40,6 +40,21 @@ const MyProfileContent = () => {
 
     router.replace("/login");
   }, [isInitialized, isAuthenticated, router]);
+
+  if (isError) {
+    return (
+      <div className="flex min-h-[40vh] flex-col items-center justify-center gap-3 px-4 text-center">
+        <p className="text-k-700 typo-medium-2">마이페이지 정보를 불러오지 못했어요.</p>
+        <button
+          type="button"
+          onClick={() => refetch()}
+          className="rounded-full bg-primary px-4 py-2 text-white typo-medium-2"
+        >
+          다시 시도
+        </button>
+      </div>
+    );
+  }
 
   if (!shouldFetchProfile || isLoading || (isFetching && !profileData) || !profileData) {
     return <CloudSpinnerPage />;

--- a/apps/web/src/app/my/_ui/MyProfileContent/index.tsx
+++ b/apps/web/src/app/my/_ui/MyProfileContent/index.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 import { useDeleteUserAccount, usePostLogout } from "@/apis/Auth";
-import { type MyInfoResponse, useGetMyInfo } from "@/apis/MyPage";
+import { useGetMyInfo } from "@/apis/MyPage";
+import CloudSpinnerPage from "@/components/ui/CloudSpinnerPage";
 import LinkedTextWithIcon from "@/components/ui/LinkedTextWithIcon";
 import ProfileWithBadge from "@/components/ui/ProfileWithBadge";
 import { showIconToast } from "@/lib/toast/showIconToast";
@@ -23,10 +26,24 @@ import { openKakaoOpenChat } from "@/utils/openKakaoOpenChat";
 const NEXT_PUBLIC_CONTACT_LINK = process.env.NEXT_PUBLIC_CONTACT_LINK;
 
 const MyProfileContent = () => {
-  const { data: profileData = {} as MyInfoResponse } = useGetMyInfo();
+  const router = useRouter();
+  const isInitialized = useAuthStore((state) => state.isInitialized);
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const shouldFetchProfile = isInitialized && isAuthenticated;
+  const { data: profileData, isLoading, isFetching } = useGetMyInfo({ enabled: shouldFetchProfile });
   const { mutate: deleteUserAccount } = useDeleteUserAccount();
   const { mutate: postLogout } = usePostLogout();
   const clientRole = useAuthStore((state) => state.clientRole);
+
+  useEffect(() => {
+    if (!isInitialized || isAuthenticated) return;
+
+    router.replace("/login");
+  }, [isInitialized, isAuthenticated, router]);
+
+  if (!shouldFetchProfile || isLoading || (isFetching && !profileData) || !profileData) {
+    return <CloudSpinnerPage />;
+  }
 
   const { nickname, email, profileImageUrl } = profileData;
   const isMentor = profileData.role === UserRole.MENTOR || profileData.role === UserRole.ADMIN;

--- a/apps/web/src/utils/axiosInstance.ts
+++ b/apps/web/src/utils/axiosInstance.ts
@@ -1,5 +1,7 @@
 import axios, { type AxiosError, type AxiosInstance } from "axios";
 import { postReissueToken } from "@/apis/Auth/server";
+import { QueryKeys } from "@/apis/queryKeys";
+import queryClient from "@/lib/react-query/queryClient";
 import { showIconToast } from "@/lib/toast/showIconToast";
 import useAuthStore from "@/lib/zustand/useAuthStore";
 import { isTokenExpired } from "@/utils/jwtUtils";
@@ -18,17 +20,22 @@ export class AuthenticationRequiredError extends Error {
 // --- 상태 관리 변수 ---
 let isRedirecting = false;
 
+const clearAuthState = () => {
+  useAuthStore.getState().clearAccessToken();
+  queryClient.removeQueries({ queryKey: [QueryKeys.MyPage.profile] });
+};
+
 // --- 유틸리티 함수 ---
 const redirectToLogin = (message: string) => {
   if (typeof window !== "undefined" && !isRedirecting) {
     isRedirecting = true;
     // Zustand 스토어 및 쿠키 상태 초기화
-    useAuthStore.getState().clearAccessToken();
+    clearAuthState();
     try {
       // 쿠키 유틸이 클라이언트에서만 동작하므로 window 가드 내에서 호출
     } catch {}
     showIconToast("logo", message);
-    window.location.href = "/login";
+    window.location.replace("/login");
   }
 };
 
@@ -40,7 +47,7 @@ const tryReissueAccessToken = async (): Promise<string | null> => {
     return useAuthStore.getState().accessToken;
   }
 
-  const { setLoading, clearAccessToken, setInitialized, setRefreshStatus } = useAuthStore.getState();
+  const { setLoading, setInitialized, setRefreshStatus } = useAuthStore.getState();
 
   reissuePromise = (async () => {
     setRefreshStatus("refreshing");
@@ -49,7 +56,7 @@ const tryReissueAccessToken = async (): Promise<string | null> => {
       await postReissueToken();
       setRefreshStatus("success");
     } catch {
-      clearAccessToken();
+      clearAuthState();
       setRefreshStatus("failed");
     } finally {
       setLoading(false);


### PR DESCRIPTION
## 작업 내용

- 비로그인 상태에서 마이페이지(`/my`) 진입 시 프로필 화면이 먼저 렌더링되지 않도록 인증 상태 가드를 추가했습니다.
- 인증 초기화가 완료되고 로그인 상태가 확인된 경우에만 마이페이지 프로필 API를 호출하도록 `useGetMyInfo`에 `enabled` 옵션을 추가했습니다.
- 인증 실패 또는 토큰 재발급 실패 시 마이페이지 프로필 캐시를 제거하도록 처리했습니다.
- 로그인 페이지 이동 시 브라우저 히스토리에 보호 페이지가 남지 않도록 `window.location.replace("/login")`를 사용하도록 변경했습니다.

## 특이 사항

- 기존에는 `/my` 진입 후 프로필 API 요청 실패 시 axios 인터셉터에서 로그인 페이지로 이동하는 구조라, 뒤로가기 시 마이페이지가 다시 노출될 수 있었습니다.
- 이번 변경으로 비로그인 상태에서는 마이페이지 콘텐츠 렌더링과 프로필 API 호출을 모두 막습니다.