### PR TITLE
fix: 지원자 현황 지원 대학 표시 수정

### DIFF
--- a/apps/web/src/app/university/application/ScorePageContent.tsx
+++ b/apps/web/src/app/university/application/ScorePageContent.tsx
@@ -8,6 +8,7 @@ import { useGetApplicationsList } from "@/apis/applications";
 import ConfirmCancelModal from "@/components/modal/ConfirmCancelModal";
 import { DEFAULT_MAX_CHOICE_COUNT, getHomeUniversityById, REGIONS_KO } from "@/constants/university";
 import useAuthStore from "@/lib/zustand/useAuthStore";
+import { IconExpandMoreFilled } from "@/public/svgs/community";
 import type { Applicant, ScoreSheet as ScoreSheetType } from "@/types/application";
 import type { RegionKo } from "@/types/university";
 import { getApplicationDetailHref, MobileScoreSheet } from "./ScoreSheet";
@@ -160,7 +161,7 @@ const AppliedUniversitySection = ({
 }) => (
   <section className="mt-5">
     <div className="flex items-center justify-between gap-3">
-      <h1 className="text-k-900 typo-bold-4">지원한 대학({appliedUniversities.length})</h1>
+      <h1 className="text-k-900 typo-bold-4">지원한 대학 ({appliedUniversities.length}개)</h1>
       <button
         type="button"
         onClick={onChangeUniversities}
@@ -202,8 +203,8 @@ const AppliedUniversityRow = ({ preference, scoreSheet }: AppliedUniversity) => 
       <span className="min-w-0 flex-1 truncate text-k-900 typo-sb-7">
         {scoreSheet.koreanName} ({preference}/{capacity})
       </span>
-      <span className="text-k-500" aria-hidden>
-        ˅
+      <span className="flex size-6 shrink-0 items-center justify-center text-k-600" aria-hidden>
+        <IconExpandMoreFilled />
       </span>
     </Link>
   );

--- a/apps/web/src/app/university/application/ScorePageContent.tsx
+++ b/apps/web/src/app/university/application/ScorePageContent.tsx
@@ -11,7 +11,7 @@ import useAuthStore from "@/lib/zustand/useAuthStore";
 import { IconExpandMoreFilled } from "@/public/svgs/community";
 import type { Applicant, ScoreSheet as ScoreSheetType } from "@/types/application";
 import type { RegionKo } from "@/types/university";
-import { getApplicationDetailHref, MobileScoreSheet } from "./ScoreSheet";
+import { getApplicationDetailHref, MobileScoreSheet, ScoreSheetLogo } from "./ScoreSheet";
 
 type ApplicantScope = "all" | "withApplicants";
 type ScoreSort = "applicants" | "gpa";
@@ -199,7 +199,7 @@ const AppliedUniversityRow = ({ preference, scoreSheet }: AppliedUniversity) => 
       href={getApplicationDetailHref(scoreSheet.koreanName)}
       className="flex h-11 items-center gap-2.5 rounded-lg border border-k-50 bg-white px-3.5 shadow-[0_0_10px_rgba(0,0,0,0.05)]"
     >
-      <span className="size-5 shrink-0 rounded-full bg-k-50" aria-hidden />
+      <ScoreSheetLogo scoreSheet={scoreSheet} className="size-5" />
       <span className="min-w-0 flex-1 truncate text-k-900 typo-sb-7">
         {scoreSheet.koreanName} ({preference}/{capacity})
       </span>
@@ -343,7 +343,15 @@ const uniqueScoreSheets = (scoreSheets: ScoreSheetType[]) => {
     const prev = scoreSheetMap.get(key);
     scoreSheetMap.set(
       key,
-      prev ? { ...prev, applicants: mergeApplicants(prev.applicants, scoreSheet.applicants) } : scoreSheet,
+      prev
+        ? {
+            ...prev,
+            englishName: prev.englishName ?? scoreSheet.englishName,
+            logoImageUrl: prev.logoImageUrl ?? scoreSheet.logoImageUrl,
+            backgroundImageUrl: prev.backgroundImageUrl ?? scoreSheet.backgroundImageUrl,
+            applicants: mergeApplicants(prev.applicants, scoreSheet.applicants),
+          }
+        : scoreSheet,
     );
   }
 

--- a/apps/web/src/app/university/application/ScoreSheet.tsx
+++ b/apps/web/src/app/university/application/ScoreSheet.tsx
@@ -3,6 +3,7 @@
 import clsx from "clsx";
 import Link from "next/link";
 import { useState } from "react";
+import Image from "@/components/ui/FallbackImage";
 import { IconExpandMoreFilled } from "@/public/svgs/community";
 import type { Applicant, ScoreSheet as ScoreSheetType } from "@/types/application";
 import { formatLanguageTestScore, isLanguageTestEnum, languageTestMapping } from "@/types/score";
@@ -61,6 +62,26 @@ const getScoreSheetCapacity = (scoreSheet: ScoreSheetType) => {
   return String(scoreSheet.studentCapacity);
 };
 
+export const ScoreSheetLogo = ({
+  scoreSheet,
+  className,
+  size = 20,
+}: {
+  scoreSheet: Pick<ScoreSheetType, "logoImageUrl">;
+  className?: string;
+  size?: number;
+}) => (
+  <Image
+    src={scoreSheet.logoImageUrl ?? ""}
+    alt=""
+    width={size}
+    height={size}
+    className={clsx("shrink-0 rounded-full border border-k-50 bg-white object-cover", className)}
+    fallbackSrc="/svgs/placeholders/university-logo-placeholder.svg"
+    aria-hidden
+  />
+);
+
 export const MobileScoreSheet = ({ scoreSheet, defaultOpen = false, detailHref }: ScoreSheetProps) => {
   const [tableOpened, setTableOpened] = useState(defaultOpen);
   const resolvedDetailHref = detailHref ?? getApplicationDetailHref(scoreSheet.koreanName);
@@ -81,7 +102,7 @@ export const MobileScoreSheet = ({ scoreSheet, defaultOpen = false, detailHref }
         )}
         onClick={toggleTableOpened}
       >
-        <span className="size-5 shrink-0 rounded-full bg-white" aria-hidden />
+        <ScoreSheetLogo scoreSheet={scoreSheet} className="size-5" />
         <Link
           href={resolvedDetailHref}
           className="min-w-0 flex-1 truncate text-k-900 typo-sb-7"

--- a/apps/web/src/app/university/application/[universityName]/ApplicationUniversityDetailContent.tsx
+++ b/apps/web/src/app/university/application/[universityName]/ApplicationUniversityDetailContent.tsx
@@ -234,6 +234,16 @@ const findScoreSheetWithApplicants = (
 
   const baseScoreSheet = matches[0].scoreSheet;
   const applicantMap = new Map<string, Applicant>();
+  const mergedUniversityImages = matches.reduce(
+    (images, { scoreSheet }) => ({
+      logoImageUrl: images.logoImageUrl ?? scoreSheet.logoImageUrl,
+      backgroundImageUrl: images.backgroundImageUrl ?? scoreSheet.backgroundImageUrl,
+    }),
+    {
+      logoImageUrl: baseScoreSheet.logoImageUrl,
+      backgroundImageUrl: baseScoreSheet.backgroundImageUrl,
+    },
+  );
 
   for (const { preferenceOrder, scoreSheet } of matches) {
     for (const applicant of scoreSheet.applicants) {
@@ -249,6 +259,7 @@ const findScoreSheetWithApplicants = (
 
   return {
     ...baseScoreSheet,
+    ...mergedUniversityImages,
     applicants: Array.from(applicantMap.values()),
   };
 };

--- a/apps/web/src/types/application.ts
+++ b/apps/web/src/types/application.ts
@@ -22,8 +22,8 @@ export interface ScoreSheet {
   id?: number;
   koreanName: string;
   englishName?: string;
-  logoImageUrl?: string;
-  backgroundImageUrl?: string;
+  logoImageUrl?: string | null;
+  backgroundImageUrl?: string | null;
   studentCapacity: number | null;
   region: string;
   country: string;


### PR DESCRIPTION
## 관련 이슈

- 없음

## 작업 내용

- 지원자 현황 확인 페이지 상단 문구를 `지원한 대학 ({n}개)` 형식으로 수정했습니다.
- 지원한 대학 카드 우측 꺾새를 문자 표시에서 기존 SVG 아이콘으로 교체해 리스트 카드와 시각적으로 통일했습니다.
- 서버에서 내려주는 대학 `logoImageUrl`을 지원한 대학 카드와 지원자 현황 목록 카드에 표시하도록 반영했습니다.
- 동일 대학 데이터 병합 시 `logoImageUrl`, `backgroundImageUrl`이 누락되지 않도록 보강했습니다.

## 특이 사항

- 기능 동작 변경 없이 UI 표시 문구와 이미지 렌더링만 수정했습니다.
- `/applications` API는 인증이 필요해 비인증 curl에서는 401이 반환됩니다. 현재 프론트 타입에 반영된 `logoImageUrl/backgroundImageUrl` 기준으로 렌더링을 연결했습니다.
- 기존 PR #604가 이미 머지되어, 이번 수정은 별도 브랜치/PR로 분리했습니다.

## 리뷰 요구사항 (선택)

- 지원한 대학 카운트 단위와 카드 우측 아이콘이 디자인 의도와 맞는지 확인 부탁드립니다.
- 지원자 현황 목록에서 대학 로고가 의도한 크기로 보이는지 확인 부탁드립니다.

## 검증

- `pnpm --filter @solid-connect/web exec biome check src/app/university/application/ScoreSheet.tsx src/app/university/application/ScorePageContent.tsx 'src/app/university/application/[universityName]/ApplicationUniversityDetailContent.tsx' src/types/application.ts`
- `pnpm --filter @solid-connect/web run typecheck:ci`
- commit hook: web `ci:check` 통과
- push hook: web `ci:check` 및 `build` 통과