### PR TITLE
Fix/829 admin host universities pagination

### DIFF
--- a/apps/admin/src/components/features/univ-apply-infos/tabs/HostUniversityTab.tsx
+++ b/apps/admin/src/components/features/univ-apply-infos/tabs/HostUniversityTab.tsx
@@ -134,7 +134,8 @@ export function HostUniversityTab() {
 
 	const query = useQuery({
 		queryKey: ["admin", "host-universities", searchParams],
-		queryFn: () => adminApi.getHostUniversities({ ...searchParams, size: 20 }),
+		// 서버의 page 파라미터는 1-indexed 계약이므로, 0-indexed로 관리되는 UI 상태를 API 호출 시점에 변환한다.
+		queryFn: () => adminApi.getHostUniversities({ ...searchParams, page: searchParams.page + 1, size: 20 }),
 		placeholderData: keepPreviousData,
 	});
 

--- a/apps/admin/src/components/features/univ-apply-infos/tabs/HostUniversityTab.tsx
+++ b/apps/admin/src/components/features/univ-apply-infos/tabs/HostUniversityTab.tsx
@@ -134,7 +134,6 @@ export function HostUniversityTab() {
 
 	const query = useQuery({
 		queryKey: ["admin", "host-universities", searchParams],
-		// 서버의 page 파라미터는 1-indexed 계약이므로, 0-indexed로 관리되는 UI 상태를 API 호출 시점에 변환한다.
 		queryFn: () => adminApi.getHostUniversities({ ...searchParams, page: searchParams.page + 1, size: 20 }),
 		placeholderData: keepPreviousData,
 	});


### PR DESCRIPTION
서버의 page 계약은 1-indexed인데 이 화면의 UI 상태는 0부터 시작해 그대로 요청에 실려 보내고 있었다. page=0과 page=1 요청이 모두 서버 내부에서 동일한 오프셋으로 클램프되어, "다음" 버튼을 처음 눌렀을 때 같은 목록이 다시 보이고 마지막 페이지에는 영원히 도달하지 못했다.

API 호출 시점에만 page + 1로 변환해 서버 계약에 맞춘다.
