### PR TITLE
🔥 릴리즈 승격 워크플로에서 admin 타깃 제거 (admin: main 병합 = 프로덕션 배포)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ on:
         options:
           - all
           - web
-          - admin
           - university
       force_redeploy:
         description: "When up to date, skip divergence and print manual redeploy guidance"
@@ -40,14 +39,11 @@ jobs:
             web)
               TARGETS='["web"]'
               ;;
-            admin)
-              TARGETS='["admin"]'
-              ;;
             university)
               TARGETS='["university"]'
               ;;
             all)
-              TARGETS='["web","admin","university"]'
+              TARGETS='["web","university"]'
               ;;
             *)
               echo "Unsupported target: $TARGET" >&2

--- a/docs/git-cicd.md
+++ b/docs/git-cicd.md
@@ -41,17 +41,17 @@ GitHub Actions, Vercel를 사용하여 CI/CD를 관리합니다.
 
 main 브랜치에 push가 되면 자동으로 CI가 진행되어 stage 환경에 배포됩니다.
 
-Github Actions의 `Promote Main to Release Branches`를 가동시키면 선택한 release branch가 main으로 갱신되고, 각 Vercel Project의 production 환경에 배포됩니다.
+**admin은 main 병합만으로 production이 배포됩니다.** Vercel Admin Project의 production branch가 `main`이며, release branch 승격 단계가 없습니다. admin 앱은 배포가 하나(main)이고, stage/prod API 전환은 앱 내 환경 스위처로 런타임에 처리합니다.
+
+web, university-web은 Github Actions의 `Promote Main to Release Branches`를 가동시키면 선택한 release branch가 main으로 갱신되고, 각 Vercel Project의 production 환경에 배포됩니다.
 
 - `release-web`: web production 배포
-- `release-admin`: admin production 배포
 - `release-university`: university-web production 배포
 
 릴리즈 workflow의 target은 다음과 같이 사용합니다.
 
-- `all`: web, admin, university-web 전체 릴리즈
+- `all`: web, university-web 전체 릴리즈
 - `web`: web만 릴리즈
-- `admin`: admin만 릴리즈
 - `university`: university-web만 릴리즈
 
-기본값은 `all`입니다. 특정 project만 production 릴리즈하려면 `web`, `admin`, `university`를 선택합니다.
+기본값은 `all`입니다. 특정 project만 production 릴리즈하려면 `web`, `university`를 선택합니다.

--- a/docs/university-multizone-deployment.md
+++ b/docs/university-multizone-deployment.md
@@ -69,14 +69,13 @@ University project의 직접 배포 도메인은 검색엔진에 노출하지 �
 production 릴리즈는 GitHub Actions `Promote Main to Release Branches` workflow로 release branch를 갱신해 Vercel 배포를 트리거한다.
 
 - Main Web Project production branch: `release-web`
-- Admin Project production branch: `release-admin`
+- Admin Project production branch: `main` (release 승격 없이 main 병합 시 production 배포)
 - University Web Project production branch: `release-university`
 
 workflow target은 다음과 같이 사용한다.
 
-- `all`: `release-web`, `release-admin`, `release-university`를 모두 main으로 갱신
+- `all`: `release-web`, `release-university`를 모두 main으로 갱신
 - `web`: `release-web`만 main으로 갱신
-- `admin`: `release-admin`만 main으로 갱신
 - `university`: `release-university`만 main으로 갱신
 
 workflow 기본값은 `all`이다. 개별 production 배포가 필요하면 `web`, `admin`, `university`를 선택한다.


### PR DESCRIPTION
## 요약

- `Promote Main to Release Branches` workflow에서 **admin 타깃만 제거**합니다. web/university의 release branch 승격 배포는 그대로 유지됩니다.
- admin은 이제 main 병합만으로 프로덕션이 배포되는 모델로 전환합니다. `release-admin` 승격 단계가 사라집니다.
- `docs/git-cicd.md`, `docs/university-multizone-deployment.md`의 admin 배포 설명을 갱신했습니다.

## 배경

어드민에 API 환경(stage/prod) 런타임 전환이 도입되면서(#615, #616, 후속으로 플로팅 스위처 예정) 어드민을 stage + production 이중으로 관리할 필요가 없어졌습니다. admin 배포를 main 하나로 통합하고, stage/prod API 전환은 앱 안에서 처리합니다.

## 필요한 후속 작업 (Vercel, 저장소 설정)

- [ ] Vercel **Admin Project의 Production Branch를 `release-admin` → `main`으로 변경** (@hanmw110 진행 예정)
- [ ] 전환 확인 후 원격의 `release-admin` 브랜치 정리(선택)

## 특이 사항

- 이 PR 머지 후 Vercel Admin Project의 production branch를 바꾸기 전까지는 `release-admin`이 더 이상 갱신되지 않으므로 **admin 프로덕션 배포 수단이 일시적으로 없습니다.** 머지 직후 Vercel 설정 변경을 권장합니다.
- admin의 HeadVer 태깅/GitHub Release 생성은 승격 workflow 안에 있었으므로 이 PR 이후 admin 자동 태깅이 중단됩니다(web/university 태깅은 유지). `.github/scripts/create-headver-tag.sh`의 admin 분기는 다른 곳에서 재사용될 수 있어 남겨두었습니다.
- web, university-web의 배포 흐름은 변경하지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)