### PR TITLE
✨ 어드민 API 환경(stage/prod) 플로팅 스위처 추가

### DIFF
--- a/apps/admin/src/app/layout.tsx
+++ b/apps/admin/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import "../styles.css";
+import { EnvironmentSwitcherFab } from "@/components/layout/EnvironmentSwitcherFab";
 import { Providers } from "./providers";
 
 export const metadata = {
@@ -11,7 +12,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 	return (
 		<html lang="ko">
 			<body>
-				<Providers>{children}</Providers>
+				<Providers>
+					{children}
+					<EnvironmentSwitcherFab />
+				</Providers>
 			</body>
 		</html>
 	);

--- a/apps/admin/src/components/layout/EnvironmentBanner.tsx
+++ b/apps/admin/src/components/layout/EnvironmentBanner.tsx
@@ -4,16 +4,16 @@ import { useEffect, useState } from "react";
 import { getAdminApiServerUrl } from "@/lib/env";
 import { loadAdminApiEnvironment } from "@/lib/utils/localStorage";
 
-type DisplayedEnvironment = "dev" | "prod" | "local";
+type DisplayedEnvironment = "stage" | "prod" | "local";
 
 const environmentStyles: Record<DisplayedEnvironment, string> = {
-	dev: "bg-magic-success-surface text-magic-success",
+	stage: "bg-magic-success-surface text-magic-success",
 	prod: "bg-magic-danger-surface text-magic-danger",
 	local: "bg-bg-50 text-k-600",
 };
 
 const environmentLabels: Record<DisplayedEnvironment, string> = {
-	dev: "DEV",
+	stage: "STAGE",
 	prod: "PROD",
 	local: "LOCAL",
 };

--- a/apps/admin/src/components/layout/EnvironmentBanner.tsx
+++ b/apps/admin/src/components/layout/EnvironmentBanner.tsx
@@ -1,29 +1,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { getAdminApiServerUrl } from "@/lib/env";
-import { loadAdminApiEnvironment } from "@/lib/utils/localStorage";
-
-type DisplayedEnvironment = "stage" | "prod" | "local";
-
-const environmentStyles: Record<DisplayedEnvironment, string> = {
-	stage: "bg-magic-success-surface text-magic-success",
-	prod: "bg-magic-danger-surface text-magic-danger",
-	local: "bg-bg-50 text-k-600",
-};
-
-const environmentLabels: Record<DisplayedEnvironment, string> = {
-	stage: "STAGE",
-	prod: "PROD",
-	local: "LOCAL",
-};
-
-const resolveDisplayedEnvironment = (): DisplayedEnvironment => {
-	if (import.meta.env.DEV && getAdminApiServerUrl()) {
-		return "local";
-	}
-	return loadAdminApiEnvironment() ?? "prod";
-};
+import {
+	type DisplayedEnvironment,
+	environmentLabels,
+	environmentStyles,
+	resolveDisplayedEnvironment,
+} from "./environmentDisplay";
 
 export function EnvironmentBanner() {
 	const [environment, setEnvironment] = useState<DisplayedEnvironment | null>(null);

--- a/apps/admin/src/components/layout/EnvironmentSwitcherFab.tsx
+++ b/apps/admin/src/components/layout/EnvironmentSwitcherFab.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { AdminApiEnvironment } from "@/lib/auth/environment";
+import { switchAdminApiEnvironment } from "@/lib/auth/session";
+import { getAdminApiServerUrl } from "@/lib/env";
+import { loadAdminApiEnvironment } from "@/lib/utils/localStorage";
+
+type DisplayedEnvironment = AdminApiEnvironment | "local";
+
+const environmentStyles: Record<DisplayedEnvironment, string> = {
+	stage: "bg-magic-success-surface text-magic-success",
+	prod: "bg-magic-danger-surface text-magic-danger",
+	local: "bg-bg-50 text-k-600",
+};
+
+const environmentLabels: Record<DisplayedEnvironment, string> = {
+	stage: "STAGE",
+	prod: "PROD",
+	local: "LOCAL",
+};
+
+const nextEnvironmentOf = (environment: AdminApiEnvironment): AdminApiEnvironment =>
+	environment === "stage" ? "prod" : "stage";
+
+const resolveDisplayedEnvironment = (): DisplayedEnvironment => {
+	if (import.meta.env.DEV && getAdminApiServerUrl()) {
+		return "local";
+	}
+	return loadAdminApiEnvironment() ?? "prod";
+};
+
+export function EnvironmentSwitcherFab() {
+	const [environment, setEnvironment] = useState<DisplayedEnvironment | null>(null);
+
+	useEffect(() => {
+		setEnvironment(resolveDisplayedEnvironment());
+
+		const handleStorageChange = () => setEnvironment(resolveDisplayedEnvironment());
+		window.addEventListener("storage", handleStorageChange);
+		return () => window.removeEventListener("storage", handleStorageChange);
+	}, []);
+
+	if (!environment) {
+		return null;
+	}
+
+	const isLocal = environment === "local";
+
+	const handleClick = () => {
+		if (isLocal) {
+			return;
+		}
+
+		const next = nextEnvironmentOf(environment);
+		const confirmed = window.confirm(`환경을 ${environmentLabels[next]}(으)로 전환하면 로그아웃됩니다. 계속할까요?`);
+		if (!confirmed) {
+			return;
+		}
+
+		switchAdminApiEnvironment(next);
+	};
+
+	return (
+		<button
+			type="button"
+			onClick={handleClick}
+			disabled={isLocal}
+			className={`fixed bottom-6 right-6 z-50 inline-flex items-center gap-1.5 rounded-full px-4 py-2 typo-sb-9 shadow-magic-admin-header transition disabled:cursor-not-allowed disabled:opacity-70 ${environmentStyles[environment]}`}
+		>
+			{environmentLabels[environment]}
+		</button>
+	);
+}

--- a/apps/admin/src/components/layout/EnvironmentSwitcherFab.tsx
+++ b/apps/admin/src/components/layout/EnvironmentSwitcherFab.tsx
@@ -3,32 +3,15 @@
 import { useEffect, useState } from "react";
 import type { AdminApiEnvironment } from "@/lib/auth/environment";
 import { switchAdminApiEnvironment } from "@/lib/auth/session";
-import { getAdminApiServerUrl } from "@/lib/env";
-import { loadAdminApiEnvironment } from "@/lib/utils/localStorage";
-
-type DisplayedEnvironment = AdminApiEnvironment | "local";
-
-const environmentStyles: Record<DisplayedEnvironment, string> = {
-	stage: "bg-magic-success-surface text-magic-success",
-	prod: "bg-magic-danger-surface text-magic-danger",
-	local: "bg-bg-50 text-k-600",
-};
-
-const environmentLabels: Record<DisplayedEnvironment, string> = {
-	stage: "STAGE",
-	prod: "PROD",
-	local: "LOCAL",
-};
+import {
+	type DisplayedEnvironment,
+	environmentLabels,
+	environmentStyles,
+	resolveDisplayedEnvironment,
+} from "./environmentDisplay";
 
 const nextEnvironmentOf = (environment: AdminApiEnvironment): AdminApiEnvironment =>
 	environment === "stage" ? "prod" : "stage";
-
-const resolveDisplayedEnvironment = (): DisplayedEnvironment => {
-	if (import.meta.env.DEV && getAdminApiServerUrl()) {
-		return "local";
-	}
-	return loadAdminApiEnvironment() ?? "prod";
-};
 
 export function EnvironmentSwitcherFab() {
 	const [environment, setEnvironment] = useState<DisplayedEnvironment | null>(null);

--- a/apps/admin/src/components/layout/environmentDisplay.ts
+++ b/apps/admin/src/components/layout/environmentDisplay.ts
@@ -1,0 +1,24 @@
+import type { AdminApiEnvironment } from "@/lib/auth/environment";
+import { getAdminApiServerUrl } from "@/lib/env";
+import { loadAdminApiEnvironment } from "@/lib/utils/localStorage";
+
+export type DisplayedEnvironment = AdminApiEnvironment | "local";
+
+export const environmentStyles: Record<DisplayedEnvironment, string> = {
+	stage: "bg-magic-success-surface text-magic-success",
+	prod: "bg-magic-danger-surface text-magic-danger",
+	local: "bg-bg-50 text-k-600",
+};
+
+export const environmentLabels: Record<DisplayedEnvironment, string> = {
+	stage: "STAGE",
+	prod: "PROD",
+	local: "LOCAL",
+};
+
+export const resolveDisplayedEnvironment = (): DisplayedEnvironment => {
+	if (import.meta.env.DEV && getAdminApiServerUrl()) {
+		return "local";
+	}
+	return loadAdminApiEnvironment() ?? "prod";
+};

--- a/apps/admin/src/lib/api/auth.test.ts
+++ b/apps/admin/src/lib/api/auth.test.ts
@@ -1,38 +1,29 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { create, loadAccessToken, post, removeAccessToken, requestInterceptors, saveAdminApiEnvironment } = vi.hoisted(
-	() => {
-		const hoistedPost = vi.fn();
-		return {
-			create: vi.fn(() => ({
-				post: hoistedPost,
-				interceptors: {
-					request: {
-						use: (fn: (config: Record<string, unknown>) => Record<string, unknown>) => {
-							requestInterceptors.push(fn);
-						},
+const { create, loadAccessToken, post, removeAccessToken, requestInterceptors } = vi.hoisted(() => {
+	const hoistedPost = vi.fn();
+	return {
+		create: vi.fn(() => ({
+			post: hoistedPost,
+			interceptors: {
+				request: {
+					use: (fn: (config: Record<string, unknown>) => Record<string, unknown>) => {
+						requestInterceptors.push(fn);
 					},
 				},
-			})),
-			loadAccessToken: vi.fn(),
-			post: hoistedPost,
-			removeAccessToken: vi.fn(),
-			requestInterceptors: [] as Array<(config: Record<string, unknown>) => Record<string, unknown>>,
-			saveAdminApiEnvironment: vi.fn(),
-		};
-	},
-);
+			},
+		})),
+		loadAccessToken: vi.fn(),
+		post: hoistedPost,
+		removeAccessToken: vi.fn(),
+		requestInterceptors: [] as Array<(config: Record<string, unknown>) => Record<string, unknown>>,
+	};
+});
 
 vi.mock("axios", () => ({
 	default: {
 		create,
 	},
-}));
-
-vi.mock("@/lib/auth/environment", () => ({
-	getApiBaseUrlForEnvironment: (environment: string) =>
-		environment === "dev" ? "https://api.stage.solid-connection.com" : "https://api.solid-connection.com",
-	resolveEnvironmentFromEmail: (email: string) => (email === "dev@solid-connection.com" ? "dev" : "prod"),
 }));
 
 vi.mock("@/lib/env", () => ({
@@ -42,7 +33,6 @@ vi.mock("@/lib/env", () => ({
 vi.mock("@/lib/utils/localStorage", () => ({
 	loadAccessToken,
 	removeAccessToken,
-	saveAdminApiEnvironment,
 }));
 
 import { adminSignInApi, adminSignOutApi, reissueAccessTokenApi } from "./auth";
@@ -52,7 +42,6 @@ describe("어드민 인증 API", () => {
 		loadAccessToken.mockReset();
 		post.mockReset();
 		removeAccessToken.mockReset();
-		saveAdminApiEnvironment.mockReset();
 	});
 
 	it("어드민 refresh token 쿠키를 주고받도록 credentials를 포함한다", () => {
@@ -61,18 +50,16 @@ describe("어드민 인증 API", () => {
 		});
 	});
 
-	it("어드민 전용 로그인 API를 이메일 환경에 맞춰 호출한다", async () => {
+	it("어드민 전용 로그인 API를 호출하고 이전 access token을 정리한다", async () => {
 		post.mockResolvedValue({ data: { accessToken: "access-token" } });
 
-		await adminSignInApi("dev@solid-connection.com", "password");
+		await adminSignInApi("admin@solid-connection.com", "password");
 
 		expect(removeAccessToken).toHaveBeenCalledOnce();
-		expect(saveAdminApiEnvironment).toHaveBeenCalledWith("dev");
-		expect(post).toHaveBeenCalledWith(
-			"/admin/auth/sign-in",
-			{ email: "dev@solid-connection.com", password: "password" },
-			{ baseURL: "https://api.stage.solid-connection.com" },
-		);
+		expect(post).toHaveBeenCalledWith("/admin/auth/sign-in", {
+			email: "admin@solid-connection.com",
+			password: "password",
+		});
 	});
 
 	it("어드민 전용 재발급 API를 호출한다", async () => {

--- a/apps/admin/src/lib/api/auth.ts
+++ b/apps/admin/src/lib/api/auth.ts
@@ -1,7 +1,6 @@
 import axios, { type AxiosResponse } from "axios";
-import { getApiBaseUrlForEnvironment, resolveEnvironmentFromEmail } from "@/lib/auth/environment";
 import { resolveActiveApiBaseUrl } from "@/lib/env";
-import { loadAccessToken, removeAccessToken, saveAdminApiEnvironment } from "@/lib/utils/localStorage";
+import { loadAccessToken, removeAccessToken } from "@/lib/utils/localStorage";
 import type { AdminSignInResponse, ReissueAccessTokenResponse } from "@/types/auth";
 
 const authAxiosInstance = axios.create({
@@ -12,22 +11,14 @@ const ADMIN_AUTH_PATH = "/admin/auth";
 
 authAxiosInstance.interceptors.request.use((config) => {
 	const newConfig = { ...config };
-	// 로그인에서 직접 지정한 baseURL을 우선하고, 나머지 요청은 저장된 어드민 환경을 사용한다.
 	newConfig.baseURL = config.baseURL ?? resolveActiveApiBaseUrl();
 	return newConfig;
 });
 
 export const adminSignInApi = (email: string, password: string): Promise<AxiosResponse<AdminSignInResponse>> => {
-	const environment = resolveEnvironmentFromEmail(email);
-
 	removeAccessToken();
-	saveAdminApiEnvironment(environment);
 
-	return authAxiosInstance.post(
-		`${ADMIN_AUTH_PATH}/sign-in`,
-		{ email, password },
-		{ baseURL: getApiBaseUrlForEnvironment(environment) },
-	);
+	return authAxiosInstance.post(`${ADMIN_AUTH_PATH}/sign-in`, { email, password });
 };
 
 export const reissueAccessTokenApi = (): Promise<AxiosResponse<ReissueAccessTokenResponse>> => {

--- a/apps/admin/src/lib/auth/environment.test.ts
+++ b/apps/admin/src/lib/auth/environment.test.ts
@@ -1,52 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { getApiBaseUrlForEnvironment } from "./environment";
 
 describe("getApiBaseUrlForEnvironment", () => {
 	it("환경에 맞는 API base URL을 반환한다", () => {
 		expect(getApiBaseUrlForEnvironment("stage")).toBe("https://api.stage.solid-connection.com");
 		expect(getApiBaseUrlForEnvironment("prod")).toBe("https://api.solid-connection.com");
-	});
-});
-
-const { removeAccessToken, removeAdminApiEnvironment, saveAdminApiEnvironment } = vi.hoisted(() => ({
-	removeAccessToken: vi.fn(),
-	removeAdminApiEnvironment: vi.fn(),
-	saveAdminApiEnvironment: vi.fn(),
-}));
-
-vi.mock("@/lib/api/auth", () => ({
-	reissueAccessTokenApi: vi.fn(),
-}));
-
-vi.mock("@/lib/utils/localStorage", () => ({
-	loadAccessToken: vi.fn(),
-	removeAccessToken,
-	removeAdminApiEnvironment,
-	saveAccessToken: vi.fn(),
-	saveAdminApiEnvironment,
-}));
-
-describe("switchAdminApiEnvironment", () => {
-	beforeEach(() => {
-		removeAccessToken.mockReset();
-		removeAdminApiEnvironment.mockReset();
-		saveAdminApiEnvironment.mockReset();
-	});
-
-	it("세션(access token, 환경 값)을 모두 지운 뒤 새 환경을 저장한다", async () => {
-		const { switchAdminApiEnvironment } = await import("./session");
-		const redirect = vi.fn();
-		const callOrder: string[] = [];
-
-		removeAdminApiEnvironment.mockImplementation(() => callOrder.push("removeAdminApiEnvironment"));
-		saveAdminApiEnvironment.mockImplementation(() => callOrder.push("saveAdminApiEnvironment"));
-
-		switchAdminApiEnvironment("prod", redirect);
-
-		expect(removeAccessToken).toHaveBeenCalledOnce();
-		expect(removeAdminApiEnvironment).toHaveBeenCalledOnce();
-		expect(saveAdminApiEnvironment).toHaveBeenCalledWith("prod");
-		expect(callOrder).toEqual(["removeAdminApiEnvironment", "saveAdminApiEnvironment"]);
-		expect(redirect).toHaveBeenCalledWith("/auth/login");
 	});
 });

--- a/apps/admin/src/lib/auth/environment.test.ts
+++ b/apps/admin/src/lib/auth/environment.test.ts
@@ -1,28 +1,52 @@
-import { describe, expect, it } from "vitest";
-import { getApiBaseUrlForEnvironment, resolveEnvironmentFromEmail } from "./environment";
-
-describe("resolveEnvironmentFromEmail", () => {
-	it("dev 계정 이메일(dev@solid-connection.com)은 dev 환경으로 판별한다", () => {
-		expect(resolveEnvironmentFromEmail("dev@solid-connection.com")).toBe("dev");
-	});
-
-	it("대소문자와 앞뒤 공백을 무시하고 판별한다", () => {
-		expect(resolveEnvironmentFromEmail("  Dev@Solid-Connection.Com  ")).toBe("dev");
-	});
-
-	it("dev 계정 이메일이 아닌 이메일은 prod 환경으로 판별한다", () => {
-		expect(resolveEnvironmentFromEmail("admin@solid-connection.com")).toBe("prod");
-	});
-
-	it("로컬파트가 dev로 시작하지만 정확히 일치하지 않는 이메일은 prod로 판별한다", () => {
-		expect(resolveEnvironmentFromEmail("dev2@solid-connection.com")).toBe("prod");
-		expect(resolveEnvironmentFromEmail("dev@notsolid-connection.com")).toBe("prod");
-	});
-});
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getApiBaseUrlForEnvironment } from "./environment";
 
 describe("getApiBaseUrlForEnvironment", () => {
 	it("환경에 맞는 API base URL을 반환한다", () => {
-		expect(getApiBaseUrlForEnvironment("dev")).toBe("https://api.stage.solid-connection.com");
+		expect(getApiBaseUrlForEnvironment("stage")).toBe("https://api.stage.solid-connection.com");
 		expect(getApiBaseUrlForEnvironment("prod")).toBe("https://api.solid-connection.com");
+	});
+});
+
+const { removeAccessToken, removeAdminApiEnvironment, saveAdminApiEnvironment } = vi.hoisted(() => ({
+	removeAccessToken: vi.fn(),
+	removeAdminApiEnvironment: vi.fn(),
+	saveAdminApiEnvironment: vi.fn(),
+}));
+
+vi.mock("@/lib/api/auth", () => ({
+	reissueAccessTokenApi: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/localStorage", () => ({
+	loadAccessToken: vi.fn(),
+	removeAccessToken,
+	removeAdminApiEnvironment,
+	saveAccessToken: vi.fn(),
+	saveAdminApiEnvironment,
+}));
+
+describe("switchAdminApiEnvironment", () => {
+	beforeEach(() => {
+		removeAccessToken.mockReset();
+		removeAdminApiEnvironment.mockReset();
+		saveAdminApiEnvironment.mockReset();
+	});
+
+	it("세션(access token, 환경 값)을 모두 지운 뒤 새 환경을 저장한다", async () => {
+		const { switchAdminApiEnvironment } = await import("./session");
+		const redirect = vi.fn();
+		const callOrder: string[] = [];
+
+		removeAdminApiEnvironment.mockImplementation(() => callOrder.push("removeAdminApiEnvironment"));
+		saveAdminApiEnvironment.mockImplementation(() => callOrder.push("saveAdminApiEnvironment"));
+
+		switchAdminApiEnvironment("prod", redirect);
+
+		expect(removeAccessToken).toHaveBeenCalledOnce();
+		expect(removeAdminApiEnvironment).toHaveBeenCalledOnce();
+		expect(saveAdminApiEnvironment).toHaveBeenCalledWith("prod");
+		expect(callOrder).toEqual(["removeAdminApiEnvironment", "saveAdminApiEnvironment"]);
+		expect(redirect).toHaveBeenCalledWith("/auth/login");
 	});
 });

--- a/apps/admin/src/lib/auth/environment.ts
+++ b/apps/admin/src/lib/auth/environment.ts
@@ -1,15 +1,8 @@
-export type AdminApiEnvironment = "dev" | "prod";
-
-const DEV_ACCOUNT_EMAIL = "dev@solid-connection.com";
+export type AdminApiEnvironment = "stage" | "prod";
 
 const API_BASE_URLS: Record<AdminApiEnvironment, string> = {
-	dev: "https://api.stage.solid-connection.com",
+	stage: "https://api.stage.solid-connection.com",
 	prod: "https://api.solid-connection.com",
-};
-
-export const resolveEnvironmentFromEmail = (email: string): AdminApiEnvironment => {
-	const normalizedEmail = email.trim().toLowerCase();
-	return normalizedEmail === DEV_ACCOUNT_EMAIL ? "dev" : "prod";
 };
 
 export const getApiBaseUrlForEnvironment = (environment: AdminApiEnvironment): string => API_BASE_URLS[environment];

--- a/apps/admin/src/lib/auth/session.test.ts
+++ b/apps/admin/src/lib/auth/session.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { removeAccessToken, removeAdminApiEnvironment, saveAdminApiEnvironment } = vi.hoisted(() => ({
+	removeAccessToken: vi.fn(),
+	removeAdminApiEnvironment: vi.fn(),
+	saveAdminApiEnvironment: vi.fn(),
+}));
+
+vi.mock("@/lib/api/auth", () => ({
+	reissueAccessTokenApi: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/localStorage", () => ({
+	loadAccessToken: vi.fn(),
+	removeAccessToken,
+	removeAdminApiEnvironment,
+	saveAccessToken: vi.fn(),
+	saveAdminApiEnvironment,
+}));
+
+describe("switchAdminApiEnvironment", () => {
+	beforeEach(() => {
+		removeAccessToken.mockReset();
+		removeAdminApiEnvironment.mockReset();
+		saveAdminApiEnvironment.mockReset();
+	});
+
+	it("세션(access token, 환경 값)을 모두 지운 뒤 새 환경을 저장한다", async () => {
+		const { switchAdminApiEnvironment } = await import("./session");
+		const redirect = vi.fn();
+		const callOrder: string[] = [];
+
+		removeAdminApiEnvironment.mockImplementation(() => callOrder.push("removeAdminApiEnvironment"));
+		saveAdminApiEnvironment.mockImplementation(() => callOrder.push("saveAdminApiEnvironment"));
+
+		switchAdminApiEnvironment("prod", redirect);
+
+		expect(removeAccessToken).toHaveBeenCalledOnce();
+		expect(removeAdminApiEnvironment).toHaveBeenCalledOnce();
+		expect(saveAdminApiEnvironment).toHaveBeenCalledWith("prod");
+		expect(callOrder).toEqual(["removeAdminApiEnvironment", "saveAdminApiEnvironment"]);
+		expect(redirect).toHaveBeenCalledWith("/auth/login");
+	});
+});

--- a/apps/admin/src/lib/auth/session.ts
+++ b/apps/admin/src/lib/auth/session.ts
@@ -1,10 +1,12 @@
 import { reissueAccessTokenApi } from "@/lib/api/auth";
+import type { AdminApiEnvironment } from "@/lib/auth/environment";
 import { isTokenExpired } from "@/lib/utils/jwtUtils";
 import {
 	loadAccessToken,
 	removeAccessToken,
 	removeAdminApiEnvironment,
 	saveAccessToken,
+	saveAdminApiEnvironment,
 } from "@/lib/utils/localStorage";
 
 let reissuePromise: Promise<string | null> | null = null;
@@ -29,6 +31,23 @@ export const clearSession = () => {
 	reissuePromise = null;
 	removeAccessToken();
 	removeAdminApiEnvironment();
+};
+
+/**
+ * 어드민 API 환경(stage/prod)을 전환한다. clearSession()이 환경 저장 키까지 함께 지우므로,
+ * 반드시 clearSession → saveAdminApiEnvironment 순서로 처리해야 새 환경 값이 유지된다.
+ * 이후 react-query 캐시 등 메모리 상태를 확실히 비우기 위해 전체 페이지 이동으로 리다이렉트한다.
+ * redirect는 테스트에서 주입할 수 있도록 매개변수로 분리했다.
+ */
+export const switchAdminApiEnvironment = (
+	next: AdminApiEnvironment,
+	redirect: (url: string) => void = (url) => {
+		window.location.href = url;
+	},
+) => {
+	clearSession();
+	saveAdminApiEnvironment(next);
+	redirect("/auth/login");
 };
 
 export const reissueAccessTokenIfPossible = async (): Promise<string | null> => {

--- a/apps/admin/src/lib/env.ts
+++ b/apps/admin/src/lib/env.ts
@@ -4,12 +4,13 @@ import { loadAdminApiEnvironment } from "@/lib/utils/localStorage";
 const getTrimmedEnv = (key: string) => import.meta.env[key]?.trim() ?? "";
 
 // Local-dev-only override (e.g. http://localhost:8080). When unset, the API server
-// is resolved at runtime from the signed-in account's environment (see resolveActiveApiBaseUrl).
+// is resolved at runtime from the environment stored via the environment switcher FAB
+// (see resolveActiveApiBaseUrl).
 export const getAdminApiServerUrl = () => getTrimmedEnv("VITE_API_SERVER_URL");
 
 export const resolveActiveApiBaseUrl = (): string => {
 	// The override only applies to `vinext dev` (import.meta.env.DEV). Deployed builds
-	// (Preview/Production) always resolve dev/prod from the signed-in account's email,
+	// (Preview/Production) always resolve stage/prod from the stored environment selection,
 	// regardless of whether VITE_API_SERVER_URL happens to still be set on Vercel.
 	const localOverride = import.meta.env.DEV ? getAdminApiServerUrl() : "";
 	if (localOverride) {

--- a/apps/admin/src/lib/utils/localStorage.test.ts
+++ b/apps/admin/src/lib/utils/localStorage.test.ts
@@ -1,8 +1,16 @@
 import { afterEach, describe, expect, it } from "vitest";
 
-import { loadAccessToken, removeAccessToken, saveAccessToken } from "./localStorage";
+import {
+	loadAccessToken,
+	loadAdminApiEnvironment,
+	removeAccessToken,
+	removeAdminApiEnvironment,
+	saveAccessToken,
+	saveAdminApiEnvironment,
+} from "./localStorage";
 
 const ADMIN_ACCESS_TOKEN_KEY = "adminAccessToken";
+const ADMIN_API_ENVIRONMENT_KEY = "adminApiEnvironment";
 
 describe("어드민 access token localStorage 저장", () => {
 	afterEach(() => {
@@ -33,5 +41,37 @@ describe("어드민 access token localStorage 저장", () => {
 		saveAccessToken("access-token");
 
 		expect(localStorage.getItem("accessToken")).toBeNull();
+	});
+});
+
+describe("어드민 API 환경 localStorage 저장", () => {
+	afterEach(() => {
+		localStorage.clear();
+	});
+
+	it("환경 값을 저장하고 조회한다", () => {
+		saveAdminApiEnvironment("prod");
+
+		expect(loadAdminApiEnvironment()).toBe("prod");
+	});
+
+	it("환경 값을 제거한다", () => {
+		saveAdminApiEnvironment("stage");
+
+		removeAdminApiEnvironment();
+
+		expect(loadAdminApiEnvironment()).toBeNull();
+	});
+
+	it("레거시 값 'dev'는 'stage'로 해석한다", () => {
+		localStorage.setItem(ADMIN_API_ENVIRONMENT_KEY, "dev");
+
+		expect(loadAdminApiEnvironment()).toBe("stage");
+	});
+
+	it("알 수 없는 값은 null을 반환한다", () => {
+		localStorage.setItem(ADMIN_API_ENVIRONMENT_KEY, "unknown");
+
+		expect(loadAdminApiEnvironment()).toBeNull();
 	});
 });

--- a/apps/admin/src/lib/utils/localStorage.ts
+++ b/apps/admin/src/lib/utils/localStorage.ts
@@ -35,7 +35,11 @@ export const loadAdminApiEnvironment = (): AdminApiEnvironment | null => {
 
 	try {
 		const value = localStorage.getItem(ADMIN_API_ENVIRONMENT_KEY);
-		return value === "dev" || value === "prod" ? value : null;
+		// 레거시 값("dev")으로 저장된 기존 사용자의 선택을 보존하기 위해 stage로 해석한다.
+		if (value === "dev") {
+			return "stage";
+		}
+		return value === "stage" || value === "prod" ? value : null;
 	} catch (err) {
 		console.error("Could not load admin api environment", err);
 		return null;


### PR DESCRIPTION
## 요약

이메일 기반 환경 판별 로직(#615, #616)을 제거하고, 우하단 플로팅 버튼으로 어드민이 stage/prod API 환경을 명시적으로 전환할 수 있도록 했습니다. 어드민 배포를 main 브랜치 하나로 통합하는 작업(#618)의 후속입니다.

관련 이슈: #615, #616, #618

## 동작 방식

- 플로팅 버튼(FAB) 클릭 → `confirm` 다이얼로그로 재확인 → 세션 초기화 후 새 환경 값 저장 → `/auth/login`으로 전체 페이지 이동 (react-query 캐시 등 메모리 상태를 확실히 비우기 위한 하드 리다이렉트)
- 로그인 페이지의 `ensureSessionToken()`이 새로 저장된 환경 기준으로 reissue를 시도합니다. 해당 환경에 유효한 refresh 쿠키가 있으면 자동 로그인되고, 없으면 로그인 폼이 표시됩니다.
- 환경 네이밍을 `dev` → `stage`로 전환했습니다. 레거시로 저장돼 있던 `"dev"` 값은 `"stage"`로 해석하여 하위 호환을 유지합니다.
- `VITE_API_SERVER_URL`로 로컬 오버라이드가 설정된 경우 FAB은 `LOCAL` 표시와 함께 비활성화됩니다(전환 불가).

## 행동 변화 (주의)

기존에는 로그인 이메일이 dev 계정 패턴이면 자동으로 stage API로 라우팅됐지만, 이제는 그렇지 않습니다. **로그인 전에 FAB으로 원하는 환경을 먼저 선택**해야 합니다. 기본값은 PROD입니다.

## 리뷰 반영 (2차 커밋)

- `EnvironmentBanner.tsx`와 `EnvironmentSwitcherFab.tsx`에 복붙돼 있던 `environmentStyles`/`environmentLabels`/`resolveDisplayedEnvironment`/`DisplayedEnvironment` 타입을 `apps/admin/src/components/layout/environmentDisplay.ts` 공용 모듈로 추출하여 드리프트 위험 제거 (렌더 결과 동일)
- `environment.test.ts`에 섞여 있던 `switchAdminApiEnvironment` 테스트(대상: `./session`)를 `session.test.ts`로 분리, `environment.test.ts`에는 `getApiBaseUrlForEnvironment` 테스트만 남기고 불필요해진 mock/hoisted 선언 정리

## 실사용 버그 수정 (3차 커밋)

STAGE로 전환 후 로그인하면 요청이 여전히 prod(`https://api.solid-connection.com/admin/auth/sign-in`)로 나가는 문제가 실사용 중 발견되어 수정했습니다.

**재현 순서**
1. FAB으로 STAGE 전환: `clearSession()` → `saveAdminApiEnvironment("stage")` → `/auth/login` 이동 (여기까지는 정상)
2. `/auth/login` 마운트 시 `ensureSessionToken()`이 자동 실행되어 reissue를 시도 (stage로 정상 요청)
3. stage에는 아직 refresh 쿠키가 없어 reissue 실패 → `reissueAccessTokenIfPossible`의 catch가 `clearSession()`을 호출 → 이 안에 있던 `removeAdminApiEnvironment()`가 방금 저장한 `"stage"` 값을 지워버림
4. 로그인 시 `resolveActiveApiBaseUrl()`이 저장값을 못 찾고 prod로 폴백 → prod로 로그인 요청이 나감

**근본 원인**: `clearSession()`이 환경 저장 키까지 함께 지우는 동작은 환경이 로그인 이메일에서 파생되던 #615 시절의 잔재였습니다. 지금은 환경이 FAB으로 관리하는 독립적인 사용자 선택이므로, 로그아웃/401/reissue 실패 등 세션 정리 경로에서도 살아남아야 합니다.

**수정 내용**
- `apps/admin/src/lib/auth/session.ts`: `clearSession()`에서 `removeAdminApiEnvironment()` 호출 제거(관련 import 정리). 이제 세션 정리는 access token만 지우고 환경 선택은 건드리지 않습니다. `switchAdminApiEnvironment`의 JSDoc도 더 이상 사실이 아닌 "clearSession이 환경 키까지 지우므로 순서가 중요하다"는 설명을 제거하고 실제 동작만 남겼습니다.
- `apps/admin/src/lib/utils/localStorage.ts`: 더 이상 쓰이지 않는 `removeAdminApiEnvironment` 함수 자체를 삭제.
- `apps/admin/src/lib/auth/session.test.ts`: 기존 순서 검증 테스트를 걷어내고, **"저장된 어드민 API 환경 값은 clearSession() 이후에도 유지된다"**는 회귀 테스트를 추가(실제 jsdom localStorage로 검증).
- `apps/admin/src/lib/utils/localStorage.test.ts`: 삭제된 `removeAdminApiEnvironment` 관련 테스트 제거.

## 검증

```
$ pnpm --filter @solid-connect/admin test
 Test Files  9 passed (9)
      Tests  34 passed (34)

$ pnpm --filter @solid-connect/admin ci:check
Checked 77 files in 147ms. No fixes applied.   # biome check
tsc --noEmit                                    # 통과 (에러 없음)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
