### PR TITLE
design(signup): 가입 준비 단계 정렬 조정

### DIFF
--- a/apps/web/src/app/sign-up/page.tsx
+++ b/apps/web/src/app/sign-up/page.tsx
@@ -15,7 +15,7 @@ const SignUpPage = () => {
   return (
     <>
       <TopDetailNavigation title="회원가입" />
-      <div className="w-full px-5">
+      <div className="w-full">
         <Suspense fallback={<CloudSpinnerPage />}>
           <SignupSurvey baseNickname="" baseEmail="" baseProfileImageUrl="" />
         </Suspense>

--- a/apps/web/src/components/login/signup/SignupPrepareScreen.tsx
+++ b/apps/web/src/components/login/signup/SignupPrepareScreen.tsx
@@ -94,15 +94,18 @@ const PrepareChoiceButton = ({
 }: PrepareChoiceButtonProps) => {
   return (
     <button
-      className={clsx("flex items-center gap-9 rounded-lg py-5 shadow-magic-signup-step", {
-        "border border-primary bg-primary-100": preparation === status,
-        "border border-white bg-white": preparation !== status,
-      })}
+      className={clsx(
+        "flex items-center gap-7 rounded-lg border px-6 py-5 text-left shadow-magic-signup-step focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
+        {
+          "border-primary bg-primary-100": preparation === status,
+          "border-white bg-white": preparation !== status,
+        },
+      )}
       onClick={() => setPreparation(status)}
       type="button"
     >
-      <div className="pl-[2.75rem]">{icon}</div>
-      <div className="flex flex-col items-start">
+      <div className="flex w-16 shrink-0 justify-center">{icon}</div>
+      <div className="flex min-w-0 flex-col items-start">
         <span className="text-k-500 typo-regular-4">{description}</span>
         <span className="text-k-800 typo-sb-4">{name}</span>
       </div>


### PR DESCRIPTION
## 요약
- 회원가입 준비 단계 화면에서 바깥 padding 중복으로 카드 폭 기준이 어긋나 보이던 부분을 정리했습니다.
- 준비 단계 카드의 아이콘 영역을 고정 폭 슬롯으로 맞춰 각 카드의 텍스트 시작점이 동일하게 보이도록 조정했습니다.
- 버튼 focus outline을 primary 색상으로 명시해 선택/포커스 상태가 화면 톤과 맞게 보이도록 했습니다.

## 변경 사항
- `sign-up` 페이지 wrapper의 중복 `px-5` 제거
- 준비 단계 선택 카드의 아이콘 슬롯을 `w-16`으로 고정하고 텍스트 영역을 `min-w-0`로 안정화
- 준비 단계 선택 카드의 focus-visible outline 색상을 primary로 지정

## 검증
- `pnpm --filter @solid-connect/web run ci:check`
- push hook에서 `pnpm run lint:check && pnpm run typecheck:ci`, `next build` 통과
- 로컬 브라우저에서 `/sign-up?token=test` 진입 후 준비 단계 카드 정렬 확인

## 노트

