### PR TITLE
🐛 중앙대 슬러그가 university-web으로 rewrite되지 않던 문제 수정

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -21,7 +21,20 @@ const imageRemotePatterns = [
 
 const universityWebDomain = process.env.UNIVERSITY_WEB_DOMAIN?.replace(/\/$/, "");
 const isProductionRuntime = process.env.NODE_ENV === "production";
-const universitySlugPattern = "(inha|kyunghee)";
+
+/**
+ * `/university/:homeUniversity` 를 university-web 으로 넘길 홈 대학 슬러그 목록.
+ *
+ * 여기에 없는 슬러그는 rewrite 되지 않고 apps/web 으로 떨어져 404 가 된다.
+ * `/university/score/*`, `/university/application/*` 는 apps/web 소유이므로
+ * 와일드카드 대신 allowlist 를 유지한다.
+ *
+ * 홈 대학을 추가할 때는 `apps/university-web/src/constants/university.ts` 의
+ * `HOME_UNIVERSITY_SLUGS` 와 **이 목록을 함께** 갱신해야 한다.
+ * (next.config 는 .mjs 라 TS 상수를 직접 import 할 수 없어 수동 동기화가 필요하다.)
+ */
+const UNIVERSITY_SLUGS = ["inha", "kyunghee", "chungang"];
+const universitySlugPattern = `(${UNIVERSITY_SLUGS.join("|")})`;
 
 if (isProductionRuntime && !universityWebDomain) {
   throw new Error("UNIVERSITY_WEB_DOMAIN is required because /university catalog routes are served by university-web.");


### PR DESCRIPTION
## 문제

https://www.solid-connection.com/university/chungang 이 404를 반환합니다.

```
/university/inha     -> 200
/university/kyunghee -> 200
/university/chungang -> 404
```

## 원인

`apps/web/next.config.mjs`의 멀티존 rewrite 슬러그가 하드코딩되어 있었습니다.

```js
const universitySlugPattern = "(inha|kyunghee)";
```

이 패턴이 `/university/:homeUniversity` 요청을 university-web으로 넘길지 결정합니다. `chungang`이 목록에 없어 rewrite가 걸리지 않고, 해당 라우트가 없는 `apps/web`으로 떨어져 404가 났습니다.

**#622(중앙대 추가)에서 놓친 두 번째 등록 지점입니다.** 홈 대학은 `apps/university-web`의 상수와 이 rewrite 패턴 **두 곳**에 등록되어야 하는데, 전자만 반영했습니다.

## 수정

슬러그 목록을 배열로 분리하고 `chungang`을 추가했습니다. 두 곳을 함께 갱신해야 한다는 점을 주석으로 명시했습니다.

`/university/score/*`, `/university/application/*`는 `apps/web` 소유이므로 와일드카드 대신 allowlist 구조를 유지했습니다. 실제로 생성되는 패턴을 확인했습니다.

| 세그먼트 | 처리 |
|---|---|
| `inha` / `kyunghee` / `chungang` | university-web으로 rewrite |
| `score` / `application` | apps/web 유지 |

## 배포 순서 (중요)

이 PR 머지만으로는 사이트가 고쳐지지 않습니다.

- `release-university` — main과 동일, 중앙대 포함 ✅ (university-web 쪽은 이미 준비 완료)
- `release-web` — **main보다 15커밋 뒤처짐**. rewrite를 소유한 앱이라 이 브랜치가 갱신되어야 반영됩니다.

머지 후 **`Promote Main to Release Branches` workflow를 `web` 타깃으로 실행**해야 `/university/chungang`이 열립니다.

## 검증

- `pnpm --filter @solid-connect/web run lint:check` — 통과 (university-zone-navigation 룰 포함)
- `pnpm --filter @solid-connect/web run typecheck` — 통과
- `pnpm --filter @solid-connect/web run build` — 통과

## 후속 제안 (이 PR 범위 밖)

`next.config.mjs`가 `.mjs`라 TS 상수를 import할 수 없어 수동 동기화가 남아 있습니다. 같은 사고가 반복되지 않으려면 슬러그 목록을 양쪽이 import할 수 있는 공용 `.mjs` 모듈로 빼거나, CI에서 두 목록의 일치를 검사하는 편이 안전합니다.

또한 `apps/web`의 `HOME_UNIVERSITY_LIST`에는 여전히 중앙대가 없습니다(홈 목록·sitemap). `maxChoiceCount` 값이 확정되면 별도 PR로 반영하겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)