### PR TITLE
✨ 지원자 현황을 소속 대학 기준으로 필터링

### DIFF
--- a/apps/web/src/apis/applications/getApplicants.ts
+++ b/apps/web/src/apis/applications/getApplicants.ts
@@ -1,8 +1,13 @@
 import { type UseQueryOptions, type UseQueryResult, useQuery } from "@tanstack/react-query";
 import type { AxiosError, AxiosResponse } from "axios";
+import { useMemo } from "react";
 
+import useAuthStore from "@/lib/zustand/useAuthStore";
 import type { ApplicationListResponse } from "@/types/application";
+import { QueryKeys } from "../queryKeys";
+import { universitiesApi } from "../universities/api";
 import { ApplicationsQueryKeys, applicationsApi } from "./api";
+import { filterApplicationsByHomeUniversityScope } from "./homeUniversityScope";
 
 type UseGetApplicationsListOptions = Omit<
   UseQueryOptions<AxiosResponse<ApplicationListResponse>, AxiosError<{ message: string }>, ApplicationListResponse>,
@@ -11,17 +16,50 @@ type UseGetApplicationsListOptions = Omit<
 
 /**
  * @description 지원 목록 조회 훅
+ *
+ * `GET /applications` 는 전체 지원자 현황을 내려주고 소속 대학을 구분해주지 않는다.
+ * 그래서 access token 에서 파싱된 소속 대학(useAuthStore.homeUniversityId)으로
+ * 파견학교 목록을 따로 받아, 그 범위에 속한 항목만 남기도록 클라이언트에서 걸러낸다.
  */
 const useGetApplicationsList = (
   props?: UseGetApplicationsListOptions,
 ): UseQueryResult<ApplicationListResponse, AxiosError<{ message: string }>> => {
-  return useQuery({
+  const homeUniversityId = useAuthStore((state) => state.homeUniversityId);
+
+  const applicationsQuery = useQuery({
     queryKey: [ApplicationsQueryKeys.competitorsApplicationList],
     queryFn: applicationsApi.getApplicationsList,
     staleTime: 1000 * 60 * 5, // 5분간 캐시
     select: (response) => response.data,
     ...props,
   });
+
+  // 필터 기준이 되는 소속 대학의 파견학교 목록
+  const { data: scopedUniversities } = useQuery({
+    queryKey: [QueryKeys.universities.searchText, { homeUniversityId }],
+    queryFn: () => universitiesApi.getSearchText({ value: "", homeUniversityId: homeUniversityId ?? undefined }),
+    enabled: homeUniversityId !== null,
+    staleTime: 1000 * 60 * 5,
+    select: (response) => response.univApplyInfoPreviews,
+  });
+
+  const scopedData = useMemo(() => {
+    if (!applicationsQuery.data) {
+      return applicationsQuery.data;
+    }
+
+    // 소속 대학을 모르면(비인증·학교 미인증) 기존과 동일하게 전체를 보여준다.
+    if (homeUniversityId === null) {
+      return applicationsQuery.data;
+    }
+
+    return filterApplicationsByHomeUniversityScope(applicationsQuery.data, scopedUniversities);
+  }, [applicationsQuery.data, homeUniversityId, scopedUniversities]);
+
+  return { ...applicationsQuery, data: scopedData } as UseQueryResult<
+    ApplicationListResponse,
+    AxiosError<{ message: string }>
+  >;
 };
 
 export default useGetApplicationsList;

--- a/apps/web/src/apis/applications/homeUniversityScope.ts
+++ b/apps/web/src/apis/applications/homeUniversityScope.ts
@@ -1,0 +1,40 @@
+import type { ApplicationListResponse, ScoreSheet } from "@/types/application";
+
+/**
+ * 지원자 현황 응답을 소속 대학 기준으로 걸러내기 위한 키.
+ *
+ * `GET /applications` 응답(ScoreSheet)에는 홈 대학 식별자도, 지원 정보 id 도 없다.
+ * 그래서 파견학교 목록과 겹치는 필드(파견학교명 + 국가 + 모집인원)를 합쳐 식별한다.
+ *
+ * 파견학교명만으로는 부족하다. 서로 다른 홈 대학이 같은 이름의 파견학교를 가질 수 있고
+ * (예: 경희대·중앙대 모두 보유한 국립정치대학교), 그 경우 이름만으로는 구분되지 않는다.
+ */
+type ScopeKeySource = {
+  koreanName: string;
+  country: string;
+  studentCapacity: number | null;
+};
+
+export const createHomeUniversityScopeKey = ({ koreanName, country, studentCapacity }: ScopeKeySource): string =>
+  `${koreanName}|${country}|${studentCapacity ?? ""}`;
+
+/**
+ * 소속 대학의 파견학교 목록에 포함된 항목만 남긴다.
+ * 기준 목록이 비어 있으면 필터링하지 않고 원본을 그대로 돌려준다.
+ */
+export const filterApplicationsByHomeUniversityScope = (
+  applications: ApplicationListResponse,
+  scopedUniversities: ScopeKeySource[] | undefined,
+): ApplicationListResponse => {
+  if (!scopedUniversities || scopedUniversities.length === 0) {
+    return applications;
+  }
+
+  const allowedKeys = new Set(scopedUniversities.map(createHomeUniversityScopeKey));
+
+  return {
+    choices: applications.choices.map((scoreSheets: ScoreSheet[]) =>
+      scoreSheets.filter((scoreSheet) => allowedKeys.has(createHomeUniversityScopeKey(scoreSheet))),
+    ),
+  };
+};


### PR DESCRIPTION
## 요약

`GET /applications`(지원자 현황)는 전체를 그대로 내려주고 소속 대학을 구분해주지 않습니다. 서버는 건드리지 않고, **전체를 받아온 뒤 access token의 소속 대학 기준으로 클라이언트에서 걸러내도록** 했습니다.

## 동작

1. 기존과 동일하게 `/applications` 전체 조회
2. token에서 파싱된 `useAuthStore.homeUniversityId`로 파견학교 목록(`/univ-apply-infos/search/text`) 조회
3. 그 목록에 속한 항목만 남겨서 반환

훅(`useGetApplicationsList`) 내부에서 처리하므로 호출부(`ApplicationUniversityDetailContent`, `ApprovedApplicationStatusPage`) 수정은 없습니다. 소속 대학을 모르는 경우(비인증·학교 미인증)에는 필터를 걸지 않아 기존 동작 그대로입니다.

## 매칭 키를 이름만 쓰지 않은 이유

`/applications` 응답(`ApplicantsResponse`)에는 **홈 대학 식별자도, 지원 정보 id도 없습니다.**

```java
public record ApplicantsResponse(
        String koreanName, Integer studentCapacity,
        String region, String country, List<ApplicantResponse> applicants) {}
```

파견학교명만으로 매칭하면 틀립니다. 실제 운영 데이터를 확인한 결과, 경희대와 중앙대가 **같은 이름의 파견학교를 4곳** 공유합니다.

| 파견학교명 | 경희대 (국가/정원) | 중앙대 (국가/정원) |
|---|---|---|
| 국립대만사범대학교 | 대만 / 3 | 대만 / 2 |
| 국립정치대학교 | 대만 / 5 | 대만 / 1 |
| 링난대학교 | 홍콩 / 4 | 슬로베니아 / 2 |
| 홍콩이공대학교 | 홍콩 / 2 | 스페인 / 1 |

이름만 쓰면 이 4곳은 다른 학교 항목까지 함께 남습니다. 그래서 두 응답에 공통으로 있는 필드를 합쳐 **`파견학교명 + 국가 + 모집인원`** 을 키로 사용했고, 위 4건이 모두 구분되는 것을 확인했습니다.

## 검증

실제 운영 API 데이터(경희대 170건 + 중앙대 186건)를 섞어 필터를 돌렸습니다.

```
전체(섞인) 항목 수: 356
중앙대 기준 필터 후: 186 (기대: 186)
  국립대만사범대학교 -> 1 건 대만/2
  국립정치대학교 -> 1 건 대만/1
  링난대학교 -> 1 건 슬로베니아/2
  홍콩이공대학교 -> 1 건 스페인/1
```

- `pnpm --filter @solid-connect/web run typecheck` — 통과
- `pnpm --filter @solid-connect/web run lint:check` — 480 files 통과

## 한계 (알고 넘어가야 할 부분)

이 방식은 **응답에 식별자가 없어서 값으로 추론하는 우회책**입니다.

- 서로 다른 홈 대학이 `이름 + 국가 + 정원`까지 완전히 같은 파견학교를 갖게 되면 구분되지 않습니다. 지금 데이터에서는 그런 경우가 없지만, 구조적으로 보장되지는 않습니다.
- 전체 데이터를 받아 클라이언트에서 버리므로 전송량이 줄지 않습니다.

근본 해결은 서버가 `/applications` 응답에 홈 대학 식별자(또는 지원 정보 id)를 포함하거나, 요청자의 소속 대학으로 서버에서 필터링하는 것입니다. 여유가 될 때 정리하시는 걸 권합니다.

## 관련 PR

#626(프론트에서 `homeUniversityId` 쿼리 파라미터 전송)은 이 방식으로 대체되므로 닫으셔도 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)