### PR TITLE
fix: 지원자 현황 대학 수 단위 표시

### DIFF
--- a/apps/web/src/app/university/application/ScorePageContent.tsx
+++ b/apps/web/src/app/university/application/ScorePageContent.tsx
@@ -236,10 +236,10 @@ const ApplicationScopeTabs = ({
 }) => (
   <div className="mt-6 flex h-11 items-start justify-between">
     <ScopeTabButton isActive={scope === "all"} onClick={() => onScopeChange("all")}>
-      모든 대학 ({totalUniversityCount})
+      모든 대학 ({totalUniversityCount}개)
     </ScopeTabButton>
     <ScopeTabButton isActive={scope === "withApplicants"} onClick={() => onScopeChange("withApplicants")}>
-      지원자 있는 대학 ({applicantUniversityCount})
+      지원자 있는 대학 ({applicantUniversityCount}개)
     </ScopeTabButton>
   </div>
 );


### PR DESCRIPTION
## 관련 이슈

- 없음

## 작업 내용

- 지원자 현황 확인 페이지의 탭 카운트가 학교 수임을 명확히 알 수 있도록 `개` 단위를 추가했습니다.
- `모든 대학`, `지원자 있는 대학` 모두 인원수가 아니라 대학 개수 기준임을 UI 문구로 드러냈습니다.

## 특이 사항

- 기능 동작 변경 없이 표시 문구만 수정했습니다.

## 리뷰 요구사항 (선택)

- 탭 카운트 단위가 사용자에게 자연스럽게 읽히는지 확인 부탁드립니다.

## 검증

- `pnpm --filter @solid-connect/web run ci:check`
- push hook: web ci:check 및 build 통과