### PR TITLE
fix: 지원자 현황 카드 토글 영역 수정

### DIFF
--- a/apps/web/src/app/university/application/ScoreSheet.tsx
+++ b/apps/web/src/app/university/application/ScoreSheet.tsx
@@ -65,6 +65,7 @@ export const MobileScoreSheet = ({ scoreSheet, defaultOpen = false, detailHref }
   const [tableOpened, setTableOpened] = useState(defaultOpen);
   const resolvedDetailHref = detailHref ?? getApplicationDetailHref(scoreSheet.koreanName);
   const capacity = getScoreSheetCapacity(scoreSheet);
+  const toggleTableOpened = () => setTableOpened((prev) => !prev);
 
   return (
     <article
@@ -74,14 +75,25 @@ export const MobileScoreSheet = ({ scoreSheet, defaultOpen = false, detailHref }
       )}
     >
       <div
-        className={clsx("flex min-h-11 w-full items-center gap-2.5 px-4", tableOpened ? "bg-secondary-100" : "bg-k-50")}
+        className={clsx(
+          "flex min-h-11 w-full cursor-pointer items-center gap-2.5 px-4",
+          tableOpened ? "bg-secondary-100" : "bg-k-50",
+        )}
+        onClick={toggleTableOpened}
       >
         <span className="size-5 shrink-0 rounded-full bg-white" aria-hidden />
-        <Link href={resolvedDetailHref} className="min-w-0 flex-1 truncate text-k-900 typo-sb-7">
+        <Link
+          href={resolvedDetailHref}
+          className="min-w-0 flex-1 truncate text-k-900 typo-sb-7"
+          onClick={(event) => event.stopPropagation()}
+        >
           {scoreSheet.koreanName} ({scoreSheet.applicants.length}/{capacity})
         </Link>
         <button
-          onClick={() => setTableOpened((prev) => !prev)}
+          onClick={(event) => {
+            event.stopPropagation();
+            toggleTableOpened();
+          }}
           className="flex size-6 shrink-0 items-center justify-center text-k-600"
           type="button"
           aria-label={`${scoreSheet.koreanName} 지원자 목록 ${tableOpened ? "접기" : "펼치기"}`}


### PR DESCRIPTION
## 관련 이슈

- 없음

## 작업 내용

- 지원자 현황 카드 헤더에서 학교명 텍스트만 상세 이동 링크로 동작하도록 유지했습니다.
- 학교명 외 헤더 여백과 화살표 버튼 클릭 시 지원자 목록이 펼침/접힘 처리되도록 수정했습니다.
- 링크와 버튼 클릭이 부모 토글 이벤트와 중복 실행되지 않도록 이벤트 전파를 막았습니다.

## 검증

- `pnpm --filter @solid-connect/web run lint:check`
- `pnpm --filter @solid-connect/web run typecheck:ci`
- push hook의 `@solid-connect/web` CI parity checks 통과

## 특이 사항

- UI 구조 변경 없이 클릭 이벤트 범위만 조정했습니다.

## 리뷰 요구사항 (선택)

- 학교명 텍스트 클릭과 헤더 여백 클릭의 동작이 의도대로 분리됐는지 확인 부탁드립니다.