### PR TITLE
🐛 세션 정리 시 어드민 API 환경 선택이 초기화되는 문제 수정

### DIFF
--- a/apps/admin/src/lib/auth/session.test.ts
+++ b/apps/admin/src/lib/auth/session.test.ts
@@ -1,44 +1,59 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { removeAccessToken, removeAdminApiEnvironment, saveAdminApiEnvironment } = vi.hoisted(() => ({
+const { removeAccessToken } = vi.hoisted(() => ({
 	removeAccessToken: vi.fn(),
-	removeAdminApiEnvironment: vi.fn(),
-	saveAdminApiEnvironment: vi.fn(),
 }));
 
 vi.mock("@/lib/api/auth", () => ({
 	reissueAccessTokenApi: vi.fn(),
 }));
 
-vi.mock("@/lib/utils/localStorage", () => ({
-	loadAccessToken: vi.fn(),
-	removeAccessToken,
-	removeAdminApiEnvironment,
-	saveAccessToken: vi.fn(),
-	saveAdminApiEnvironment,
-}));
+// 환경(stage/prod) 저장·조회 함수는 실제 구현(jsdom localStorage)을 그대로 사용해,
+// clearSession()이 저장된 환경 값을 건드리지 않는지 회귀 테스트로 검증한다.
+vi.mock("@/lib/utils/localStorage", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/lib/utils/localStorage")>();
+	return {
+		...actual,
+		loadAccessToken: vi.fn(),
+		removeAccessToken,
+		saveAccessToken: vi.fn(),
+	};
+});
 
 describe("switchAdminApiEnvironment", () => {
 	beforeEach(() => {
 		removeAccessToken.mockReset();
-		removeAdminApiEnvironment.mockReset();
-		saveAdminApiEnvironment.mockReset();
+		localStorage.clear();
 	});
 
-	it("세션(access token, 환경 값)을 모두 지운 뒤 새 환경을 저장한다", async () => {
+	it("access token을 지운 뒤 새 환경을 저장하고 로그인 페이지로 리다이렉트한다", async () => {
 		const { switchAdminApiEnvironment } = await import("./session");
+		const { loadAdminApiEnvironment } = await import("@/lib/utils/localStorage");
 		const redirect = vi.fn();
-		const callOrder: string[] = [];
-
-		removeAdminApiEnvironment.mockImplementation(() => callOrder.push("removeAdminApiEnvironment"));
-		saveAdminApiEnvironment.mockImplementation(() => callOrder.push("saveAdminApiEnvironment"));
 
 		switchAdminApiEnvironment("prod", redirect);
 
 		expect(removeAccessToken).toHaveBeenCalledOnce();
-		expect(removeAdminApiEnvironment).toHaveBeenCalledOnce();
-		expect(saveAdminApiEnvironment).toHaveBeenCalledWith("prod");
-		expect(callOrder).toEqual(["removeAdminApiEnvironment", "saveAdminApiEnvironment"]);
+		expect(loadAdminApiEnvironment()).toBe("prod");
 		expect(redirect).toHaveBeenCalledWith("/auth/login");
+	});
+});
+
+describe("clearSession", () => {
+	beforeEach(() => {
+		removeAccessToken.mockReset();
+		localStorage.clear();
+	});
+
+	it("access token은 지우지만 저장된 어드민 API 환경 값은 유지한다 (회귀 테스트)", async () => {
+		const { clearSession } = await import("./session");
+		const { loadAdminApiEnvironment, saveAdminApiEnvironment } = await import("@/lib/utils/localStorage");
+
+		saveAdminApiEnvironment("stage");
+
+		clearSession();
+
+		expect(removeAccessToken).toHaveBeenCalledOnce();
+		expect(loadAdminApiEnvironment()).toBe("stage");
 	});
 });

--- a/apps/admin/src/lib/auth/session.ts
+++ b/apps/admin/src/lib/auth/session.ts
@@ -1,13 +1,7 @@
 import { reissueAccessTokenApi } from "@/lib/api/auth";
 import type { AdminApiEnvironment } from "@/lib/auth/environment";
 import { isTokenExpired } from "@/lib/utils/jwtUtils";
-import {
-	loadAccessToken,
-	removeAccessToken,
-	removeAdminApiEnvironment,
-	saveAccessToken,
-	saveAdminApiEnvironment,
-} from "@/lib/utils/localStorage";
+import { loadAccessToken, removeAccessToken, saveAccessToken, saveAdminApiEnvironment } from "@/lib/utils/localStorage";
 
 let reissuePromise: Promise<string | null> | null = null;
 let sessionVersion = 0;
@@ -30,13 +24,11 @@ export const clearSession = () => {
 	sessionVersion += 1;
 	reissuePromise = null;
 	removeAccessToken();
-	removeAdminApiEnvironment();
 };
 
 /**
- * 어드민 API 환경(stage/prod)을 전환한다. clearSession()이 환경 저장 키까지 함께 지우므로,
- * 반드시 clearSession → saveAdminApiEnvironment 순서로 처리해야 새 환경 값이 유지된다.
- * 이후 react-query 캐시 등 메모리 상태를 확실히 비우기 위해 전체 페이지 이동으로 리다이렉트한다.
+ * 어드민 API 환경(stage/prod)을 전환한다. 세션(access token)을 정리한 뒤 새 환경 값을 저장하고,
+ * react-query 캐시 등 메모리 상태를 확실히 비우기 위해 전체 페이지 이동으로 리다이렉트한다.
  * redirect는 테스트에서 주입할 수 있도록 매개변수로 분리했다.
  */
 export const switchAdminApiEnvironment = (

--- a/apps/admin/src/lib/utils/localStorage.test.ts
+++ b/apps/admin/src/lib/utils/localStorage.test.ts
@@ -4,7 +4,6 @@ import {
 	loadAccessToken,
 	loadAdminApiEnvironment,
 	removeAccessToken,
-	removeAdminApiEnvironment,
 	saveAccessToken,
 	saveAdminApiEnvironment,
 } from "./localStorage";
@@ -53,14 +52,6 @@ describe("어드민 API 환경 localStorage 저장", () => {
 		saveAdminApiEnvironment("prod");
 
 		expect(loadAdminApiEnvironment()).toBe("prod");
-	});
-
-	it("환경 값을 제거한다", () => {
-		saveAdminApiEnvironment("stage");
-
-		removeAdminApiEnvironment();
-
-		expect(loadAdminApiEnvironment()).toBeNull();
 	});
 
 	it("레거시 값 'dev'는 'stage'로 해석한다", () => {

--- a/apps/admin/src/lib/utils/localStorage.ts
+++ b/apps/admin/src/lib/utils/localStorage.ts
@@ -53,11 +53,3 @@ export const saveAdminApiEnvironment = (environment: AdminApiEnvironment) => {
 		console.error("Could not save admin api environment", err);
 	}
 };
-
-export const removeAdminApiEnvironment = () => {
-	try {
-		localStorage.removeItem(ADMIN_API_ENVIRONMENT_KEY);
-	} catch (err) {
-		console.error("Could not remove admin api environment", err);
-	}
-};


### PR DESCRIPTION
## 배경

#619(어드민 API 환경 stage/prod 플로팅 스위처)가 이 버그 수정 없이 먼저 머지되어, 아래 문제가 아직 main에 남아 있습니다. 이 PR은 그 수정만 담아 별도로 올립니다.

## 문제

`admins.solid-connection.com`에서 FAB으로 STAGE로 전환한 뒤 로그인해도, 실제 요청은 `https://api.solid-connection.com/admin/auth/sign-in`(PROD)으로 나갑니다.

## 원인

1. FAB 전환: `clearSession()` → `saveAdminApiEnvironment("stage")` → `/auth/login`으로 이동 (여기까지는 `"stage"` 저장 정상)
2. `/auth/login` 마운트 시 `ensureSessionToken()`이 자동 실행되어 access token 재발급을 시도 (stage로 정상 요청)
3. STAGE 계정에 아직 유효한 refresh 쿠키가 없으면 재발급 실패 → `reissueAccessTokenIfPossible`의 catch가 `clearSession()`을 호출
4. `clearSession()` 안의 `removeAdminApiEnvironment()`가 방금 저장한 `"stage"` 값을 지움
5. 로그인 폼 제출 시 `resolveActiveApiBaseUrl()`이 저장값 없음 → 기본값 `"prod"`로 폴백 → PROD로 로그인 요청

즉 STAGE에 유효한 refresh 쿠키가 있으면(과거 로그인 이력) 3~5단계 없이 자동 로그인되어 버그가 드러나지 않고, **STAGE를 처음 쓰거나 쿠키가 만료된 경우에만** PROD로 새는 형태였습니다.

근본 원인은 `clearSession()`이 환경 키까지 지우는 로직이 이메일 기반 환경 판별(#615) 시절의 잔재라는 점입니다. 이제 환경은 FAB이 관리하는 독립적인 사용자 선택이므로, 로그아웃/재발급 실패/401 등 세션 정리 경로에서 살아남아야 합니다.

## 수정

- `clearSession()`에서 `removeAdminApiEnvironment()` 호출 제거 — access token만 정리하고 환경 선택은 그대로 유지합니다.
- 사용처가 없어진 `removeAdminApiEnvironment` 함수를 `localStorage.ts`에서 삭제했습니다.
- `switchAdminApiEnvironment`의 JSDoc에서 더 이상 사실이 아닌 "clearSession이 환경 키까지 지우므로 순서가 중요하다"는 설명을 제거했습니다.
- 회귀 테스트 추가: "환경 저장 → `clearSession()` → `loadAdminApiEnvironment()`가 여전히 해당 환경을 반환"을 실제 jsdom `localStorage`로 검증합니다(mock 아님).

## 검증

- `pnpm --filter @solid-connect/admin test` → 34 tests passed
- `pnpm --filter @solid-connect/admin ci:check` → biome 77 files 통과, `tsc --noEmit` 클린

🤖 Generated with [Claude Code](https://claude.com/claude-code)