### PR TITLE
어드민 dev 계정 이메일 판별 규칙 수정

### DIFF
--- a/apps/admin/src/lib/api/auth.test.ts
+++ b/apps/admin/src/lib/api/auth.test.ts
@@ -32,7 +32,7 @@ vi.mock("axios", () => ({
 vi.mock("@/lib/auth/environment", () => ({
 	getApiBaseUrlForEnvironment: (environment: string) =>
 		environment === "dev" ? "https://api.stage.solid-connection.com" : "https://api.solid-connection.com",
-	resolveEnvironmentFromEmail: (email: string) => (email.endsWith("@dev.solid-connection.com") ? "dev" : "prod"),
+	resolveEnvironmentFromEmail: (email: string) => (email === "dev@solid-connection.com" ? "dev" : "prod"),
 }));
 
 vi.mock("@/lib/env", () => ({
@@ -64,13 +64,13 @@ describe("어드민 인증 API", () => {
 	it("어드민 전용 로그인 API를 이메일 환경에 맞춰 호출한다", async () => {
 		post.mockResolvedValue({ data: { accessToken: "access-token" } });
 
-		await adminSignInApi("admin@dev.solid-connection.com", "password");
+		await adminSignInApi("dev@solid-connection.com", "password");
 
 		expect(removeAccessToken).toHaveBeenCalledOnce();
 		expect(saveAdminApiEnvironment).toHaveBeenCalledWith("dev");
 		expect(post).toHaveBeenCalledWith(
 			"/admin/auth/sign-in",
-			{ email: "admin@dev.solid-connection.com", password: "password" },
+			{ email: "dev@solid-connection.com", password: "password" },
 			{ baseURL: "https://api.stage.solid-connection.com" },
 		);
 	});

--- a/apps/admin/src/lib/auth/environment.test.ts
+++ b/apps/admin/src/lib/auth/environment.test.ts
@@ -2,21 +2,21 @@ import { describe, expect, it } from "vitest";
 import { getApiBaseUrlForEnvironment, resolveEnvironmentFromEmail } from "./environment";
 
 describe("resolveEnvironmentFromEmail", () => {
-	it("dev 도메인 이메일은 dev 환경으로 판별한다", () => {
-		expect(resolveEnvironmentFromEmail("admin@dev.solid-connection.com")).toBe("dev");
+	it("dev 계정 이메일(dev@solid-connection.com)은 dev 환경으로 판별한다", () => {
+		expect(resolveEnvironmentFromEmail("dev@solid-connection.com")).toBe("dev");
 	});
 
 	it("대소문자와 앞뒤 공백을 무시하고 판별한다", () => {
-		expect(resolveEnvironmentFromEmail("  Admin@Dev.Solid-Connection.Com  ")).toBe("dev");
+		expect(resolveEnvironmentFromEmail("  Dev@Solid-Connection.Com  ")).toBe("dev");
 	});
 
-	it("dev 도메인이 아닌 이메일은 prod 환경으로 판별한다", () => {
+	it("dev 계정 이메일이 아닌 이메일은 prod 환경으로 판별한다", () => {
 		expect(resolveEnvironmentFromEmail("admin@solid-connection.com")).toBe("prod");
 	});
 
-	it("dev 도메인을 부분 문자열로만 포함하는 이메일은 prod로 판별한다", () => {
-		expect(resolveEnvironmentFromEmail("admin@notdev.solid-connection.com")).toBe("prod");
-		expect(resolveEnvironmentFromEmail("admin@dev.solid-connection.com.evil.com")).toBe("prod");
+	it("로컬파트가 dev로 시작하지만 정확히 일치하지 않는 이메일은 prod로 판별한다", () => {
+		expect(resolveEnvironmentFromEmail("dev2@solid-connection.com")).toBe("prod");
+		expect(resolveEnvironmentFromEmail("dev@notsolid-connection.com")).toBe("prod");
 	});
 });
 

--- a/apps/admin/src/lib/auth/environment.ts
+++ b/apps/admin/src/lib/auth/environment.ts
@@ -1,6 +1,6 @@
 export type AdminApiEnvironment = "dev" | "prod";
 
-const DEV_EMAIL_DOMAIN = "dev.solid-connection.com";
+const DEV_ACCOUNT_EMAIL = "dev@solid-connection.com";
 
 const API_BASE_URLS: Record<AdminApiEnvironment, string> = {
 	dev: "https://api.stage.solid-connection.com",
@@ -9,7 +9,7 @@ const API_BASE_URLS: Record<AdminApiEnvironment, string> = {
 
 export const resolveEnvironmentFromEmail = (email: string): AdminApiEnvironment => {
 	const normalizedEmail = email.trim().toLowerCase();
-	return normalizedEmail.endsWith(`@${DEV_EMAIL_DOMAIN}`) ? "dev" : "prod";
+	return normalizedEmail === DEV_ACCOUNT_EMAIL ? "dev" : "prod";
 };
 
 export const getApiBaseUrlForEnvironment = (environment: AdminApiEnvironment): string => API_BASE_URLS[environment];


### PR DESCRIPTION
## 요약
#615에서 어드민 로그인 계정에 따라 dev/prod API를 런타임 전환하는 기능을 추가하면서, dev 계정 판별 규칙을 `@dev.solid-connection.com` 서브도메인으로 가정하고 구현했습니다. 실제 dev 관리자 계정은 `dev@solid-connection.com`(로컬파트가 정확히 "dev", 도메인은 prod와 동일)이라 패턴이 맞지 않아 dev 계정으로 로그인하면 prod API(`api.solid-connection.com`)로 요청이 가서 401이 발생했습니다.

## 변경
- `resolveEnvironmentFromEmail`을 로컬파트 정확히 `dev` 일치로 수정
- `environment.test.ts`를 실제 이메일 기준으로 갱신
- #613에서 재작성된 `auth.test.ts`의 mock 예시(`@dev.solid-connection.com`)도 실제 이메일로 갱신 (mock이라 테스트 통과에는 영향 없었지만, 잘못된 패턴을 계속 문서화하고 있어 함께 수정)

## Test plan
- [x] `pnpm --filter admin typecheck`
- [x] `pnpm --filter admin lint:check`
- [x] `pnpm --filter admin test` (33 tests passed)
- [x] `pnpm --filter admin build`
- [ ] 실제 dev 계정(dev@solid-connection.com)으로 로그인해 stage API 호출 확인