### PR TITLE
chore: websocket-driver 보안 취약점 수정

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5849,8 +5849,8 @@ packages:
       webpack-cli:
         optional: true
 
-  websocket-driver@0.7.4:
-    resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
+  websocket-driver@0.7.5:
+    resolution: {integrity: sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==}
     engines: {node: '>=0.8.0'}
 
   websocket-extensions@0.1.4:
@@ -9392,7 +9392,7 @@ snapshots:
 
   faye-websocket@0.11.4:
     dependencies:
-      websocket-driver: 0.7.4
+      websocket-driver: 0.7.5
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -11334,7 +11334,7 @@ snapshots:
       - postcss
       - uglify-js
 
-  websocket-driver@0.7.4:
+  websocket-driver@0.7.5:
     dependencies:
       http-parser-js: 0.5.10
       safe-buffer: 5.2.1


### PR DESCRIPTION
## 관련 이슈

- Dependabot 보안 경고 #231
- https://github.com/solid-connection/solid-connect-web/security/dependabot/231

## 작업 내용

- 전이 의존성 `websocket-driver`를 취약한 0.7.4에서 패치 버전 0.7.5로 업데이트했습니다.
- 불필요한 의존성 변경 없이 `pnpm-lock.yaml`만 최소 범위로 갱신했습니다.

## 특이 사항

- `pnpm audit --prod=false --audit-level=critical`: 알려진 취약점 없음
- `pnpm typecheck`: 통과
- 커밋 및 푸시 훅의 Web/University Web/Admin CI 동등성 검사와 빌드: 통과

## 리뷰 요구사항 (선택)

- 잠금 파일에서 `websocket-driver` 참조가 모두 0.7.5로 변경되었는지 확인 부탁드립니다.