### PR TITLE
🐛 지원 대학 관리 검색 시 국내 대학/학기 필터 미적용 버그 수정

### DIFF
--- a/apps/admin/src/components/features/univ-apply-infos/tabs/UnivApplyInfoManageTab.tsx
+++ b/apps/admin/src/components/features/univ-apply-infos/tabs/UnivApplyInfoManageTab.tsx
@@ -78,7 +78,12 @@ export function UnivApplyInfoManageTab() {
 
 	const searchResultQuery = useQuery({
 		queryKey: ["univ-apply-infos", "search", committedSearch],
-		queryFn: () => adminApi.searchUnivApplyInfos(committedSearch?.value),
+		queryFn: () =>
+			adminApi.searchUnivApplyInfos({
+				value: committedSearch?.value,
+				homeUniversityId: committedSearch?.homeUniversityId,
+				termId: committedSearch?.termId,
+			}),
 		enabled: committedSearch !== null,
 	});
 
@@ -210,17 +215,7 @@ export function UnivApplyInfoManageTab() {
 		setCreateModal({ open: true });
 	};
 
-	const selectedHomeUniversityName = committedSearch?.homeUniversityId
-		? homeUniversitiesQuery.data?.find((university) => university.id === committedSearch.homeUniversityId)?.name
-		: undefined;
-	const selectedTermLabel = committedSearch?.termId
-		? termsQuery.data?.find((term) => term.id === committedSearch.termId)?.label
-		: undefined;
-	const results = (searchResultQuery.data?.univApplyInfoPreviews ?? []).filter(
-		(item) =>
-			(!committedSearch?.homeUniversityId || item.homeUniversityName === selectedHomeUniversityName) &&
-			(!committedSearch?.termId || item.term === selectedTermLabel),
-	);
+	const results = searchResultQuery.data?.univApplyInfoPreviews ?? [];
 	const isMutating = deleteMutation.isPending || updateMutation.isPending || createMutation.isPending;
 
 	return (

--- a/apps/admin/src/lib/api/admin.ts
+++ b/apps/admin/src/lib/api/admin.ts
@@ -370,10 +370,14 @@ export const adminApi = {
 	deleteUnivApplyInfo: (id: number) =>
 		axiosInstance.delete<void>(`/admin/univ-apply-infos/${id}`).then((res) => res.data),
 
-	searchUnivApplyInfos: (value?: string) =>
+	searchUnivApplyInfos: (params: { value?: string; homeUniversityId?: number; termId?: number }) =>
 		axiosInstance
 			.get<{ univApplyInfoPreviews: UnivApplyInfoSearchResult[] }>("/univ-apply-infos/search/text", {
-				params: { value: value ?? "" },
+				params: {
+					value: params.value ?? "",
+					homeUniversityId: params.homeUniversityId,
+					termId: params.termId,
+				},
 			})
 			.then((res) => res.data),
 };


### PR DESCRIPTION
## 요약
- 어드민 지원 대학 관리 탭에서 국내 대학·학기를 선택해 검색하면, 응답은 정상으로 오지만 화면에는 결과가 표시되지 않는 문제 수정
- `adminApi.searchUnivApplyInfos`가 검색어(`value`)만 서버로 전송하고 `homeUniversityId`/`termId`는 보내지 않아, 서버가 항상 현재 학기 기준으로만 응답하고 있었음
- 응답을 다시 선택한 학기 라벨과 비교해 클라이언트에서 필터링하던 로직 때문에, 현재 학기가 아닌 학기를 선택하면 응답에 데이터가 있어도 전부 걸러져 화면에는 아무것도 안 보였음
- `homeUniversityId`/`termId`를 실제로 서버에 전달하도록 수정하고, 서버가 이미 필터링하므로 불필요해진 클라이언트 측 재필터링 로직 제거

## 테스트 플랜
- [x] `pnpm --filter admin typecheck`, `lint:check` 통과 (커밋 시 CI parity 훅으로 확인)
- [x] 로컬 MySQL/Redis + 백엔드(local 프로필)를 직접 띄우고, 비현재 학기 데이터를 시드한 뒤 API 레벨에서 수정 전/후 동작 차이를 직접 재현·검증함
  - 수정 전 재현(파라미터 미전송): 응답은 정상이지만 항상 현재 학기 데이터만 반환 → 프론트 필터가 이를 전부 걸러내 빈 화면
  - 수정 후(파라미터 전송): 선택한 학기의 데이터가 정확히 반환됨
- [ ] admin 화면에서 직접 클릭 테스트는 못 함 — 로컬 admin dev 서버(vinext)가 이 변경과 무관한 기존 이슈로 dev 모드에서 500 에러를 반환해 실제 화면 확인이 막혀 있었음 (프로덕션 빌드는 정상 완료됨)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01EwpgqdNTrn8dGDr7g7WnYg