### PR TITLE
fix: 현재 학기 지원대학 없음 문구 수정

### DIFF
--- a/apps/university-web/src/app/university/[homeUniversity]/_ui/UniversityListContent.tsx
+++ b/apps/university-web/src/app/university/[homeUniversity]/_ui/UniversityListContent.tsx
@@ -44,6 +44,20 @@ const REGION_FILTER_ITEMS = [
   { value: RegionEnumExtend.CHINA, label: "중국권" },
 ] as const;
 
+const CurrentTermEmptyState = () => (
+  <div className="flex flex-col items-center justify-center py-20">
+    <p className="text-k-400 typo-medium-3">현재 학기 지원대학이 없습니다.</p>
+    <p className="mt-1 text-k-300 typo-medium-4">지금은 지원을 받는 대학이 없습니다.</p>
+  </div>
+);
+
+const SearchEmptyState = () => (
+  <div className="flex flex-col items-center justify-center py-20">
+    <p className="text-k-400 typo-medium-3">검색 결과가 없습니다.</p>
+    <p className="mt-1 text-k-300 typo-medium-4">다른 검색어나 필터를 시도해보세요.</p>
+  </div>
+);
+
 const UniversityListPrerenderFallback = ({ universities, homeUniversitySlug }: UniversityListContentProps) => (
   <div className="px-5">
     <div className="mb-4 mt-2">
@@ -89,10 +103,7 @@ const UniversityListPrerenderFallback = ({ universities, homeUniversitySlug }: U
     </div>
 
     {universities.length === 0 ? (
-      <div className="flex flex-col items-center justify-center py-20">
-        <p className="text-k-400 typo-medium-3">검색 결과가 없습니다.</p>
-        <p className="mt-1 text-k-300 typo-medium-4">다른 검색어나 필터를 시도해보세요.</p>
-      </div>
+      <CurrentTermEmptyState />
     ) : (
       <UniversityCards colleges={universities} className="mt-3" linkPrefix={`/university/${homeUniversitySlug}`} />
     )}
@@ -166,11 +177,10 @@ const UniversityListContentInner = ({ universities, homeUniversitySlug }: Univer
       </div>
 
       {/* 결과 표시 */}
-      {filteredUniversities.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-20">
-          <p className="text-k-400 typo-medium-3">검색 결과가 없습니다.</p>
-          <p className="mt-1 text-k-300 typo-medium-4">다른 검색어나 필터를 시도해보세요.</p>
-        </div>
+      {universities.length === 0 ? (
+        <CurrentTermEmptyState />
+      ) : filteredUniversities.length === 0 ? (
+        <SearchEmptyState />
       ) : (
         <UniversityCards
           colleges={filteredUniversities}


### PR DESCRIPTION
## 관련 이슈

- 없음

## 작업 내용

- 대학 목록 원본 데이터가 없을 때 `검색 결과가 없습니다` 대신 `현재 학기 지원대학이 없습니다`로 표시되도록 수정했습니다.
- 검색어/필터 적용 결과가 없을 때는 기존 검색 결과 없음 문구를 유지하도록 빈 상태를 분리했습니다.

## 검증

- `pnpm --filter @solid-connect/university-web run lint:check`
- `pnpm --filter @solid-connect/university-web run typecheck:ci`
- push hook의 `@solid-connect/university-web` CI parity checks 통과

## 특이 사항

- 실제 대학 데이터가 없는 상태와 검색/필터 결과가 없는 상태의 문구만 분리했습니다.

## 리뷰 요구사항 (선택)

- 현재 학기 모집 대학이 없는 경우의 빈 상태 문구가 의도와 맞는지 확인 부탁드립니다.