### PR TITLE
fix: 파견 가능학기 결측값 표시 수정

### DIFF
--- a/apps/university-web/src/app/university/[homeUniversity]/[id]/_ui/UniversityDetail/_ui/InfoSection.tsx
+++ b/apps/university-web/src/app/university/[homeUniversity]/[id]/_ui/UniversityDetail/_ui/InfoSection.tsx
@@ -11,6 +11,16 @@ interface InfoSectionProps {
   detailsForAccommodation: string;
 }
 
+const formatSemesterAvailableForDispatch = (value: string) => {
+  const trimmedValue = value.trim();
+
+  if (!trimmedValue || trimmedValue === "NO_DATA" || trimmedValue === "데이터 없음") {
+    return "-";
+  }
+
+  return trimmedValue;
+};
+
 const InfoSection = ({
   semesterRequirement,
   semesterAvailableForDispatch,
@@ -19,6 +29,7 @@ const InfoSection = ({
 }: InfoSectionProps) => {
   const [detailsForApplyFold, setDetailsForApplyFold] = useState<boolean>(true);
   const [detailsForAccomodationFold, setDetailsForAccommodationFold] = useState<boolean>(true);
+  const semesterAvailableForDispatchLabel = formatSemesterAvailableForDispatch(semesterAvailableForDispatch);
 
   return (
     <div>
@@ -41,7 +52,7 @@ const InfoSection = ({
             <span className="text-k-900 typo-sb-7">파견 가능학기</span>
           </div>
           <div className="flex h-7 w-[50px] items-center justify-center rounded-full bg-k-50">
-            <span className="text-primary typo-sb-10">{semesterAvailableForDispatch}</span>
+            <span className="text-primary typo-sb-10">{semesterAvailableForDispatchLabel}</span>
           </div>
         </div>
         {/* 자격요건 */}


### PR DESCRIPTION
## 관련 이슈

- 없음

## 작업 내용

- 파견 학교 상세의 `파견 가능학기` 값이 없을 때 `데이터 없음` 또는 `NO_DATA`가 그대로 노출되지 않도록 표시값을 정규화했습니다.
- 결측값은 상세 화면에서 `-`로 표시되도록 변경했습니다.

## 검증

- `pnpm --filter @solid-connect/university-web run lint:check`
- `pnpm --filter @solid-connect/university-web run typecheck:ci`
- `NEXT_PUBLIC_API_SERVER_URL=https://api.solid-connection.com NEXT_PUBLIC_WEB_URL=https://www.solid-connection.com pnpm --filter @solid-connect/university-web run build`
- 빌드 산출물에서 `파견 가능학기` 값이 `-`로 표시되는 것 확인
- commit/push hook의 CI parity checks 통과

## 특이 사항

- API/관리자 데이터 값은 변경하지 않고, 사용자 상세 화면의 표시값만 정리했습니다.

## 리뷰 요구사항 (선택)

- 결측값 표시를 `-`로 통일하는 방향이 상세 화면 UX에 적절한지 확인 부탁드립니다.