### PR TITLE
fix: 대학 상세 어학 로고 경로 수정

### DIFF
--- a/apps/university-web/next.config.mjs
+++ b/apps/university-web/next.config.mjs
@@ -63,6 +63,14 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
+  async rewrites() {
+    return [
+      {
+        source: "/university-static/images/language/:path*",
+        destination: "/images/language/:path*",
+      },
+    ];
+  },
   ...(shouldRunBundleAnalyzer
     ? {
         webpack: (config) => {

--- a/apps/university-web/src/utils/languageUtils.ts
+++ b/apps/university-web/src/utils/languageUtils.ts
@@ -1,27 +1,47 @@
-export const DEFAULT_LANGUAGE_TEST_LOGO_SRC = "/images/language/default.png";
+const LANGUAGE_TEST_LOGO_BASE_PATH = "/university-static/images/language";
+
+export const DEFAULT_LANGUAGE_TEST_LOGO_SRC = `${LANGUAGE_TEST_LOGO_BASE_PATH}/default.png`;
 
 export const logoMap = {
-  TOEIC: "/images/language/toeic.png",
-  TOEFL_IBT: "/images/language/toefl_ibt.png",
-  TOEFL_ITP: "/images/language/toefl_itp.png",
-  IELTS: "/images/language/ielts.png",
-  JLPT: "/images/language/jlpt.png",
-  NEW_HSK: "/images/language/new_hsk.png",
-  ETC: "/images/language/etc.png",
-  DALF: "/images/language/dalf.png",
-  DELF: "/images/language/delf.jpg",
-  CEFR: "/images/language/cefr.png",
-  TCF: "/images/language/tcf.png",
-  TEF: "/images/language/tef.png",
-  DUOLINGO: "/images/language/duolingo.svg",
+  TOEIC: `${LANGUAGE_TEST_LOGO_BASE_PATH}/toeic.png`,
+  TOEFL_IBT: `${LANGUAGE_TEST_LOGO_BASE_PATH}/toefl_ibt.png`,
+  TOEFL_ITP: `${LANGUAGE_TEST_LOGO_BASE_PATH}/toefl_itp.png`,
+  IELTS: `${LANGUAGE_TEST_LOGO_BASE_PATH}/ielts.png`,
+  JLPT: `${LANGUAGE_TEST_LOGO_BASE_PATH}/jlpt.png`,
+  NEW_HSK: `${LANGUAGE_TEST_LOGO_BASE_PATH}/new_hsk.png`,
+  ETC: `${LANGUAGE_TEST_LOGO_BASE_PATH}/etc.png`,
+  DALF: `${LANGUAGE_TEST_LOGO_BASE_PATH}/dalf.png`,
+  DELF: `${LANGUAGE_TEST_LOGO_BASE_PATH}/delf.jpg`,
+  CEFR: `${LANGUAGE_TEST_LOGO_BASE_PATH}/cefr.png`,
+  TCF: `${LANGUAGE_TEST_LOGO_BASE_PATH}/tcf.png`,
+  TEF: `${LANGUAGE_TEST_LOGO_BASE_PATH}/tef.png`,
+  DUOLINGO: `${LANGUAGE_TEST_LOGO_BASE_PATH}/duolingo.svg`,
 } as const;
 
 type LanguageTestLogoType = keyof typeof logoMap;
 
+const languageTestLogoAliases: Record<string, LanguageTestLogoType> = {
+  HSK: "NEW_HSK",
+  DUOLINGO_ENGLISH_TEST: "DUOLINGO",
+};
+
+const normalizeLanguageTestLogoType = (type: string): LanguageTestLogoType | undefined => {
+  const normalizedType = type
+    .trim()
+    .toUpperCase()
+    .replace(/[./]/g, "")
+    .replace(/[\s-]+/g, "_");
+  const logoType = languageTestLogoAliases[normalizedType] ?? normalizedType;
+
+  return logoType in logoMap ? (logoType as LanguageTestLogoType) : undefined;
+};
+
 export const getLanguageTestLogo = (type: string): string => {
-  return type in logoMap ? logoMap[type as LanguageTestLogoType] : DEFAULT_LANGUAGE_TEST_LOGO_SRC;
+  const logoType = normalizeLanguageTestLogoType(type);
+
+  return logoType ? logoMap[logoType] : DEFAULT_LANGUAGE_TEST_LOGO_SRC;
 };
 
 export const formatLanguageTestName = (type: string): string => {
-  return type.replace(/_/g, " ");
+  return type.trim().replace(/_/g, " ");
 };


### PR DESCRIPTION
## 관련 이슈

- 없음

## 작업 내용

- university-web의 어학 로고 이미지 경로를 `/university-static/images/language/*`로 변경했습니다.
- web public이나 공통 public으로 복제하지 않고, university-web public asset을 university-web rewrites로 노출하도록 정리했습니다.
- 어학 시험 타입 lookup 전에 공백, 대소문자, `.`/`/`, 공백/하이픈 구분자를 정규화하도록 보강했습니다.
- `HSK`, `DUOLINGO_ENGLISH_TEST`처럼 API 값과 로고 파일명이 다른 케이스를 alias로 매핑했습니다.

## 특이 사항

- 이 PR은 #576에 잘못 포함됐던 어학 로고 경로 수정만 별도 분리한 PR입니다.
- 로컬 Node 버전은 v23.10.0이라 repository engines의 Node 22.x 경고가 출력됩니다.

## 검증

- `pnpm --filter @solid-connect/university-web lint:check` 통과
- `pnpm --filter @solid-connect/university-web typecheck:ci` 통과
- `pnpm --filter @solid-connect/university-web build` 통과, 205개 정적 페이지 생성 확인
- `pnpm --filter @solid-connect/web lint:check` 통과
- `pnpm --filter @solid-connect/web typecheck:ci` 통과
- `UNIVERSITY_WEB_DOMAIN=http://localhost:3001 pnpm --filter @solid-connect/web build` 통과
- `node --experimental-strip-types --input-type=module`로 `IELTS`, `TOEFL IBT`, `TOEFL-ITP`, `HSK`, `UNKNOWN` 로고 매핑 확인
- production start 환경에서 web 경유 이미지 응답 확인
  - `http://localhost:3014/university-static/images/language/ielts.png` -> `200 image/png`, PNG signature 확인
  - `http://localhost:3014/university-static/images/language/toefl_ibt.png` -> `200 image/png`, PNG signature 확인
  - `http://localhost:3014/university-static/images/language/toefl_itp.png` -> `200 image/png`, PNG signature 확인
  - `http://localhost:3014/university-static/images/language/default.png` -> `200 image/png`, PNG signature 확인
  - `http://localhost:3014/university-static/images/language/jlpt.png` -> `200 image/png`, PNG signature 확인
  - `http://localhost:3014/university-static/images/language/new_hsk.png` -> `200 image/png`, PNG signature 확인
- `http://localhost:3014/university/kyunghee/3155` HTML에서 `/university-static/images/language/jlpt.png` 렌더링 경로 확인

## 리뷰 요구사항 (선택)

- web이 직접 language asset을 소유하지 않고 university-web rewrite로만 노출하는 방향이 맞는지 봐주세요.
