### PR TITLE
🐛 대학 상세페이지 진입 실패 시 전역 에러 토스트가 중복 표시되던 문제 수정

### DIFF
--- a/apps/university-web/src/apis/universities/getUniversityDetail.ts
+++ b/apps/university-web/src/apis/universities/getUniversityDetail.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import type { AxiosError } from "axios";
+import { SKIP_GLOBAL_ERROR_TOAST_META } from "@/lib/react-query/errorToastMeta";
 import type { University } from "@/types/university";
 import { QueryKeys } from "../queryKeys";
 import { type UniversityDetailResponse, universitiesApi } from "./api";
@@ -7,6 +8,10 @@ import { type UniversityDetailResponse, universitiesApi } from "./api";
 /**
  * @description 대학 상세 조회를 위한 useQuery 커스텀 훅
  * @param universityInfoForApplyId - 대학 ID
+ *
+ * 이 훅은 SSG/서버 렌더 단계에서 상세 데이터를 못 가져왔을 때의 CSR 폴백(UniversityDetailCsrFallback)
+ * 전용이다. 조회 실패 시 폴백 UI(UniversityDetailPreparingFallback)가 이미 사용자에게 상황을 안내하므로,
+ * 전역 에러 토스트("오류가 발생했습니다...")가 중복으로 뜨지 않도록 스킵한다.
  */
 const useGetUniversityDetail = (universityInfoForApplyId: number) => {
   return useQuery<UniversityDetailResponse, AxiosError, University>({
@@ -14,6 +19,7 @@ const useGetUniversityDetail = (universityInfoForApplyId: number) => {
     queryFn: () => universitiesApi.getUniversityDetail({ univApplyInfoId: universityInfoForApplyId }),
     enabled: !!universityInfoForApplyId,
     select: (data) => data as unknown as University,
+    meta: SKIP_GLOBAL_ERROR_TOAST_META,
   });
 };
 


### PR DESCRIPTION
## 문제

대학 상세페이지(`/university/:homeUniversity/:id`) 진입 시 데이터 조회에 실패하면, 화면에는 "대학 정보를 준비중입니다" 같은 안내가 정상적으로 뜨는데 **동시에 전역 에러 토스트("오류가 발생했습니다. 다시 시도해주세요.")까지 함께 표시**됩니다.

## 원인

#623에서 추가된 CSR 폴백(`UniversityDetailCsrFallback`)이 `useGetUniversityDetail` 훅(`react-query`)을 쓰는데, `apps/university-web`의 전역 `QueryCache.onError`(`queryClient.ts`)는 `meta.skipGlobalErrorToast`가 없는 모든 쿼리 실패에 토스트를 띄웁니다. 이 훅에는 그 메타가 없어서, 폴백 UI가 실패를 이미 부드럽게 안내하고 있는데도 토스트가 중복으로 얹혔습니다.

`useGetUniversityDetail`은 저장소 전체에서 이 CSR 폴백 한 곳에서만 쓰입니다 — 정확히 "대학 상세페이지 진입 실패" 시나리오입니다.

## 수정

`useGetUniversityDetail`의 `useQuery` 옵션에 `meta: SKIP_GLOBAL_ERROR_TOAST_META`를 추가했습니다. `apps/university-web`에 이미 있는 기존 패턴(`postUploadProfileImage.ts` 등)을 그대로 따랐습니다.

화면에 보이는 안내(`UniversityDetailPreparingFallback`)는 그대로 유지되고, 중복 토스트만 사라집니다.

## 검증

- `pnpm --filter @solid-connect/university-web run lint:check` — 321 files 통과
- `pnpm --filter @solid-connect/university-web run typecheck:ci` — 통과
- `meta` → `query.meta` → `shouldSkipGlobalErrorToast` 로 이어지는 경로를 코드로 재확인

## 범위 밖 (참고)

같은 페이지의 목록 CSR 폴백(`UniversityListCsrFallback`)도 인라인 `useQuery`로 동일한 전역 토스트 문제를 가질 수 있습니다. 다만 이번 요청 범위(상세페이지)에 맞춰 이 PR에는 포함하지 않았습니다. 필요하시면 별도 PR로 처리하겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)