### PR TITLE
fix: 프로필 수정 필드 테두리 제거

### DIFF
--- a/apps/web/src/app/my/modify/_ui/ModifyContent/_ui/InputFiled/index.tsx
+++ b/apps/web/src/app/my/modify/_ui/ModifyContent/_ui/InputFiled/index.tsx
@@ -27,8 +27,8 @@ const InputField = ({ name, label, placeholder }: InputFieldProps) => {
           value={(field.value as string) ?? ""} // undefined일 때 빈 문자열
           placeholder={placeholder}
           className={clsx(
-            "w-full rounded-lg border p-3 pr-12 text-primary placeholder:text-primary-200 focus:border-primary focus:outline-none",
-            error ? "border-red-500" : "border-gray-300",
+            "w-full rounded-lg bg-k-50 p-3 pr-12 text-primary placeholder:text-primary-200 focus:outline-none",
+            error && "border border-red-500",
           )}
         />
       </div>

--- a/apps/web/src/app/my/modify/_ui/ModifyContent/_ui/ReadOnlyField/index.tsx
+++ b/apps/web/src/app/my/modify/_ui/ModifyContent/_ui/ReadOnlyField/index.tsx
@@ -11,7 +11,7 @@ const ReadOnlyField = ({ label, value, placeholder }: ReadOnlyFieldProps) => {
   return (
     <div className="space-y-2">
       <label className="block text-k-700 typo-medium-2">{label}</label>
-      <div className="w-full rounded-lg border border-gray-300 bg-k-50 p-3">
+      <div className="w-full rounded-lg bg-k-50 p-3">
         {/* 읽기 전용 값은 primary-200, 값 없으면 k-400 */}
         <span className={clsx("typo-regular-2", value ? "text-primary-200" : "text-k-400")}>
           {value || placeholder}


### PR DESCRIPTION
## 작업 내용
- 프로필 수정 화면의 닉네임 입력 필드에서 기본 테두리를 제거했습니다.
- 출신학교, 수학 학교, 사용자 유형 필드의 기본 테두리를 제거했습니다.
- Figma 디자인에 맞춰 `k-50` 배경을 유지하고, 입력 오류 시 빨간 테두리는 유지했습니다.

## 검증
- `pnpm --filter @solid-connect/web run ci:check`
- `pnpm --filter @solid-connect/web run build`

## 참고
- 기존 커밋 `e3658b63`을 최신 `main` 위에 단독 체리픽했습니다.
- `main` 대비 커밋 1개, 관련 파일 2개만 포함합니다.