### PR TITLE
✨ 로그인 필요로 리디렉션될 때 안내 토스트 표시

### DIFF
--- a/apps/web/src/app/community/[boardCode]/create/PostForm.tsx
+++ b/apps/web/src/app/community/[boardCode]/create/PostForm.tsx
@@ -10,7 +10,7 @@ import CloudSpinnerPage from "@/components/ui/CloudSpinnerPage";
 import { showIconToast } from "@/lib/toast/showIconToast";
 import useAuthStore from "@/lib/zustand/useAuthStore";
 import { IconImage } from "@/public/svgs";
-import { buildLoginPathWithRedirect } from "@/utils/authRedirect";
+import { buildLoginPathWithRedirect, LOGIN_REQUIRED_MESSAGE } from "@/utils/authRedirect";
 
 type PostFormProps = {
   boardCode: string;
@@ -50,6 +50,8 @@ const PostForm = ({ boardCode }: PostFormProps) => {
     }
 
     if (!isAuthenticated || !accessToken) {
+      // SPA 이동이라 토스트가 로그인 페이지까지 유지된다.
+      showIconToast("logo", LOGIN_REQUIRED_MESSAGE);
       router.replace(buildLoginPathWithRedirect(createPath));
     }
   }, [accessToken, createPath, isAuthenticated, isInitialized, refreshStatus, router]);

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -7,6 +7,7 @@ import GlobalLayout from "@/components/layout/GlobalLayout";
 import ReissueProvider from "@/components/layout/ReissueProvider";
 import QueryProvider from "@/lib/react-query/QueryProvider";
 import AppleScriptLoader from "@/lib/ScriptLoader/AppleScriptLoader";
+import PendingToastPresenter from "@/lib/toast/PendingToastPresenter";
 import "@/styles/globals.css";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { SpeedInsights } from "@vercel/speed-insights/next";
@@ -85,6 +86,7 @@ const RootLayout = ({ children }: { children: ReactNode }) => (
             duration: 3000,
           }}
         />
+        <PendingToastPresenter />
       </QueryProvider>
     </body>
   </html>

--- a/apps/web/src/app/mentor/_ui/MentorClient/index.tsx
+++ b/apps/web/src/app/mentor/_ui/MentorClient/index.tsx
@@ -5,8 +5,10 @@ import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { useGetMyInfo } from "@/apis/MyPage";
 import CloudSpinnerPage from "@/components/ui/CloudSpinnerPage";
+import { showIconToast } from "@/lib/toast/showIconToast";
 import useAuthStore from "@/lib/zustand/useAuthStore";
 import { UserRole } from "@/types/mentor";
+import { LOGIN_REQUIRED_MESSAGE } from "@/utils/authRedirect";
 import MentorPageSkeleton from "../MentorPageSkeleton";
 import MenteePage from "./_ui/MenteePage";
 import MentorPage from "./_ui/MentorPage";
@@ -23,6 +25,8 @@ const MentorClient = () => {
   useEffect(() => {
     if (isAuthResolving) return;
     if (isUnauthorized || (!isError && !role)) {
+      // SPA 이동이라 토스트가 로그인 페이지까지 유지된다.
+      showIconToast("logo", LOGIN_REQUIRED_MESSAGE);
       router.replace("/login");
     }
   }, [isAuthResolving, isUnauthorized, isError, role, router]);

--- a/apps/web/src/app/my/_ui/MyProfileContent/index.tsx
+++ b/apps/web/src/app/my/_ui/MyProfileContent/index.tsx
@@ -21,6 +21,7 @@ import {
   IconUniversity,
 } from "@/public/svgs/my";
 import { UserRole } from "@/types/mentor";
+import { LOGIN_REQUIRED_MESSAGE } from "@/utils/authRedirect";
 import { openKakaoOpenChat } from "@/utils/openKakaoOpenChat";
 
 const NEXT_PUBLIC_CONTACT_LINK = process.env.NEXT_PUBLIC_CONTACT_LINK;
@@ -38,6 +39,8 @@ const MyProfileContent = () => {
   useEffect(() => {
     if (!isInitialized || isAuthenticated) return;
 
+    // SPA 이동이라 토스트가 로그인 페이지까지 유지된다.
+    showIconToast("logo", LOGIN_REQUIRED_MESSAGE);
     router.replace("/login");
   }, [isInitialized, isAuthenticated, router]);
 

--- a/apps/web/src/lib/toast/PendingToastPresenter.tsx
+++ b/apps/web/src/lib/toast/PendingToastPresenter.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { consumePendingToast } from "./pendingToast";
+import { showIconToast } from "./showIconToast";
+
+/**
+ * 이전 페이지에서 예약해 둔 토스트를 페이지 진입 시 한 번 띄운다.
+ * (하드 내비게이션으로 사라졌을 토스트를 도착 페이지에서 대신 보여주는 역할)
+ */
+const PendingToastPresenter = () => {
+  useEffect(() => {
+    const pendingToast = consumePendingToast();
+    if (!pendingToast) return;
+
+    showIconToast(pendingToast.icon, pendingToast.message);
+  }, []);
+
+  return null;
+};
+
+export default PendingToastPresenter;

--- a/apps/web/src/lib/toast/pendingToast.ts
+++ b/apps/web/src/lib/toast/pendingToast.ts
@@ -1,0 +1,47 @@
+import type { ToastIconKey } from "./showIconToast";
+
+const PENDING_TOAST_STORAGE_KEY = "pendingToast";
+
+type PendingToast = {
+  icon: ToastIconKey;
+  message: string;
+};
+
+/**
+ * 다음 페이지 로드 때 보여줄 토스트를 예약한다.
+ *
+ * `window.location.replace()` 같은 하드 내비게이션은 React 트리를 통째로 버리기 때문에,
+ * 이동 직전에 띄운 토스트는 화면에 나타나기도 전에 사라진다.
+ * 그래서 메시지를 sessionStorage 에 넘겨두고 도착한 페이지에서 대신 띄운다.
+ *
+ * SPA 이동(next/navigation 의 router.push/replace)은 트리가 유지되므로
+ * 이 함수가 아니라 showIconToast 를 그대로 쓰면 된다.
+ */
+export const setPendingToast = (icon: ToastIconKey, message: string) => {
+  if (typeof window === "undefined") return;
+
+  try {
+    sessionStorage.setItem(PENDING_TOAST_STORAGE_KEY, JSON.stringify({ icon, message } satisfies PendingToast));
+  } catch {
+    // sessionStorage 를 못 쓰는 환경(프라이빗 모드 등)에서는 토스트를 포기한다.
+  }
+};
+
+/** 예약된 토스트를 읽고 즉시 비운다. (같은 메시지가 다음 이동에서 또 뜨지 않도록) */
+export const consumePendingToast = (): PendingToast | null => {
+  if (typeof window === "undefined") return null;
+
+  try {
+    const raw = sessionStorage.getItem(PENDING_TOAST_STORAGE_KEY);
+    if (!raw) return null;
+
+    sessionStorage.removeItem(PENDING_TOAST_STORAGE_KEY);
+
+    const parsed = JSON.parse(raw) as Partial<PendingToast>;
+    if (!parsed?.message || !parsed?.icon) return null;
+
+    return { icon: parsed.icon, message: parsed.message };
+  } catch {
+    return null;
+  }
+};

--- a/apps/web/src/utils/authRedirect.ts
+++ b/apps/web/src/utils/authRedirect.ts
@@ -1,5 +1,8 @@
 export const AUTH_REDIRECT_PARAM = "redirect";
 
+/** 로그인이 필요해 로그인 페이지로 보낼 때 사용자에게 안내할 메시지 */
+export const LOGIN_REQUIRED_MESSAGE = "로그인이 필요한 페이지입니다.";
+
 const FALLBACK_REDIRECT_PATH = "/";
 const COMMUNITY_PATH_PREFIX = "/community/";
 

--- a/apps/web/src/utils/axiosInstance.ts
+++ b/apps/web/src/utils/axiosInstance.ts
@@ -2,7 +2,7 @@ import axios, { type AxiosError, type AxiosInstance } from "axios";
 import { postReissueToken } from "@/apis/Auth/server";
 import { QueryKeys } from "@/apis/queryKeys";
 import queryClient from "@/lib/react-query/queryClient";
-import { showIconToast } from "@/lib/toast/showIconToast";
+import { setPendingToast } from "@/lib/toast/pendingToast";
 import useAuthStore from "@/lib/zustand/useAuthStore";
 import { isTokenExpired } from "@/utils/jwtUtils";
 
@@ -34,7 +34,9 @@ const redirectToLogin = (message: string) => {
     try {
       // 쿠키 유틸이 클라이언트에서만 동작하므로 window 가드 내에서 호출
     } catch {}
-    showIconToast("logo", message);
+    // location.replace 는 하드 내비게이션이라 여기서 토스트를 띄우면 화면에 뜨기 전에 사라진다.
+    // 로그인 페이지에 도착한 뒤 PendingToastPresenter 가 대신 띄우도록 넘긴다.
+    setPendingToast("logo", message);
     window.location.replace("/login");
   }
 };


### PR DESCRIPTION
## 문제

로그인이 필요한 화면에 들어가면 아무 설명 없이 로그인 페이지로 튕깁니다. 커뮤니티 상세처럼 사용자가 방금 누른 링크가 그냥 사라지는 것처럼 보여서 어색합니다.

원인이 두 갈래였습니다.

### 1. 토스트를 띄우지만 이동이 그걸 지워버림 — `axiosInstance`

`redirectToLogin()`은 이미 토스트를 띄우고 있었는데, 바로 뒤에서 `window.location.replace("/login")`을 호출합니다. 이건 하드 내비게이션이라 React 트리가 통째로 버려지고, `<Toaster>`도 함께 사라집니다. **토스트가 화면에 그려지기 전에 페이지가 날아가서 사용자는 아무것도 못 봅니다.**

커뮤니티 상세 페이지가 정확히 이 경로입니다 — 별도 가드 없이 API 401 → 인터셉터 → 하드 리디렉션.

### 2. 아예 토스트가 없음 — 페이지 가드 3곳

`router.replace("/login")`만 호출하고 안내가 전혀 없었습니다.

- `MentorClient` (멘토)
- `MyProfileContent` (마이페이지)
- `PostForm` (커뮤니티 글쓰기)

## 수정

### 하드 내비게이션을 건너 토스트 전달

`setPendingToast()` / `consumePendingToast()`를 추가했습니다. 메시지를 `sessionStorage`에 넘겨두고, 도착한 페이지에서 `PendingToastPresenter`(루트 레이아웃의 `<Toaster>` 옆에 마운트)가 대신 띄웁니다. 한 번 읽으면 즉시 비워서 다음 이동에 다시 뜨지 않습니다.

`axiosInstance.redirectToLogin()`이 `showIconToast` 대신 이 방식을 씁니다. 기존 메시지("로그인이 필요합니다...", "세션이 만료되었습니다...")는 그대로 두고, **이제 실제로 보이게만** 했습니다.

### 페이지 가드에는 토스트 추가

세 곳 모두 `router.replace` 전에 `showIconToast("logo", LOGIN_REQUIRED_MESSAGE)`를 호출합니다. 이건 SPA 이동이라 React 트리가 유지되므로 토스트가 로그인 페이지까지 그대로 살아있습니다 — 여기엔 sessionStorage 우회가 필요 없습니다.

메시지는 `LOGIN_REQUIRED_MESSAGE = "로그인이 필요한 페이지입니다."`로 `authRedirect.ts`에 모아 뒀습니다.

## 검증

- `pnpm --filter @solid-connect/web run typecheck` — 통과
- `pnpm --filter @solid-connect/web run lint:check` — 482 files 통과
- `pnpm --filter @solid-connect/web run build` — 통과
- `pendingToast` 로직 실행 확인:

```
1) 예약 전 consume: null
2) 예약 후 consume: { icon: 'logo', message: '세션이 만료되었습니다. 다시 로그인해주세요.' }
3) 재consume(1회성): null      ← 다음 이동에 재표시 안 됨
4) 손상된 값: null              ← JSON 깨져도 안전
5) message 누락: null
```

## 참고

- `sessionStorage`를 못 쓰는 환경(프라이빗 모드 등)에서는 토스트를 조용히 포기합니다. 리디렉션 자체는 정상 동작합니다.
- `apps/university-web`에도 같은 구조의 `redirectToLogin`이 있지만, 이번 요청 범위(커뮤니티 등 `apps/web` 화면)에 맞춰 포함하지 않았습니다. 필요하면 별도 PR로 맞추겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)