### PR TITLE
fix(sign-up): 이메일 회원가입 폼 접근성 보완

### DIFF
--- a/apps/web/src/app/sign-up/email/EmailSignUpForm.tsx
+++ b/apps/web/src/app/sign-up/email/EmailSignUpForm.tsx
@@ -96,10 +96,13 @@ const EmailSignUpForm = () => {
               이메일
             </Label>
             <Input
+              id="email"
+              name="email"
               variant="gray"
               placeholder="ID@example.com"
               type="email"
               autoComplete="email"
+              spellCheck={false}
               value={email}
               onChange={handleEmailChange}
             />
@@ -112,6 +115,8 @@ const EmailSignUpForm = () => {
                 </Label>
                 <div className="relative">
                   <Input
+                    id="password"
+                    name="password"
                     variant="gray"
                     placeholder="비밀번호를 입력해주세요"
                     type={passwordsVisible ? "text" : "password"}
@@ -121,6 +126,7 @@ const EmailSignUpForm = () => {
                   />
                   <button
                     type="button"
+                    aria-label={passwordsVisible ? "비밀번호 숨기기" : "비밀번호 보기"}
                     onClick={togglePasswordVisibility}
                     className="absolute right-3.5 top-1/2 -translate-y-1/2"
                   >
@@ -135,6 +141,8 @@ const EmailSignUpForm = () => {
                 </Label>
                 <div className="relative">
                   <Input
+                    id="passwordConfirm"
+                    name="passwordConfirm"
                     variant="gray"
                     placeholder="비밀번호를 다시 입력해주세요"
                     type={passwordsVisible ? "text" : "password"}
@@ -144,6 +152,7 @@ const EmailSignUpForm = () => {
                   />
                   <button
                     type="button"
+                    aria-label={passwordsVisible ? "비밀번호 확인 숨기기" : "비밀번호 확인 보기"}
                     onClick={togglePasswordVisibility}
                     className="absolute right-3.5 top-1/2 -translate-y-1/2"
                   >


### PR DESCRIPTION
## 요약
- 이메일 회원가입 폼의 label 연결과 입력 필드 semantics를 보완했습니다.
- 비밀번호 보기/숨기기 아이콘 버튼에 접근 가능한 이름을 추가했습니다.

## 변경 사항
- 이메일, 비밀번호, 비밀번호 확인 input에 `id`와 `name`을 추가했습니다.
- 이메일 input에 `spellCheck={false}`를 추가했습니다.
- 비밀번호 보기/숨기기 버튼에 상태별 `aria-label`을 추가했습니다.

## 검증
- 브라우저 DOM 확인: input label 연결, name, email spellcheck, icon button aria-label 확인
- `/opt/homebrew/bin/pnpm --filter @solid-connect/web run lint`
- `/opt/homebrew/bin/pnpm --filter @solid-connect/web run typecheck`
- pre-push `@solid-connect/web` ci:check 및 build 통과

## 노트
- 하단 버튼 정렬 수정 PR과 분리한 접근성 보완 PR입니다.