### PR TITLE
✨ 지원자 현황 조회에 소속 대학 파라미터 추가

### DIFF
--- a/apps/web/src/apis/applications/api.ts
+++ b/apps/web/src/apis/applications/api.ts
@@ -8,6 +8,14 @@ export const ApplicationsQueryKeys = {
   applicationPreview: "applicationPreview",
 } as const;
 
+// ====== Utils ======
+/** 유효한 양의 정수만 쿼리 파라미터로 내보낸다. (universities/api.ts 와 동일한 규칙) */
+const normalizePositiveInt = (value: unknown) => {
+  const numberValue = typeof value === "string" && value.trim() !== "" ? Number(value) : value;
+
+  return typeof numberValue === "number" && Number.isInteger(numberValue) && numberValue > 0 ? numberValue : undefined;
+};
+
 // ====== Types ======
 export interface UseSubmitApplicationResponse {
   totalApplyCount: number;
@@ -37,9 +45,16 @@ export interface CompetitorsResponse {
 export const applicationsApi = {
   /**
    * 지원 목록 조회
+   *
+   * homeUniversityId 는 클라이언트가 임의로 정하는 값이 아니라,
+   * access token 에서 파싱된 로그인 사용자의 소속 대학(useAuthStore.homeUniversityId)을 그대로 전달한다.
    */
-  getApplicationsList: async (): Promise<AxiosResponse<ApplicationListResponse>> => {
-    return axiosInstance.get("/applications");
+  getApplicationsList: async (params?: {
+    homeUniversityId?: number | null;
+  }): Promise<AxiosResponse<ApplicationListResponse>> => {
+    return axiosInstance.get("/applications", {
+      params: { homeUniversityId: normalizePositiveInt(params?.homeUniversityId) },
+    });
   },
 
   /**

--- a/apps/web/src/apis/applications/getApplicants.ts
+++ b/apps/web/src/apis/applications/getApplicants.ts
@@ -1,6 +1,7 @@
 import { type UseQueryOptions, type UseQueryResult, useQuery } from "@tanstack/react-query";
 import type { AxiosError, AxiosResponse } from "axios";
 
+import useAuthStore from "@/lib/zustand/useAuthStore";
 import type { ApplicationListResponse } from "@/types/application";
 import { ApplicationsQueryKeys, applicationsApi } from "./api";
 
@@ -11,13 +12,18 @@ type UseGetApplicationsListOptions = Omit<
 
 /**
  * @description 지원 목록 조회 훅
+ *
+ * 소속 대학(homeUniversityId)은 access token 에서 파싱되어 useAuthStore 에 담긴 값을 사용한다.
+ * 다른 소속 대학의 응답이 캐시에 섞이지 않도록 queryKey 에도 포함한다.
  */
 const useGetApplicationsList = (
   props?: UseGetApplicationsListOptions,
 ): UseQueryResult<ApplicationListResponse, AxiosError<{ message: string }>> => {
+  const homeUniversityId = useAuthStore((state) => state.homeUniversityId);
+
   return useQuery({
-    queryKey: [ApplicationsQueryKeys.competitorsApplicationList],
-    queryFn: applicationsApi.getApplicationsList,
+    queryKey: [ApplicationsQueryKeys.competitorsApplicationList, homeUniversityId],
+    queryFn: () => applicationsApi.getApplicationsList({ homeUniversityId }),
     staleTime: 1000 * 60 * 5, // 5분간 캐시
     select: (response) => response.data,
     ...props,


### PR DESCRIPTION
## 요약

`GET /applications`(지원자 현황) 호출 시 `homeUniversityId`를 쿼리 파라미터로 함께 보냅니다. 대학 검색 API(`/univ-apply-infos/search/text`)가 `homeUniversityId`를 받는 것과 같은 방식입니다.

## 값의 출처

**클라이언트가 임의로 정하는 값이 아니라, access token에서 파싱된 로그인 사용자의 소속 대학을 그대로 보냅니다.**

`useAuthStore`가 이미 JWT의 `home_university` 클레임을 `homeUniversityId`로 파싱해 두고 있어(`parseAuthToken`), 그 값을 그대로 사용했습니다. 별도 파싱 로직을 추가하지 않았습니다.

## 변경 내용

- `apis/applications/api.ts` — `getApplicationsList`가 `{ homeUniversityId }`를 받아 쿼리 파라미터로 전달. `universities/api.ts`와 동일한 `normalizePositiveInt` 규칙을 적용해 유효한 양의 정수만 내보냅니다(소속 대학이 없으면 파라미터 자체가 빠짐).
- `apis/applications/getApplicants.ts` — `useAuthStore`에서 `homeUniversityId`를 읽어 전달하고, **`queryKey`에도 포함**했습니다. 포함하지 않으면 계정 전환 시 다른 소속 대학의 응답이 캐시에서 그대로 재사용됩니다.

호출부(`ApplicationUniversityDetailContent`, `ApprovedApplicationStatusPage`) 수정은 필요 없습니다. 훅 내부에서 처리합니다.

## 확인 필요: 서버가 아직 이 파라미터를 받지 않습니다

현재 `ApplicationController.getApplicants`는 `region`, `keyword`만 `@RequestParam`으로 선언되어 있습니다.

```java
public ResponseEntity<ApplicationsResponse> getApplicants(
        @AuthorizedUser long siteUserId,
        @RequestParam(required = false, defaultValue = "") String region,
        @RequestParam(required = false, defaultValue = "") String keyword
)
```

Spring은 선언되지 않은 쿼리 파라미터를 조용히 무시하므로, **이 PR만으로는 응답이 달라지지 않습니다.** 서버에서 `homeUniversityId`를 받아 필터에 반영하는 작업이 함께 배포되어야 실제 범위 제한이 동작합니다.

서버 작업이 이미 진행 중이라면 그대로 두시면 되고, 아직이라면 이 PR은 그때까지 무해한 상태로 대기합니다(파라미터만 추가로 전송).

## 검증

- `pnpm --filter @solid-connect/web run lint:check` — 통과
- `pnpm --filter @solid-connect/web run typecheck` — 통과
- 파라미터 정규화 동작 확인: `3 → 3`, `null/undefined/0/-1 → 미전송`

🤖 Generated with [Claude Code](https://claude.com/claude-code)