### PR TITLE
💚 ci: 대학 SSG 재배포 CD 추가

### DIFF
--- a/.github/workflows/university-web-redeploy.yml
+++ b/.github/workflows/university-web-redeploy.yml
@@ -1,0 +1,139 @@
+name: Redeploy University Web
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Reason for rebuilding university SSG pages"
+        required: false
+        default: "University API data updated"
+        type: string
+  repository_dispatch:
+    types: [university-data-updated]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: university-web-production-redeploy
+  cancel-in-progress: false
+
+jobs:
+  redeploy:
+    name: Redeploy university web production
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: Production – solid-connect-university-web
+      url: ${{ steps.deploy.outputs.deployment_url }}
+    env:
+      VERCEL_PROJECT_NAME: solid-connect-university-web
+      VERCEL_RELEASE_BRANCH: release-university
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      REDEPLOY_REASON: ${{ github.event.inputs.reason || github.event.client_payload.reason || 'University API data updated' }}
+    steps:
+      - name: Checkout university release branch
+        uses: actions/checkout@v4
+        with:
+          ref: release-university
+          fetch-depth: 1
+
+      - name: Validate Vercel credentials
+        run: |
+          set -euo pipefail
+
+          if [ -z "$VERCEL_ORG_ID" ] || [ -z "$VERCEL_TOKEN" ]; then
+            echo "VERCEL_ORG_ID and VERCEL_TOKEN secrets are required." >&2
+            exit 1
+          fi
+
+      - name: Trigger fresh production deployment
+        id: deploy
+        env:
+          REPOSITORY_ID: ${{ github.event.repository.id }}
+        run: |
+          set -euo pipefail
+
+          RELEASE_SHA=$(git rev-parse HEAD)
+          REQUEST_BODY=$(jq -n \
+            --arg name "$VERCEL_PROJECT_NAME" \
+            --arg ref "$VERCEL_RELEASE_BRANCH" \
+            --arg sha "$RELEASE_SHA" \
+            --argjson repoId "$REPOSITORY_ID" \
+            '{
+              name: $name,
+              gitSource: {
+                type: "github",
+                repoId: $repoId,
+                ref: $ref,
+                sha: $sha
+              },
+              target: "production"
+            }')
+
+          HTTP_STATUS=$(curl --silent --show-error \
+            --output deployment.json \
+            --write-out "%{http_code}" \
+            --request POST \
+            --header "Authorization: Bearer $VERCEL_TOKEN" \
+            --header "Content-Type: application/json" \
+            --data "$REQUEST_BODY" \
+            "https://api.vercel.com/v13/deployments?teamId=$VERCEL_ORG_ID&forceNew=1")
+
+          if [[ ! "$HTTP_STATUS" =~ ^2 ]]; then
+            jq -r '.error.message // "Vercel deployment request failed."' deployment.json >&2
+            exit 1
+          fi
+
+          DEPLOYMENT_ID=$(jq -r '.id // empty' deployment.json)
+          DEPLOYMENT_HOST=$(jq -r '.url // empty' deployment.json)
+
+          if [ -z "$DEPLOYMENT_ID" ] || [ -z "$DEPLOYMENT_HOST" ]; then
+            echo "Vercel response did not include a deployment ID and URL." >&2
+            exit 1
+          fi
+
+          {
+            echo "deployment_id=$DEPLOYMENT_ID"
+            echo "deployment_url=https://$DEPLOYMENT_HOST"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## University Web redeploy"
+            echo "- Reason: $REDEPLOY_REASON"
+            echo "- Source branch: $VERCEL_RELEASE_BRANCH"
+            echo "- Source commit: $RELEASE_SHA"
+            echo "- Deployment: https://$DEPLOYMENT_HOST"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Wait for deployment
+        env:
+          DEPLOYMENT_ID: ${{ steps.deploy.outputs.deployment_id }}
+        run: |
+          set -euo pipefail
+
+          for attempt in $(seq 1 90); do
+            RESPONSE=$(curl --fail-with-body --silent --show-error \
+              --header "Authorization: Bearer $VERCEL_TOKEN" \
+              "https://api.vercel.com/v13/deployments/$DEPLOYMENT_ID?teamId=$VERCEL_ORG_ID")
+            STATE=$(jq -r '.readyState // "UNKNOWN"' <<< "$RESPONSE")
+
+            echo "Deployment state: $STATE"
+
+            case "$STATE" in
+              READY)
+                echo "- Result: READY" >> "$GITHUB_STEP_SUMMARY"
+                exit 0
+                ;;
+              ERROR|CANCELED)
+                echo "- Result: $STATE" >> "$GITHUB_STEP_SUMMARY"
+                exit 1
+                ;;
+            esac
+
+            sleep 10
+          done
+
+          echo "Vercel deployment did not finish within 15 minutes." >&2
+          exit 1

--- a/docs/university-multizone-deployment.md
+++ b/docs/university-multizone-deployment.md
@@ -92,6 +92,23 @@ production university web project의 `NEXT_PUBLIC_WEB_URL`은 실제 사용자�
 NEXT_PUBLIC_WEB_URL=https://www.solid-connection.com
 ```
 
+## SSG 데이터 재배포
+
+대학 API 데이터만 변경된 경우에는 Git 변경이 없어도 `Redeploy University Web` workflow를 실행한다. 이 workflow는 `release-university`의 현재 소스를 사용해 university web production을 새로 빌드한다. 동일한 커밋의 기존 배포를 재사용하지 않으므로 빌드 시점의 최신 API 데이터가 SSG 페이지에 반영된다.
+
+GitHub Actions 화면에서 수동으로 실행할 수 있다. API 데이터 갱신 작업에서 자동 호출하려면 repository dispatch event type을 `university-data-updated`로 전송한다. 선택적으로 `client_payload.reason`에 갱신 이유를 넣을 수 있다.
+
+```json
+{
+  "event_type": "university-data-updated",
+  "client_payload": {
+    "reason": "대학 API 초기 데이터 입력 완료"
+  }
+}
+```
+
+workflow는 저장소의 `VERCEL_TOKEN`과 `VERCEL_ORG_ID` secret을 사용한다. 대상 프로젝트는 `solid-connect-university-web`으로 고정하며 다른 web과 admin 프로젝트는 재배포하지 않는다.
+
 ## Local Development
 
 터미널 두 개에서 실행한다.


### PR DESCRIPTION
## 관련 이슈

- 별도 이슈 없음

## 작업 내용

- 대학 API 데이터만 변경된 경우 `release-university`의 현재 소스로 university web production을 다시 빌드하는 CD를 추가했습니다.
- GitHub Actions 수동 실행과 `university-data-updated` repository dispatch 이벤트를 지원합니다.
- 같은 커밋이어도 새 배포를 만들도록 Vercel `forceNew=1`을 사용해 최신 API 데이터가 SSG 결과에 반영되도록 했습니다.
- 실행 방법과 자동 호출 payload를 multi-zone 배포 문서에 추가했습니다.

## 특이 사항

- 기존 `VERCEL_TOKEN`과 `VERCEL_ORG_ID` 저장소 secret을 사용합니다.
- 대상 Vercel 프로젝트는 `solid-connect-university-web`으로 고정했습니다.
- 실제 production 재배포는 API 데이터 준비 전이므로 실행하지 않았습니다.

## 리뷰 요구사항 (선택)

- `release-university`의 소스만 배포하는지와 다른 Vercel 프로젝트에 영향을 주지 않는지 확인 부탁드립니다.

## 검증

- `actionlint .github/workflows/university-web-redeploy.yml`
- workflow에 포함된 모든 shell script `bash -n`
- YAML parse
- `git diff --check`
