### PR TITLE
fix: 프로덕션 색인 대상 정리

### DIFF
--- a/apps/university-web/src/app/sitemap.ts
+++ b/apps/university-web/src/app/sitemap.ts
@@ -22,12 +22,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "weekly",
       priority: 0.8,
     },
-    {
-      url: `${siteUrl}/university/search`,
-      lastModified,
-      changeFrequency: "weekly",
-      priority: 0.6,
-    },
     ...HOME_UNIVERSITY_SLUGS.map((slug) => ({
       url: `${siteUrl}/university/${slug}`,
       lastModified,

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -70,6 +70,20 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
+  async redirects() {
+    return [
+      {
+        source: `/university/list/:homeUniversity${universitySlugPattern}`,
+        destination: "/university/:homeUniversity",
+        permanent: true,
+      },
+      {
+        source: `/university/list/:homeUniversity${universitySlugPattern}/:path*`,
+        destination: "/university/:homeUniversity/:path*",
+        permanent: true,
+      },
+    ];
+  },
   async rewrites() {
     if (!universityWebDomain) {
       return [];
@@ -95,10 +109,6 @@ const nextConfig = {
       {
         source: "/university/search",
         destination: `${universityWebDomain}/university/search`,
-      },
-      {
-        source: `/university/list/:homeUniversity${universitySlugPattern}`,
-        destination: `${universityWebDomain}/university/:homeUniversity`,
       },
       {
         source: `/university/:homeUniversity${universitySlugPattern}`,

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -22,7 +22,6 @@ const toSitemapEntry = (
 const getStaticRoutes = (): MetadataRoute.Sitemap => [
   toSitemapEntry("/", "daily", 1),
   toSitemapEntry("/university", "weekly", 0.85),
-  toSitemapEntry("/university/search", "weekly", 0.6),
   toSitemapEntry("/terms", "yearly", 0.35),
   ...HOME_UNIVERSITY_LIST.map((university) => toSitemapEntry(`/university/${university.slug}`, "weekly", 0.8)),
 ];

--- a/docs/university-multizone-deployment.md
+++ b/docs/university-multizone-deployment.md
@@ -31,7 +31,7 @@
 - `/university/:homeUniversity/:id`
 - `/university-static/*`
 
-`/university/list/:homeUniversity`는 legacy URL로만 취급한다. child route는 유지하지 않고, main rewrite에서 `/university/:homeUniversity` SSG 페이지로 보낸다. 이렇게 하면 오래된 외부 링크는 살리면서 SSG catalog 안에 client-fetch 목록 페이지가 섞이지 않는다.
+`/university/list/:homeUniversity`는 legacy URL로만 취급한다. child route는 유지하지 않고, main redirect에서 `/university/:homeUniversity` SSG 페이지로 보낸다. 이렇게 하면 오래된 외부 링크는 canonical URL로 정리하면서 SSG catalog 안에 client-fetch 목록 페이지가 섞이지 않는다.
 
 ## Vercel 프로젝트 설정
 


### PR DESCRIPTION
## 관련 이슈

- 없음

## 작업 내용

- `noindex`가 적용된 `/university/search`를 web/university-web sitemap에서 제거했습니다.
- legacy `/university/list/:homeUniversity` URL을 rewrite 대신 canonical URL인 `/university/:homeUniversity`로 permanent redirect 처리했습니다.
- university multi-zone 문서의 legacy URL 설명을 redirect 기준으로 갱신했습니다.

## 검증

- `NEXT_PUBLIC_API_SERVER_URL=https://api.solid-connection.com NEXT_PUBLIC_WEB_URL=https://www.solid-connection.com pnpm --filter @solid-connect/university-web run build`
- `UNIVERSITY_WEB_DOMAIN=https://www.solid-connection.com NEXT_PUBLIC_API_SERVER_URL=https://api.solid-connection.com NEXT_PUBLIC_WEB_URL=https://www.solid-connection.com pnpm --filter @solid-connect/web run build`
- `pnpm --filter @solid-connect/web run lint:check`
- `pnpm --filter @solid-connect/web run typecheck:ci`
- `pnpm --filter @solid-connect/university-web run lint:check`
- `pnpm --filter @solid-connect/university-web run typecheck:ci`
- commit/push hook의 CI parity checks 통과

## 특이 사항

- 현재 프로덕션 API 기준 `homeUniversityId=1` 인하대 목록은 0개, `homeUniversityId=2` 경희대 목록은 189개입니다. 따라서 기존 인하대 상세 URL의 404는 데이터 기준으로 사라진 URL이며, 이번 PR은 sitemap/noindex 불일치와 legacy URL 중복 신호를 줄이는 정리입니다.

## 리뷰 요구사항 (선택)

- `/university/list/:homeUniversity/:path*` redirect가 legacy 상세/하위 경로에 기대한 canonical URL을 만드는지 확인 부탁드립니다.