### PR TITLE
fix(sign-up): 이메일 회원가입 하단 버튼 정렬 수정

### DIFF
--- a/apps/web/src/app/sign-up/email/EmailSignUpForm.tsx
+++ b/apps/web/src/app/sign-up/email/EmailSignUpForm.tsx
@@ -173,8 +173,8 @@ const EmailSignUpForm = () => {
         </div>
       </div>
 
-      <div className="fixed bottom-14 w-full max-w-app bg-white">
-        <div className="mb-[37px] px-5">
+      <div className="fixed bottom-14 left-0 right-0 w-full bg-white">
+        <div className="mx-auto mb-[37px] w-full max-w-app px-5">
           <BlockBtn onClick={emailSignUp} disabled={!email || !password || !passwordConfirm || !passwordMatch}>
             다음
           </BlockBtn>


### PR DESCRIPTION
## 요약
- 모바일 이메일 회원가입 화면에서 하단 버튼이 오른쪽으로 치우쳐 보이는 문제를 수정했습니다.
- 하단 fixed 영역을 viewport 기준으로 고정하고 내부 컨테이너에서 앱 폭과 좌우 여백을 맞췄습니다.

## 변경 사항
- 이메일 회원가입 하단 버튼 wrapper에 `left-0 right-0`을 적용했습니다.
- 내부 버튼 컨테이너에 `mx-auto w-full max-w-app px-5`를 적용해 기존 앱 레이아웃과 같은 좌우 여백을 유지했습니다.

## 검증
- `pnpm --filter @solid-connect/web run lint`
- `pnpm --filter @solid-connect/web run typecheck`
- pre-push `@solid-connect/web` ci:check 및 build 통과
- 모바일 390px/360px viewport에서 버튼 좌우 여백 확인

## 노트
- 없음