### PR TITLE
fix: 프로필 수정 출신학교 표시값 수정

### DIFF
--- a/apps/web/src/app/my/modify/_ui/ModifyContent/_hooks/useModifyUserHookform.ts
+++ b/apps/web/src/app/my/modify/_ui/ModifyContent/_hooks/useModifyUserHookform.ts
@@ -14,7 +14,7 @@ type ProfileFormData = z.infer<typeof profileSchema>;
 
 interface UseModifyUserHookformReturn {
   methods: ReturnType<typeof useForm<ProfileFormData>>;
-  myInfo?: Partial<MyInfoResponse>;
+  myInfo?: MyInfoResponse;
   onSubmit: (data: ProfileFormData) => void;
 }
 

--- a/apps/web/src/app/my/modify/_ui/ModifyContent/_lib/profileFields.ts
+++ b/apps/web/src/app/my/modify/_ui/ModifyContent/_lib/profileFields.ts
@@ -1,0 +1,15 @@
+import type { MyInfoResponse } from "@/apis/MyPage";
+
+export interface ModifyProfileReadOnlyFields {
+  homeUniversityName: string;
+  attendedUniversity: string;
+}
+
+export const resolveModifyProfileReadOnlyFields = (myInfo: MyInfoResponse): ModifyProfileReadOnlyFields => {
+  const isMentorProfile = myInfo.role === "MENTOR" || myInfo.role === "ADMIN";
+
+  return {
+    homeUniversityName: myInfo.homeUniversityName ?? "",
+    attendedUniversity: isMentorProfile ? myInfo.attendedUniversity : "",
+  };
+};

--- a/apps/web/src/app/my/modify/_ui/ModifyContent/index.tsx
+++ b/apps/web/src/app/my/modify/_ui/ModifyContent/index.tsx
@@ -6,17 +6,13 @@ import { FormProvider } from "react-hook-form";
 import CloudSpinnerPage from "@/components/ui/CloudSpinnerPage";
 import { UserRole } from "@/types/mentor";
 import useModifyUserHookform from "./_hooks/useModifyUserHookform";
+import { resolveModifyProfileReadOnlyFields } from "./_lib/profileFields";
 import ImageInputFiled from "./_ui/ImageInputFiled";
 import InputField from "./_ui/InputFiled";
 import ReadOnlyField from "./_ui/ReadOnlyField";
 
 const ModifyContent = () => {
   const { methods, myInfo, onSubmit } = useModifyUserHookform();
-
-  const defaultUniversity: string =
-    (myInfo?.role === UserRole.MENTOR || myInfo?.role === UserRole.ADMIN) && myInfo.attendedUniversity
-      ? myInfo.attendedUniversity
-      : "인하대학교";
 
   const {
     handleSubmit,
@@ -26,6 +22,9 @@ const ModifyContent = () => {
   if (!myInfo) {
     return <CloudSpinnerPage />;
   }
+
+  const { homeUniversityName, attendedUniversity } = resolveModifyProfileReadOnlyFields(myInfo);
+
   return (
     <FormProvider {...methods}>
       <div className="px-5 py-6">
@@ -39,10 +38,10 @@ const ModifyContent = () => {
             <InputField name="nickname" label="닉네임" placeholder="닉네임을 입력해주세요" />
 
             {/* 출신학교 - 읽기 전용 */}
-            <ReadOnlyField label="출신학교" value={defaultUniversity} placeholder="서울대학교" />
+            <ReadOnlyField label="출신학교" value={homeUniversityName} placeholder="등록된 출신학교가 없습니다" />
 
             {/* 수학 학교 - 읽기 전용 */}
-            <ReadOnlyField label="수학 학교" value="컴퓨터공학과" placeholder="전공" />
+            <ReadOnlyField label="수학 학교" value={attendedUniversity} placeholder="등록된 수학 학교가 없습니다" />
 
             {/* 사용자 유형 - 읽기 전용 */}
             <ReadOnlyField

--- a/apps/web/src/types/myInfo.ts
+++ b/apps/web/src/types/myInfo.ts
@@ -11,7 +11,7 @@ export interface BaseUserInfo {
   email: string;
   likedPostCount: number;
   likedMentorCount: number;
-  homeUniversityName: string | null;
+  homeUniversityName?: string | null;
 }
 
 export interface MyInfo {


### PR DESCRIPTION
## 관련 이슈

- 없음

## 작업 내용

- 마이페이지 프로필 수정 화면의 출신학교 표시값에서 `인하대학교` 하드코딩 fallback을 제거했습니다.
- `/my` 프로필 응답의 `homeUniversityName`을 출신학교로 표시하도록 변경했습니다.
- 학교 인증 전처럼 `homeUniversityName`이 `null`이거나 누락된 경우 `등록된 출신학교가 없습니다`로 표시되도록 처리했습니다.
- 멘토/어드민의 수학 학교는 `attendedUniversity`를 사용하도록 하드코딩 값을 제거했습니다.

## 특이 사항

- 브루노의 `/my` 응답 예시에는 `homeUniversityName`이 누락되어 있어, 프론트 타입을 `homeUniversityName?: string | null`로 맞췄습니다.

## 리뷰 요구사항 (선택)

- 프로필 수정 화면에서 학교 인증 완료/미완료 사용자 표시 문구가 의도와 맞는지 확인 부탁드립니다.

## 검증

- `pnpm --filter @solid-connect/web lint:check`
- `pnpm --filter @solid-connect/web typecheck:ci`
- `pnpm --filter @solid-connect/web build`
- 표시값 분기 수동 검증: 학교 있음, `null`, 필드 누락, 멘토 케이스 확인
