### PR TITLE
feat: 지원자 현황 확인 디자인 구현

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -29,7 +29,7 @@ if (isProductionRuntime && !universityWebDomain) {
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  transpilePackages: ["@solid-connect/ai-inspector"],
+  transpilePackages: ["@solid-connect/ai-inspector", "@solid-connect/ui"],
   reactCompiler: {
     compilationMode: "annotation",
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,6 +26,7 @@
     "@react-google-maps/api": "^2.19.2",
     "@sentry/nextjs": "^10.61.0",
     "@solid-connect/ai-inspector": "workspace:^",
+    "@solid-connect/ui": "workspace:^",
     "@stomp/stompjs": "^7.1.1",
     "@tanstack/react-query": "^5.84.1",
     "@tanstack/react-query-devtools": "^5.84.1",

--- a/apps/web/src/app/university/application/ScorePageContent.tsx
+++ b/apps/web/src/app/university/application/ScorePageContent.tsx
@@ -1,30 +1,48 @@
 "use client";
 
+import clsx from "clsx";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { type FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { useGetApplicationsList } from "@/apis/applications";
 import ConfirmCancelModal from "@/components/modal/ConfirmCancelModal";
-import ButtonTab from "@/components/ui/ButtonTab";
-import Tab from "@/components/ui/Tab";
 import { DEFAULT_MAX_CHOICE_COUNT, getHomeUniversityById, REGIONS_KO } from "@/constants/university";
 import useAuthStore from "@/lib/zustand/useAuthStore";
-import type { ScoreSheet as ScoreSheetType } from "@/types/application";
+import type { Applicant, ScoreSheet as ScoreSheetType } from "@/types/application";
 import type { RegionKo } from "@/types/university";
-import ApplicationSectionTitle from "./_components/ApplicationSectionTitle";
-import ScoreSearchBar from "./ScoreSearchBar";
-import ScoreSearchField from "./ScoreSearchField";
-import ScoreSheet from "./ScoreSheet";
+import { getApplicationDetailHref, MobileScoreSheet } from "./ScoreSheet";
+
+type ApplicantScope = "all" | "withApplicants";
+type ScoreSort = "applicants" | "gpa";
+
+type AppliedUniversity = {
+  preference: number;
+  scoreSheet: ScoreSheetType;
+};
+
+type ScorePageViewProps = {
+  appliedUniversities: AppliedUniversity[];
+  displayedScoreSheets: ScoreSheetType[];
+  totalUniversityCount: number;
+  applicantUniversityCount: number;
+  participantCount: number;
+  scope: ApplicantScope;
+  regionFilter: RegionKo | "";
+  sortMode: ScoreSort;
+  onScopeChange: (scope: ApplicantScope) => void;
+  onRegionChange: (region: RegionKo | "") => void;
+  onSortModeChange: (sortMode: ScoreSort) => void;
+  onChangeUniversities: () => void;
+};
 
 const ScorePageContent = () => {
   const router = useRouter();
-  const searchRef = useRef<HTMLInputElement>(null!);
   const homeUniversityId = useAuthStore((state) => state.homeUniversityId);
   const maxChoiceCount = getHomeUniversityById(homeUniversityId)?.maxChoiceCount ?? DEFAULT_MAX_CHOICE_COUNT;
 
-  const [searchActive, setSearchActive] = useState(false);
-  const [preferenceIndex, setPreferenceIndex] = useState(0);
+  const [scope, setScope] = useState<ApplicantScope>("withApplicants");
   const [regionFilter, setRegionFilter] = useState<RegionKo | "">("");
-  const [searchValue, setSearchValue] = useState("");
+  const [sortMode, setSortMode] = useState<ScoreSort>("applicants");
   const [showNeedApply, _setShowNeedApply] = useState(false);
 
   const emptyChoices = useMemo(
@@ -33,74 +51,31 @@ const ScorePageContent = () => {
   );
   const { data: scoreResponseData, isError, isLoading } = useGetApplicationsList();
   const scoreChoices = scoreResponseData?.choices ?? emptyChoices;
-  const preferenceChoices = useMemo(
-    () => Array.from({ length: Math.max(scoreChoices.length, maxChoiceCount) }, (_, index) => `${index + 1}순위`),
-    [maxChoiceCount, scoreChoices.length],
+
+  const allScoreSheets = useMemo(
+    () => sortScoreSheets(uniqueScoreSheets(scoreChoices.flat()), sortMode),
+    [scoreChoices, sortMode],
   );
+  const appliedUniversities = useMemo(
+    () => getAppliedUniversities(scoreChoices, maxChoiceCount),
+    [scoreChoices, maxChoiceCount],
+  );
+  const totalUniversityCount = allScoreSheets.length;
+  const applicantUniversityCount = allScoreSheets.filter((scoreSheet) => scoreSheet.applicants.length > 0).length;
+  const participantCount = useMemo(() => getParticipantCount(allScoreSheets), [allScoreSheets]);
 
-  const filteredAndSortedData = useMemo(() => {
-    // ✨ 1. 대학 이름(koreanName)을 기준으로 중복을 제거하는 헬퍼 함수
-    const uniqueByKoreanName = (data: ScoreSheetType[]) => {
-      // Map을 사용해 koreanName을 키로 하여 중복을 효율적으로 제거합니다.
-      const universityMap = new Map(data.map((sheet) => [sheet.koreanName, sheet]));
-      // Map의 값들만 다시 배열로 변환하여 반환합니다.
-      return Array.from(universityMap.values());
-    };
+  const displayedScoreSheets = useMemo(() => {
+    let result =
+      scope === "withApplicants"
+        ? allScoreSheets.filter((scoreSheet) => scoreSheet.applicants.length > 0)
+        : allScoreSheets;
 
-    // ✨ 2. API 응답 데이터를 받자마자 중복부터 제거하고 정렬합니다.
-    const sortedData = scoreChoices.map((choice) =>
-      uniqueByKoreanName(choice).sort((a, b) => b.applicants.length - a.applicants.length),
-    );
-
-    // 4. 기존 필터링 로직을 적용합니다.
-    const applyFilters = (data: ScoreSheetType[]) => {
-      let result = data;
-      if (regionFilter) {
-        result = result.filter((sheet) => sheet.region === regionFilter);
-      }
-      if (searchValue) {
-        result = result.filter((sheet) => sheet.koreanName.toLowerCase().includes(searchValue.toLowerCase()));
-      }
-      return result;
-    };
-
-    return sortedData.map(applyFilters);
-  }, [scoreChoices, regionFilter, searchValue]);
-
-  // (이하 코드는 동일)
-  const handleSearch = (event: FormEvent) => {
-    event.preventDefault();
-    const keyword = searchRef.current?.value || "";
-    setRegionFilter("");
-    setSearchValue(keyword);
-    setSearchActive(false);
-  };
-
-  const handleSearchField = (keyword: string) => {
-    if (searchRef.current) {
-      searchRef.current.value = keyword;
+    if (regionFilter) {
+      result = result.filter((scoreSheet) => scoreSheet.region === regionFilter);
     }
-    setRegionFilter("");
-    setSearchValue(keyword);
-    setSearchActive(false);
-  };
 
-  const handleSearchClick = () => {
-    setSearchActive(true);
-  };
-
-  const handlePreferenceChange = (nextPreference: string) => {
-    const nextIndex = preferenceChoices.indexOf(nextPreference);
-    setPreferenceIndex(nextIndex >= 0 ? nextIndex : 0);
-  };
-
-  const selectedPreference = preferenceChoices[preferenceIndex] ?? preferenceChoices[0] ?? "1순위";
-  const scoreSheets = filteredAndSortedData[preferenceIndex] ?? [];
-
-  useEffect(() => {
-    if (preferenceIndex < preferenceChoices.length) return;
-    setPreferenceIndex(0);
-  }, [preferenceChoices.length, preferenceIndex]);
+    return sortScoreSheets(result, sortMode);
+  }, [allScoreSheets, regionFilter, scope, sortMode]);
 
   useEffect(() => {
     if (isLoading) return;
@@ -109,55 +84,328 @@ const ScorePageContent = () => {
     }
   }, [isError, isLoading, router]);
 
-  const hotKeyWords = ["RMIT", "오스트라바", "칼스루에", "그라츠", "추오", "프라하", "보라스", "빈", "메모리얼"];
+  const viewProps = {
+    appliedUniversities,
+    displayedScoreSheets,
+    totalUniversityCount,
+    applicantUniversityCount,
+    participantCount,
+    scope,
+    regionFilter,
+    sortMode,
+    onScopeChange: setScope,
+    onRegionChange: setRegionFilter,
+    onSortModeChange: setSortMode,
+    onChangeUniversities: () => router.push("/university/application/apply"),
+  };
 
   return (
-    <div className="px-5">
-      <ApplicationSectionTitle
-        className="mb-3 mt-5"
-        title="지원자 현황"
-        description="지원 순위와 지역 필터로 원하는 학교 현황을 빠르게 확인할 수 있어요."
+    <>
+      <ApplicationScoreView {...viewProps} />
+      <ConfirmCancelModal
+        title="학교 지원이 필요합니다"
+        isOpen={showNeedApply}
+        handleCancel={() => router.push("/")}
+        handleConfirm={() => router.push("/university/application/apply")}
+        content={"점수 공유현황을 확인하려면 지원절차를\n진행해주세요."}
+        cancelText="확인"
+        approveText="학교 지원하기"
       />
-      <ScoreSearchBar onClick={handleSearchClick} textRef={searchRef} searchHandler={handleSearch} />
+    </>
+  );
+};
 
-      {searchActive ? (
-        <div className="mt-3 rounded-lg bg-white py-4 shadow-sdwB">
-          <ScoreSearchField keyWords={hotKeyWords} setKeyWord={handleSearchField} />
-        </div>
+const ApplicationScoreView = ({
+  appliedUniversities,
+  displayedScoreSheets,
+  totalUniversityCount,
+  applicantUniversityCount,
+  participantCount,
+  scope,
+  regionFilter,
+  sortMode,
+  onScopeChange,
+  onRegionChange,
+  onSortModeChange,
+  onChangeUniversities,
+}: ScorePageViewProps) => {
+  return (
+    <main className="mx-auto w-full max-w-app px-5 pb-6 md:pt-14">
+      <AppliedUniversitySection appliedUniversities={appliedUniversities} onChangeUniversities={onChangeUniversities} />
+      <div className="mt-5 h-1 bg-k-50" />
+      <ParticipantBanner participantCount={participantCount} />
+      <ApplicationScopeTabs
+        scope={scope}
+        totalUniversityCount={totalUniversityCount}
+        applicantUniversityCount={applicantUniversityCount}
+        onScopeChange={onScopeChange}
+      />
+      <ApplicationFilterChips
+        regionFilter={regionFilter}
+        sortMode={sortMode}
+        onRegionChange={onRegionChange}
+        onSortModeChange={onSortModeChange}
+      />
+      <ScoreSheetList scoreSheets={displayedScoreSheets} />
+    </main>
+  );
+};
+
+const AppliedUniversitySection = ({
+  appliedUniversities,
+  onChangeUniversities,
+}: {
+  appliedUniversities: AppliedUniversity[];
+  onChangeUniversities: () => void;
+}) => (
+  <section className="mt-5">
+    <div className="flex items-center justify-between gap-3">
+      <h1 className="text-k-900 typo-bold-4">지원한 대학({appliedUniversities.length})</h1>
+      <button
+        type="button"
+        onClick={onChangeUniversities}
+        className="h-8 shrink-0 rounded-2xl bg-primary px-4 text-k-0 typo-sb-12"
+      >
+        지원 대학교 변경
+      </button>
+    </div>
+    <div className="mt-4 space-y-2">
+      {appliedUniversities.length > 0 ? (
+        appliedUniversities.map(({ preference, scoreSheet }) => (
+          <AppliedUniversityRow
+            key={`${preference}-${scoreSheet.koreanName}`}
+            preference={preference}
+            scoreSheet={scoreSheet}
+          />
+        ))
       ) : (
-        <>
-          <div className="mt-4 rounded-lg bg-white px-2 shadow-sdwB">
-            <Tab choices={preferenceChoices} choice={selectedPreference} setChoice={handlePreferenceChange} />
-          </div>
-          <ButtonTab
-            choices={REGIONS_KO}
-            choice={regionFilter}
-            setChoice={(newRegion) => {
-              if (searchRef.current) searchRef.current.value = "";
-              setSearchValue("");
-              setRegionFilter(newRegion as RegionKo | "");
-            }}
-            style={{ padding: "10px 0 10px 8px" }}
-          />
-
-          <div className="mx-auto mt-3 flex w-full flex-col gap-3 overflow-x-auto pb-4">
-            {scoreSheets.map((choice) => (
-              <ScoreSheet key={choice.koreanName} scoreSheet={choice} />
-            ))}
-          </div>
-          <ConfirmCancelModal
-            title="학교 지원이 필요합니다"
-            isOpen={showNeedApply}
-            handleCancel={() => router.push("/")}
-            handleConfirm={() => router.push("/university/application/apply")}
-            content={"점수 공유현황을 확인하려면 지원절차를\n진행해주세요."}
-            cancelText="확인"
-            approveText="학교 지원하기"
-          />
-        </>
+        <div className="rounded-lg bg-k-50 px-4 py-4 text-k-500 typo-medium-3">
+          지원한 대학 정보를 불러오는 중입니다.
+        </div>
       )}
     </div>
+  </section>
+);
+
+const AppliedUniversityRow = ({ preference, scoreSheet }: AppliedUniversity) => {
+  const capacity =
+    scoreSheet.studentCapacity === null || scoreSheet.studentCapacity === undefined
+      ? "미정"
+      : scoreSheet.studentCapacity;
+
+  return (
+    <Link
+      href={getApplicationDetailHref(scoreSheet.koreanName)}
+      className="flex h-11 items-center gap-2.5 rounded-lg border border-k-50 bg-white px-3.5 shadow-[0_0_10px_rgba(0,0,0,0.05)]"
+    >
+      <span className="size-5 shrink-0 rounded-full bg-k-50" aria-hidden />
+      <span className="min-w-0 flex-1 truncate text-k-900 typo-sb-7">
+        {scoreSheet.koreanName} ({preference}/{capacity})
+      </span>
+      <span className="text-k-500" aria-hidden>
+        ˅
+      </span>
+    </Link>
   );
+};
+
+const ParticipantBanner = ({ participantCount }: { participantCount: number }) => (
+  <section className="mt-6 rounded-lg bg-secondary-100 px-5 py-3">
+    <div className="flex items-center gap-4">
+      <div className="flex size-10 items-center justify-center text-[34px]" aria-hidden>
+        🔥
+      </div>
+      <div className="min-w-0 text-k-800">
+        <p className="typo-regular-4">솔리드 커넥션과 함께하고 있어요</p>
+        <p className="mt-0.5 typo-sb-9">총 {participantCount}명이 성적 공유 참여중!</p>
+      </div>
+    </div>
+  </section>
+);
+
+const ApplicationScopeTabs = ({
+  scope,
+  totalUniversityCount,
+  applicantUniversityCount,
+  onScopeChange,
+}: {
+  scope: ApplicantScope;
+  totalUniversityCount: number;
+  applicantUniversityCount: number;
+  onScopeChange: (scope: ApplicantScope) => void;
+}) => (
+  <div className="mt-6 flex h-11 items-start justify-between">
+    <ScopeTabButton isActive={scope === "all"} onClick={() => onScopeChange("all")}>
+      모든 대학 ({totalUniversityCount})
+    </ScopeTabButton>
+    <ScopeTabButton isActive={scope === "withApplicants"} onClick={() => onScopeChange("withApplicants")}>
+      지원자 있는 대학 ({applicantUniversityCount})
+    </ScopeTabButton>
+  </div>
+);
+
+const ScopeTabButton = ({
+  children,
+  isActive,
+  onClick,
+}: {
+  children: ReactNode;
+  isActive: boolean;
+  onClick: () => void;
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={clsx(
+      "flex h-11 flex-1 items-center justify-center border-b-2 typo-medium-2",
+      isActive ? "border-primary text-k-900" : "border-transparent text-k-300",
+    )}
+  >
+    {children}
+  </button>
+);
+
+const ApplicationFilterChips = ({
+  regionFilter,
+  sortMode,
+  onRegionChange,
+  onSortModeChange,
+}: {
+  regionFilter: RegionKo | "";
+  sortMode: ScoreSort;
+  onRegionChange: (region: RegionKo | "") => void;
+  onSortModeChange: (sortMode: ScoreSort) => void;
+}) => (
+  <div className="mt-4 flex gap-2 overflow-x-auto whitespace-nowrap pb-1">
+    {REGIONS_KO.map((region) => (
+      <FilterChip
+        key={region}
+        isActive={regionFilter === region}
+        onClick={() => onRegionChange(regionFilter === region ? "" : region)}
+      >
+        {region}
+      </FilterChip>
+    ))}
+    <FilterChip
+      isActive={sortMode === "gpa"}
+      onClick={() => onSortModeChange(sortMode === "gpa" ? "applicants" : "gpa")}
+    >
+      학점 높은 순
+    </FilterChip>
+  </div>
+);
+
+const FilterChip = ({
+  children,
+  isActive,
+  onClick,
+}: {
+  children: ReactNode;
+  isActive: boolean;
+  onClick: () => void;
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={clsx("rounded-full px-3 py-[5px] typo-sb-12", isActive ? "bg-primary text-k-0" : "bg-k-50 text-k-300")}
+  >
+    {children}
+  </button>
+);
+
+const ScoreSheetList = ({ scoreSheets }: { scoreSheets: ScoreSheetType[] }) => {
+  if (scoreSheets.length === 0) {
+    return <ApplicationScoreEmptyState />;
+  }
+
+  return (
+    <div className="mt-3 flex flex-col gap-2 pb-6">
+      {scoreSheets.map((scoreSheet, index) => (
+        <MobileScoreSheet key={scoreSheet.koreanName} scoreSheet={scoreSheet} defaultOpen={index === 0} />
+      ))}
+    </div>
+  );
+};
+
+const ApplicationScoreEmptyState = () => (
+  <div className="mt-4 flex min-h-48 flex-col items-center justify-center rounded-lg bg-k-50 px-6 py-8 text-center">
+    <p className="text-k-900 typo-sb-7">조건에 맞는 대학이 없어요.</p>
+    <p className="mt-2 text-k-500 typo-medium-3">다른 필터로 다시 확인해 주세요.</p>
+  </div>
+);
+
+const uniqueScoreSheets = (scoreSheets: ScoreSheetType[]) => {
+  const scoreSheetMap = new Map<string, ScoreSheetType>();
+
+  for (const scoreSheet of scoreSheets) {
+    const key = getScoreSheetKey(scoreSheet);
+    const prev = scoreSheetMap.get(key);
+    scoreSheetMap.set(
+      key,
+      prev ? { ...prev, applicants: mergeApplicants(prev.applicants, scoreSheet.applicants) } : scoreSheet,
+    );
+  }
+
+  return Array.from(scoreSheetMap.values());
+};
+
+const getAppliedUniversities = (scoreChoices: ScoreSheetType[][], maxChoiceCount: number): AppliedUniversity[] => {
+  return scoreChoices.slice(0, maxChoiceCount).flatMap((choice, index) => {
+    const mine = choice.find((scoreSheet) => scoreSheet.applicants.some((applicant) => applicant.isMine));
+
+    return mine ? [{ preference: index + 1, scoreSheet: mine }] : [];
+  });
+};
+
+const getScoreSheetKey = (scoreSheet: ScoreSheetType) => {
+  return scoreSheet.id ? String(scoreSheet.id) : scoreSheet.koreanName;
+};
+
+const mergeApplicants = (currentApplicants: Applicant[], nextApplicants: Applicant[]) => {
+  const applicantMap = new Map<string, Applicant>();
+
+  for (const applicant of currentApplicants) {
+    applicantMap.set(applicant.nicknameForApply, applicant);
+  }
+
+  for (const applicant of nextApplicants) {
+    if (!applicantMap.has(applicant.nicknameForApply)) {
+      applicantMap.set(applicant.nicknameForApply, applicant);
+    }
+  }
+
+  return Array.from(applicantMap.values());
+};
+
+const getParticipantCount = (scoreSheets: ScoreSheetType[]) => {
+  const nicknames = new Set<string>();
+
+  for (const scoreSheet of scoreSheets) {
+    for (const applicant of scoreSheet.applicants) {
+      nicknames.add(applicant.nicknameForApply);
+    }
+  }
+
+  return nicknames.size;
+};
+
+const getAverageGpa = (scoreSheet: ScoreSheetType) => {
+  if (scoreSheet.applicants.length === 0) {
+    return 0;
+  }
+
+  const totalGpa = scoreSheet.applicants.reduce((sum, applicant) => sum + applicant.gpa, 0);
+  return totalGpa / scoreSheet.applicants.length;
+};
+
+const sortScoreSheets = (scoreSheets: ScoreSheetType[], sortMode: ScoreSort) => {
+  return [...scoreSheets].sort((a, b) => {
+    if (sortMode === "gpa") {
+      return getAverageGpa(b) - getAverageGpa(a);
+    }
+
+    return b.applicants.length - a.applicants.length;
+  });
 };
 
 export default ScorePageContent;

--- a/apps/web/src/app/university/application/ScoreSheet.tsx
+++ b/apps/web/src/app/university/application/ScoreSheet.tsx
@@ -1,50 +1,113 @@
+"use client";
+
+import clsx from "clsx";
+import Link from "next/link";
 import { useState } from "react";
 import { IconExpandMoreFilled } from "@/public/svgs/community";
-import type { ScoreSheet as ScoreSheetType } from "@/types/application";
+import type { Applicant, ScoreSheet as ScoreSheetType } from "@/types/application";
 import { formatLanguageTestScore, isLanguageTestEnum, languageTestMapping } from "@/types/score";
 
-const ScoreSheet = ({ scoreSheet }: { scoreSheet: ScoreSheetType }) => {
-  const [tableOpened, setTableOpened] = useState(false);
+type ScoreSheetProps = {
+  scoreSheet: ScoreSheetType;
+  defaultOpen?: boolean;
+  detailHref?: string;
+};
+
+export const getApplicationDetailHref = (koreanName: string) =>
+  `/university/application/${encodeURIComponent(koreanName)}`;
+
+export const formatApplicantGpa = (gpa: number | null | undefined) => {
+  if (typeof gpa !== "number" || Number.isNaN(gpa)) {
+    return "-";
+  }
+
+  return gpa.toFixed(1);
+};
+
+export const formatApplicantLanguageTest = (applicant: Pick<Applicant, "testType" | "testScore">) => {
+  const testName = isLanguageTestEnum(applicant.testType)
+    ? languageTestMapping[applicant.testType]
+    : applicant.testType;
+  const score = isLanguageTestEnum(applicant.testType)
+    ? formatLanguageTestScore(applicant.testType, applicant.testScore)
+    : applicant.testScore;
+
+  if (!testName || !score) {
+    return "-";
+  }
+
+  return `${testName} ${score}`;
+};
+
+export const formatApplicantLanguageTestName = (testType: string) => {
+  return isLanguageTestEnum(testType) ? languageTestMapping[testType] : testType;
+};
+
+export const formatApplicantLanguageScore = (applicant: Pick<Applicant, "testType" | "testScore">) => {
+  if (!applicant.testScore) {
+    return "-";
+  }
+
+  return isLanguageTestEnum(applicant.testType)
+    ? formatLanguageTestScore(applicant.testType, applicant.testScore)
+    : applicant.testScore;
+};
+
+const getScoreSheetCapacity = (scoreSheet: ScoreSheetType) => {
+  if (scoreSheet.studentCapacity === null || scoreSheet.studentCapacity === undefined) {
+    return "미정";
+  }
+
+  return String(scoreSheet.studentCapacity);
+};
+
+export const MobileScoreSheet = ({ scoreSheet, defaultOpen = false, detailHref }: ScoreSheetProps) => {
+  const [tableOpened, setTableOpened] = useState(defaultOpen);
+  const resolvedDetailHref = detailHref ?? getApplicationDetailHref(scoreSheet.koreanName);
+  const capacity = getScoreSheetCapacity(scoreSheet);
 
   return (
-    <div className="w-full overflow-hidden rounded-lg bg-white shadow-sdwB">
-      <button
-        onClick={() => setTableOpened(!tableOpened)}
-        className="flex min-h-12 w-full items-center justify-between border-b border-k-50 bg-k-50 px-4 text-left"
-        type="button"
+    <article
+      className={clsx(
+        "w-full overflow-hidden rounded-lg",
+        tableOpened ? "border border-secondary-300 bg-white" : "bg-k-50",
+      )}
+    >
+      <div
+        className={clsx("flex min-h-11 w-full items-center gap-2.5 px-4", tableOpened ? "bg-secondary-100" : "bg-k-50")}
       >
-        <p className="truncate text-k-900 typo-sb-7">
-          {scoreSheet.koreanName} ({scoreSheet.applicants.length}/{scoreSheet.studentCapacity})
-        </p>
-        <span className="flex h-6 w-6 items-center justify-center">
+        <span className="size-5 shrink-0 rounded-full bg-white" aria-hidden />
+        <Link href={resolvedDetailHref} className="min-w-0 flex-1 truncate text-k-900 typo-sb-7">
+          {scoreSheet.koreanName} ({scoreSheet.applicants.length}/{capacity})
+        </Link>
+        <button
+          onClick={() => setTableOpened((prev) => !prev)}
+          className="flex size-6 shrink-0 items-center justify-center text-k-600"
+          type="button"
+          aria-label={`${scoreSheet.koreanName} 지원자 목록 ${tableOpened ? "접기" : "펼치기"}`}
+        >
           <IconExpandMoreFilled className={`transition-transform duration-300 ${tableOpened ? "rotate-180" : ""}`} />
-        </span>
-      </button>
+        </button>
+      </div>
 
       {tableOpened ? (
-        <div className="divide-y divide-k-50">
-          {scoreSheet.applicants.map((applicant) => (
-            <div key={applicant.nicknameForApply} className="flex min-h-12 items-center px-4 text-k-600 typo-medium-3">
-              <span className="min-w-[30px] flex-1 overflow-hidden whitespace-nowrap text-k-900 typo-regular-2">
-                {applicant.nicknameForApply}
-              </span>
-              <span className="min-w-[30px] flex-1 overflow-hidden whitespace-nowrap text-center typo-medium-2">
-                {applicant.gpa.toFixed(2)}
-              </span>
-              <span className="min-w-[30px] flex-1 overflow-hidden whitespace-nowrap text-center typo-medium-2">
-                {isLanguageTestEnum(applicant.testType) ? languageTestMapping[applicant.testType] : applicant.testType}
-              </span>
-              <span className="min-w-[30px] flex-1 overflow-hidden whitespace-nowrap text-center typo-medium-2">
-                {isLanguageTestEnum(applicant.testType)
-                  ? formatLanguageTestScore(applicant.testType, applicant.testScore)
-                  : applicant.testScore}
-              </span>
-            </div>
+        <div className="bg-white">
+          {scoreSheet.applicants.map((applicant, index) => (
+            <ApplicantInlineRow key={`${applicant.nicknameForApply}-${index}`} applicant={applicant} />
           ))}
         </div>
       ) : null}
-    </div>
+    </article>
   );
 };
 
-export default ScoreSheet;
+const ApplicantInlineRow = ({ applicant }: { applicant: Applicant }) => (
+  <div className="grid min-h-[46px] grid-cols-[1fr_54px_1fr_54px] items-center px-9 text-k-700 typo-regular-3">
+    <span className="truncate text-k-900">{applicant.nicknameForApply}</span>
+    <span className="text-center">{formatApplicantGpa(applicant.gpa)}</span>
+    <span className="truncate text-center text-k-900">{formatApplicantLanguageTestName(applicant.testType)}</span>
+    <span className="truncate text-right">{formatApplicantLanguageScore(applicant)}</span>
+  </div>
+);
+
+export default MobileScoreSheet;

--- a/apps/web/src/app/university/application/[universityName]/ApplicationUniversityDetailContent.tsx
+++ b/apps/web/src/app/university/application/[universityName]/ApplicationUniversityDetailContent.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { MobileHeroDetailShell } from "@solid-connect/ui";
+import clsx from "clsx";
+import Link from "next/link";
+import { type ReactNode, useMemo, useState } from "react";
+import { useGetApplicationsList } from "@/apis/applications";
+import Image from "@/components/ui/FallbackImage";
+import { showIconToast } from "@/lib/toast/showIconToast";
+import { IconShare } from "@/public/svgs";
+import type { Applicant, ScoreSheet as ScoreSheetType } from "@/types/application";
+import { normalizeImageUrlToUploadCdn } from "@/utils/cdnUrl";
+import { formatApplicantGpa, formatApplicantLanguageTest } from "../ScoreSheet";
+
+type ApplicantSort = "preference" | "gpa";
+
+type ApplicationUniversityDetailContentProps = {
+  universityName: string;
+};
+
+const ApplicationUniversityDetailContent = ({ universityName }: ApplicationUniversityDetailContentProps) => {
+  const [sortMode, setSortMode] = useState<ApplicantSort>("preference");
+  const { data, isLoading } = useGetApplicationsList();
+  const scoreSheet = useMemo(
+    () => findScoreSheetWithApplicants(data?.choices ?? [], universityName),
+    [data?.choices, universityName],
+  );
+
+  const applicants = useMemo(() => {
+    if (!scoreSheet) return [];
+
+    return [...scoreSheet.applicants].sort((a, b) => {
+      if (sortMode === "gpa") {
+        return b.gpa - a.gpa;
+      }
+
+      return (a.preferenceOrder ?? 999) - (b.preferenceOrder ?? 999);
+    });
+  }, [scoreSheet, sortMode]);
+
+  if (isLoading) {
+    return <ApplicationUniversityDetailSkeleton />;
+  }
+
+  if (!scoreSheet) {
+    return <ApplicationUniversityDetailNotFound universityName={universityName} />;
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-app bg-white md:min-h-screen">
+      <MobileApplicationUniversityDetail
+        scoreSheet={scoreSheet}
+        applicants={applicants}
+        sortMode={sortMode}
+        setSortMode={setSortMode}
+      />
+    </div>
+  );
+};
+
+const MobileApplicationUniversityDetail = ({
+  scoreSheet,
+  applicants,
+  sortMode,
+  setSortMode,
+}: {
+  scoreSheet: ScoreSheetType;
+  applicants: Applicant[];
+  sortMode: ApplicantSort;
+  setSortMode: (sortMode: ApplicantSort) => void;
+}) => (
+  <MobileHeroDetailShell
+    rightAction={<ShareActionButton />}
+    background={
+      <Image
+        alt={`${scoreSheet.koreanName} 이미지`}
+        src={normalizeImageUrlToUploadCdn(scoreSheet.backgroundImageUrl)}
+        fill
+        className="object-cover"
+        fallbackSrc="/svgs/placeholders/university-background-placeholder.svg"
+        priority
+      />
+    }
+    logo={<UniversityLogo scoreSheet={scoreSheet} />}
+    title={scoreSheet.koreanName}
+    subtitle={scoreSheet.englishName ?? ""}
+    stats={[
+      { key: "country", content: getCountryLabel(scoreSheet.country) },
+      { key: "capacity", content: getCapacityLabel(scoreSheet) },
+      { key: "applicants", content: `지원자 ${scoreSheet.applicants.length}명` },
+    ]}
+  >
+    <ApplicantListSection applicants={applicants} sortMode={sortMode} setSortMode={setSortMode} />
+  </MobileHeroDetailShell>
+);
+
+const ApplicantListSection = ({
+  applicants,
+  sortMode,
+  setSortMode,
+}: {
+  applicants: Applicant[];
+  sortMode: ApplicantSort;
+  setSortMode: (sortMode: ApplicantSort) => void;
+}) => (
+  <section className="pt-7">
+    <h2 className="text-k-900 typo-bold-4">지원자 목록 ({applicants.length}명)</h2>
+    <p className="mt-1 text-k-400 typo-regular-2">모든 지원자들의 성적 정보를 확인하세요.</p>
+    <div className="mt-5 flex h-11">
+      <ApplicantSortTab active={sortMode === "preference"} onClick={() => setSortMode("preference")}>
+        지망 순위 순
+      </ApplicantSortTab>
+      <ApplicantSortTab active={sortMode === "gpa"} onClick={() => setSortMode("gpa")}>
+        학점 순
+      </ApplicantSortTab>
+    </div>
+    <div className="mt-4 flex flex-col gap-2">
+      {applicants.map((applicant, index) => (
+        <ApplicantScoreCard key={`${applicant.nicknameForApply}-${index}`} applicant={applicant} />
+      ))}
+    </div>
+  </section>
+);
+
+const ApplicantSortTab = ({
+  children,
+  active,
+  onClick,
+}: {
+  children: ReactNode;
+  active: boolean;
+  onClick: () => void;
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={clsx(
+      "flex flex-1 items-center justify-center border-b-2 typo-medium-2",
+      active ? "border-primary text-k-900" : "border-transparent text-k-300",
+    )}
+  >
+    {children}
+  </button>
+);
+
+const ApplicantScoreCard = ({ applicant }: { applicant: Applicant }) => (
+  <article className="rounded-[10px] bg-white p-4 shadow-[0_0_5px_rgba(0,0,0,0.05)]">
+    <h3 className="text-k-900 typo-bold-5">{applicant.nicknameForApply}</h3>
+    <dl className="mt-4 grid grid-cols-2 gap-x-6 gap-y-3 text-[13px]">
+      <ApplicantMetric label="지망" value={`${applicant.preferenceOrder ?? "-"} 지망`} />
+      <ApplicantMetric label="환산점수" value={`${getApplicantConvertedScore(applicant)} 점`} />
+      <ApplicantMetric label="학점" value={`${formatApplicantGpa(applicant.gpa)}/4.5 점`} />
+      <ApplicantMetric label="어학성적" value={formatApplicantLanguageTest(applicant)} />
+    </dl>
+  </article>
+);
+
+const ApplicantMetric = ({ label, value }: { label: string; value: string }) => (
+  <div className="flex min-w-0 items-center justify-between gap-2">
+    <dt className="shrink-0 text-k-400 typo-regular-3">{label}</dt>
+    <dd className="min-w-0 truncate text-right text-k-900 typo-bold-5">{value}</dd>
+  </div>
+);
+
+const UniversityLogo = ({ scoreSheet }: { scoreSheet: ScoreSheetType }) => (
+  <Image
+    src={normalizeImageUrlToUploadCdn(scoreSheet.logoImageUrl)}
+    alt="대학 로고"
+    width={62}
+    height={62}
+    className="size-[62px] rounded-full border border-k-50 bg-white object-cover"
+    fallbackSrc="/svgs/placeholders/university-logo-placeholder.svg"
+  />
+);
+
+const ShareActionButton = () => {
+  const handleShare = async () => {
+    if (!navigator.clipboard?.writeText) {
+      showIconToast("logo", "링크 복사를 지원하지 않는 환경이에요.");
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      showIconToast("link", "URL이 복사되었습니다.");
+    } catch {
+      showIconToast("logo", "URL 복사에 실패했습니다.");
+    }
+  };
+
+  return (
+    <button type="button" onClick={handleShare} className="size-10" aria-label="공유하기">
+      <IconShare width={40} height={40} />
+    </button>
+  );
+};
+
+const ApplicationUniversityDetailSkeleton = () => (
+  <div className="px-5 py-8">
+    <div className="h-60 animate-pulse rounded-3xl bg-k-50" />
+    <div className="mt-6 space-y-3">
+      <div className="h-28 animate-pulse rounded-[10px] bg-k-50" />
+      <div className="h-28 animate-pulse rounded-[10px] bg-k-50" />
+      <div className="h-28 animate-pulse rounded-[10px] bg-k-50" />
+    </div>
+  </div>
+);
+
+const ApplicationUniversityDetailNotFound = ({ universityName }: { universityName: string }) => (
+  <div className="flex min-h-[60vh] flex-col items-center justify-center px-5 text-center">
+    <p className="text-k-900 typo-sb-5">{universityName} 지원자 현황을 찾지 못했어요.</p>
+    <Link href="/university/application" className="mt-4 rounded-lg bg-primary px-4 py-2 text-k-0 typo-sb-9">
+      목록으로 돌아가기
+    </Link>
+  </div>
+);
+
+const findScoreSheetWithApplicants = (
+  scoreChoices: ScoreSheetType[][],
+  universityName: string,
+): ScoreSheetType | null => {
+  const matches = scoreChoices.flatMap((choice, choiceIndex) =>
+    choice
+      .filter((scoreSheet) => scoreSheet.koreanName === universityName)
+      .map((scoreSheet) => ({
+        preferenceOrder: choiceIndex + 1,
+        scoreSheet,
+      })),
+  );
+
+  if (matches.length === 0) {
+    return null;
+  }
+
+  const baseScoreSheet = matches[0].scoreSheet;
+  const applicantMap = new Map<string, Applicant>();
+
+  for (const { preferenceOrder, scoreSheet } of matches) {
+    for (const applicant of scoreSheet.applicants) {
+      const key = applicant.nicknameForApply;
+      if (!applicantMap.has(key)) {
+        applicantMap.set(key, {
+          ...applicant,
+          preferenceOrder: applicant.preferenceOrder ?? preferenceOrder,
+        });
+      }
+    }
+  }
+
+  return {
+    ...baseScoreSheet,
+    applicants: Array.from(applicantMap.values()),
+  };
+};
+
+const getApplicantConvertedScore = (applicant: Applicant) => {
+  const score = applicant.convertedScore ?? applicant.score;
+
+  if (typeof score !== "number" || Number.isNaN(score)) {
+    return "-";
+  }
+
+  return String(score);
+};
+
+const getCapacityLabel = (scoreSheet: ScoreSheetType) => {
+  if (scoreSheet.studentCapacity === null || scoreSheet.studentCapacity === undefined) {
+    return "모집 미정";
+  }
+
+  return `모집 ${scoreSheet.studentCapacity}명`;
+};
+
+const countryFlagMap: Record<string, string> = {
+  미국: "🇺🇸",
+  캐나다: "🇨🇦",
+  일본: "🇯🇵",
+  중국: "🇨🇳",
+  대만: "🇹🇼",
+  독일: "🇩🇪",
+  프랑스: "🇫🇷",
+  호주: "🇦🇺",
+};
+
+const getCountryLabel = (country: string) => {
+  const flag = countryFlagMap[country];
+  return flag ? `${flag} ${country}` : country;
+};
+
+export default ApplicationUniversityDetailContent;

--- a/apps/web/src/app/university/application/[universityName]/page.tsx
+++ b/apps/web/src/app/university/application/[universityName]/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import TopDetailNavigation from "@/components/layout/TopDetailNavigation";
+import { NO_INDEX_ROBOTS } from "@/utils/seo";
+import ApplicationUniversityDetailContent from "./ApplicationUniversityDetailContent";
+
+type ApplicationUniversityDetailPageProps = {
+  params: Promise<{ universityName: string }>;
+};
+
+export const generateMetadata = async ({ params }: ApplicationUniversityDetailPageProps): Promise<Metadata> => {
+  const { universityName } = await params;
+  const decodedUniversityName = decodeUniversityNameParam(universityName);
+
+  return {
+    title: decodedUniversityName ? `${decodedUniversityName} 지원자 현황` : "지원자 현황 확인",
+    robots: NO_INDEX_ROBOTS,
+  };
+};
+
+const ApplicationUniversityDetailPage = async ({ params }: ApplicationUniversityDetailPageProps) => {
+  const { universityName } = await params;
+  const decodedUniversityName = decodeUniversityNameParam(universityName);
+
+  if (!decodedUniversityName) {
+    notFound();
+  }
+
+  const title = `${decodedUniversityName} 지원자 현황`;
+
+  return (
+    <>
+      <TopDetailNavigation title={title} backHref="/university/application" />
+      <ApplicationUniversityDetailContent universityName={decodedUniversityName} />
+    </>
+  );
+};
+
+const decodeUniversityNameParam = (universityName: string) => {
+  try {
+    return decodeURIComponent(universityName);
+  } catch {
+    return null;
+  }
+};
+
+export default ApplicationUniversityDetailPage;

--- a/apps/web/src/app/university/application/page.tsx
+++ b/apps/web/src/app/university/application/page.tsx
@@ -6,14 +6,14 @@ import { NO_INDEX_ROBOTS } from "@/utils/seo";
 import ScorePageContent from "./ScorePageContent";
 
 export const metadata: Metadata = {
-  title: "점수 공유 현황",
+  title: "지원자 현황 확인",
   robots: NO_INDEX_ROBOTS,
 };
 
 const ScorePage = () => {
   return (
     <>
-      <TopDetailNavigation title="점수 공유 현황" />
+      <TopDetailNavigation title="지원자 현황 확인" />
       <div className="w-full">
         <ScorePageContent />
       </div>

--- a/apps/web/src/constants/university.ts
+++ b/apps/web/src/constants/university.ts
@@ -4,12 +4,13 @@ import {
   type HomeUniversitySlug,
   LanguageTestType,
   RegionEnumExtend,
+  type RegionKo,
   type TestScoreInfo,
 } from "@/types/university";
 
 export const REGIONS_SEARCH = ["유럽권", "미주권", "아시아권", "중국권"] as const;
 
-export const REGIONS_KO = ["유럽권", "미주권", "아시아권", "중국권"];
+export const REGIONS_KO = ["유럽권", "미주권", "아시아권", "중국권"] as const satisfies readonly RegionKo[];
 
 /**
  * 홈 대학교 URL 슬러그 매핑

--- a/apps/web/src/types/application.ts
+++ b/apps/web/src/types/application.ts
@@ -13,11 +13,18 @@ export interface Applicant {
   testType: string;
   testScore: string;
   isMine: boolean;
+  score?: number | null;
+  convertedScore?: number | null;
+  preferenceOrder?: number | null;
 }
 
 export interface ScoreSheet {
+  id?: number;
   koreanName: string;
-  studentCapacity: number;
+  englishName?: string;
+  logoImageUrl?: string;
+  backgroundImageUrl?: string;
+  studentCapacity: number | null;
   region: string;
   country: string;
   applicants: Applicant[];

--- a/apps/web/src/types/university.ts
+++ b/apps/web/src/types/university.ts
@@ -1,4 +1,4 @@
-export type RegionKo = "유럽권" | "미주권" | "아시아권";
+export type RegionKo = "유럽권" | "미주권" | "아시아권" | "중국권";
 
 export enum HomeUniversityName {
   INHA = "인하대학교",

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -30,7 +30,7 @@ const typographyPlugin = plugin(({ addUtilities, theme }) => {
 
 const config: Config = {
   darkMode: ["class"],
-  content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
+  content: ["./src/**/*.{js,ts,jsx,tsx,mdx}", "../../packages/ui/src/**/*.{js,ts,jsx,tsx,mdx}"],
   safelist: [
     "ml-0",
     "ml-12",

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,1 +1,3 @@
 export { cn } from "./cn";
+export type { MobileHeroDetailShellProps, MobileHeroDetailStat } from "./mobile-hero-detail-shell";
+export { MobileHeroDetailShell } from "./mobile-hero-detail-shell";

--- a/packages/ui/src/mobile-hero-detail-shell.tsx
+++ b/packages/ui/src/mobile-hero-detail-shell.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from "react";
+
+export type MobileHeroDetailStat = {
+  key: string;
+  content: ReactNode;
+};
+
+export type MobileHeroDetailShellProps = {
+  background: ReactNode;
+  logo: ReactNode;
+  title: ReactNode;
+  subtitle?: ReactNode;
+  stats?: MobileHeroDetailStat[];
+  leftAction?: ReactNode;
+  rightAction?: ReactNode;
+  children: ReactNode;
+};
+
+export const MobileHeroDetailShell = ({
+  background,
+  logo,
+  title,
+  subtitle,
+  stats = [],
+  leftAction,
+  rightAction,
+  children,
+}: MobileHeroDetailShellProps) => (
+  <div className="relative min-h-screen bg-k-0">
+    <section className="relative h-[236px] overflow-hidden bg-k-100">
+      <div className="absolute inset-0">{background}</div>
+      <div className="absolute inset-0 bg-gradient-to-b from-black/0 via-black/5 to-black/60" />
+      {leftAction || rightAction ? (
+        <div className="absolute left-5 right-5 top-4 z-10 flex items-center justify-between gap-3">
+          <div className="flex min-w-10 items-center justify-start">{leftAction}</div>
+          <div className="flex min-w-10 items-center justify-end">{rightAction}</div>
+        </div>
+      ) : null}
+    </section>
+
+    <main className="relative z-10 -mt-[66px] min-h-[calc(100vh-170px)] rounded-t-[30px] bg-k-0 px-5 pb-20 pt-10">
+      <header className="flex flex-col items-center">
+        <div className="flex max-w-full items-center justify-center gap-2.5">
+          <div className="shrink-0">{logo}</div>
+          <div className="min-w-0">
+            <h1 className="truncate text-k-900 typo-sb-2">{title}</h1>
+            {subtitle ? <p className="mt-0.5 truncate text-k-400 typo-medium-1">{subtitle}</p> : null}
+          </div>
+        </div>
+
+        {stats.length > 0 ? (
+          <dl className="mt-9 flex w-full items-center justify-center divide-x divide-k-100">
+            {stats.map((stat) => (
+              <div key={stat.key} className="flex min-w-0 flex-1 justify-center px-3 text-center text-k-900 typo-sb-9">
+                {stat.content}
+              </div>
+            ))}
+          </dl>
+        ) : null}
+      </header>
+
+      {stats.length > 0 ? <div className="mt-7 h-1 bg-k-50" /> : null}
+      <div>{children}</div>
+    </main>
+  </div>
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,6 +310,9 @@ importers:
       '@solid-connect/ai-inspector':
         specifier: workspace:^
         version: link:../../packages/ai-inspector
+      '@solid-connect/ui':
+        specifier: workspace:^
+        version: link:../../packages/ui
       '@stomp/stompjs':
         specifier: ^7.1.1
         version: 7.2.1


### PR DESCRIPTION
## 관련 이슈

- 없음

## 작업 내용

- 지원자 현황 확인 목록 화면을 Figma flow 1 기준으로 재구성했습니다.
  - 지원한 대학 영역, 성적 공유 참여 배너, 전체/지원자 있는 대학 탭, 권역/학점 필터 칩을 추가했습니다.
  - 대학별 지원자 현황 카드를 펼침/접힘 구조로 정리하고, 상세 페이지로 이동할 수 있게 했습니다.
- 지원자 현황 대학 상세 화면을 Figma flow 2 기준으로 추가했습니다.
  - 대학 상세와 같은 hero/sheet 템플릿 위에 지원자 목록, 지망 순위/학점 정렬, 지원자 성적 카드를 배치했습니다.
- `university-web` 대학 상세와 지원자 현황 상세에서 함께 쓸 수 있도록 `MobileHeroDetailShell`을 `@solid-connect/ui`에 추가했습니다.
- 공통 UI 패키지의 Tailwind 클래스가 누락되지 않도록 `web`, `university-web` Tailwind content/transpile 설정을 보강했습니다.

## 검증

- `git diff --check`
- commit hook CI parity checks 통과
  - `@solid-connect/web` lint, typecheck
  - `@solid-connect/university-web` lint, typecheck
  - `@solid-connect/admin` lint, typecheck
- pre-push hook CI parity checks 통과
  - `@solid-connect/web` lint, typecheck, build
  - `@solid-connect/university-web` lint, typecheck, build
  - `@solid-connect/admin` lint, typecheck, build
- 추가 수동 검증
  - `@solid-connect/ui` lint/typecheck 통과
  - mock API + 실제 로그인 플로우로 `/university/application` 모바일/데스크톱 렌더 확인
  - mock API + 실제 로그인 플로우로 `/university/application/[universityName]` 모바일/데스크톱 렌더 확인
  - `university-web` 대학 상세 모바일/데스크톱 렌더 및 공통 hero sheet 적용 확인

## 참고

- 이 PR은 기존 `feat/desktop-mode-poc` PR(#576)에 섞이지 않도록 해당 브랜치를 base로 둔 stacked PR입니다.
- #576이 먼저 머지되면 base를 `main`으로 변경할 수 있습니다.
- 로컬 Node 버전은 v23.10.0이라 repository engines의 Node 22.x 경고가 출력됩니다.
